### PR TITLE
fix(test): green up E2E browser tests (check_origin, waitForFunction options)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,12 +165,17 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('assets/bun.lock') }}
           restore-keys: ${{ runner.os }}-playwright-
 
+      # mix deps.get must run before bun install: assets/package.json declares
+      # `"workspaces": ["../deps/*"]` and pulls phoenix / phoenix_html /
+      # phoenix_live_view via `workspace:*`. Without populated `deps/` the
+      # workspace resolution diverges from bun.lock and `--frozen-lockfile`
+      # fails with "lockfile had changes".
+      - name: Install deps
+        run: pixi run mix deps.get
+
       - name: Install Bun deps
         working-directory: assets
         run: pixi run bun install --frozen-lockfile
-
-      - name: Install deps
-        run: pixi run mix deps.get
 
       - name: Build assets
         run: pixi run mix assets.build

--- a/assets/e2e/auth.setup.mjs
+++ b/assets/e2e/auth.setup.mjs
@@ -49,7 +49,7 @@ setup('authenticate', async ({ page }) => {
   }
 
   await page.waitForURL(/\/projects/, { timeout: 10_000 })
-  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), { timeout: 10_000 })
+  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
 
   fs.mkdirSync(path.dirname(authFile), { recursive: true })
   await page.context().storageState({ path: authFile })

--- a/assets/e2e/editor_load.spec.mjs
+++ b/assets/e2e/editor_load.spec.mjs
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test'
 // Returns after the editor URL is confirmed.
 async function createProjectAndOpenEditor(page, name) {
   await page.goto('/projects')
-  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), { timeout: 10_000 })
+  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
   await page.locator('#new-project-button').click()
   await expect(page.locator('.ts-dialog')).toBeVisible()
 

--- a/assets/e2e/preview.spec.mjs
+++ b/assets/e2e/preview.spec.mjs
@@ -4,7 +4,7 @@ test.setTimeout(60_000)
 
 async function createProjectAndOpenEditor(page, name) {
   await page.goto('/projects')
-  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), { timeout: 10_000 })
+  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
   await page.locator('#new-project-button').click()
   await expect(page.locator('.ts-dialog')).toBeVisible({ timeout: 10_000 })
   await page.locator('.ts-dialog input[name="name"]').fill(name)
@@ -14,7 +14,7 @@ async function createProjectAndOpenEditor(page, name) {
   await expect(row).toBeVisible()
   await row.getByRole('link', { name: 'Open' }).click()
   await expect(page).toHaveURL(/\/projects\/.+\/edit/)
-  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), { timeout: 10_000 })
+  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
 }
 
 async function createFileAndOpenEditor(page) {

--- a/assets/e2e/theme_pour.spec.mjs
+++ b/assets/e2e/theme_pour.spec.mjs
@@ -51,7 +51,7 @@ test.describe("theme pour animation", () => {
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark")
 
     // Pour clears within ~900ms (CSS keyframe duration is 760ms).
-    await expect(toggle).not.toHaveClass(/is-pouring/, { timeout: 1500 })
+    await expect(toggle).not.toHaveClass(/is-pouring/, { timeout: 3000 })
 
     // Persisted to localStorage so reload keeps the new theme.
     expect(await page.evaluate(() => localStorage.getItem("phx:theme"))).toBe("dark")
@@ -65,7 +65,7 @@ test.describe("theme pour animation", () => {
     await page.locator(TOGGLE).click()
 
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light")
-    await expect(page.locator(TOGGLE)).not.toHaveClass(/is-pouring/, { timeout: 1500 })
+    await expect(page.locator(TOGGLE)).not.toHaveClass(/is-pouring/, { timeout: 3000 })
     expect(await page.evaluate(() => localStorage.getItem("phx:theme"))).toBe("light")
   })
 

--- a/assets/e2e/wasm.spec.mjs
+++ b/assets/e2e/wasm.spec.mjs
@@ -19,7 +19,7 @@ test.describe('WASM assets', () => {
 test.describe('Typst WASM compilation pipeline', () => {
   async function createProjectAndOpenEditor(page, name) {
     await page.goto('/projects')
-    await page.waitForFunction(() => window.liveSocket?.isConnected?.(), { timeout: 10_000 })
+    await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
     await page.locator('#new-project-button').click()
     await expect(page.locator('.ts-dialog')).toBeVisible()
     await page.locator('.ts-dialog input[name="name"]').fill(name)
@@ -46,7 +46,7 @@ test.describe('Typst WASM compilation pipeline', () => {
     })
 
     await createProjectAndOpenEditor(page, 'E2E WASM Test')
-    await page.waitForFunction(() => window.liveSocket?.isConnected?.(), { timeout: 10_000 })
+    await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
 
     await page.locator('#create-main-file-button').click()
     await expect(page.locator('.ts-dialog')).toBeVisible()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,6 +28,13 @@ if System.get_env("PHX_SERVER") && config_env() == :test do
   config :typster, Typster.Repo,
     pool: DBConnection.ConnectionPool,
     pool_size: 10
+
+  # Playwright drives the server via http://127.0.0.1:4000 while the global
+  # endpoint config keeps url.host: "localhost", so Phoenix' default
+  # check_origin rejects the LiveView socket handshake. Disable origin
+  # checks for the loopback server — only enabled when the server is
+  # actually booted under MIX_ENV=test (i.e. by the E2E web server).
+  config :typster, TypsterWeb.Endpoint, check_origin: false
 end
 
 if config_env() == :prod do


### PR DESCRIPTION
## Summary

The Browser tests job on PR #76 has been stuck at the same call site for every authenticated spec:

```
page.waitForFunction: Test timeout exceeded.
> 7 |   await page.waitForFunction(() => window.liveSocket?.isConnected?.(), { timeout: 10_000 })
```

Reproduced locally and traced through to two root causes:

### 1. `check_origin` rejects the WebSocket handshake

The webServer drives Phoenix via `http://127.0.0.1:4000`, but the global endpoint config keeps `url.host: "localhost"`. Phoenix' default `check_origin` therefore declines the LiveView socket handshake on every page:

```
[error] Could not check origin for Phoenix.Socket transport.
Origin of the request: http://127.0.0.1:4000
```

Setup occasionally squeaks through via the longpoll fallback, but the authenticated specs land on `/projects` and see the `phx-disconnected` reconnect banner with `liveSocket.isConnected() === false`. The page snapshot from the failing trace confirms it — "Connection dropped — reconnecting" on top of the rendered project list.

Fix: set `check_origin: false` on the test endpoint, gated on `PHX_SERVER && config_env() == :test` so it only affects the E2E webServer boot, not `mix test`.

### 2. `waitForFunction(fn, options)` — options were being passed as `arg`

`page.waitForFunction(pageFn, arg, options)`. Every spec was calling

```js
await page.waitForFunction(() => …, { timeout: 10_000 })
```

so the options object was serialised and handed to the page function as its (unused) argument, leaving the helper with no explicit timeout — it inherited the surrounding test timeout (20s for editor_load, 60s for preview/wasm). The 10s budget was a no-op. Passing `null` as the unused arg slot routes the options object where it belongs.

This is a quality-of-failure fix only — but it makes future failures error out at the helper level with the right message instead of consuming the whole test budget.

### 3. `.is-pouring` teardown window widened for headless flakes

`theme_pour.spec.mjs` checks the toggle's `is-pouring` class is removed within 1500ms after a click. The class is removed by a `setTimeout(…, 900)` after a 760ms keyframe; under headless Chromium with 3 concurrent workers it sometimes lingers past 1500ms. Widened to 3000ms — the contract doesn't change.

## Local results

Before (against `feat/gui-update` tip, 3 workers):
```
8 failed
9 passed (4.3m)
```

After all three patches:
```
17 passed (1.4m)
```

(One transient `preview.spec.mjs:72` flake at 3 workers when total CPU was saturated; passes reliably at 1–2 workers and the CI runner uses 2.)

## Test plan
- [ ] CI: Static checks, Elixir tests, **Browser tests**, security scans
- [ ] Local: `pixi run bun run test:e2e` → all 17 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)