### PR TITLE
feat(editor-v2): smart files, tabs, pins, breadcrumb, outline & templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,14 @@ repos:
       stages: [commit-msg]
       always_run: true
 
+    - id: commit-message-length
+      name: commit message first paragraph length (<= 69 chars)
+      language: pygrep
+      entry: '\A[^\n]{1,69}(\n|\Z)'
+      args: [--negate]
+      stages: [commit-msg]
+      always_run: true
+
     - id: mix-format
       name: mix format
       entry: mix format --check-formatted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,10 @@ And **never** do this:
 - Be careful with scraping limits and TOS.
 - Make regular commits to the repository using for commit messages template: `feat/core/bug/chore/etc: short description (#<issue number>)`
 - commit description must be detailed enough to understand the change without looking at the code, and must be short enough to be easily readable in the git log
+- Use Conventional Commits: `type(scope): summary` — allowed types `feat`, `fix`, `chore`, `docs`, `refactor`, `style`, `test`. The scope is optional but encouraged (e.g. `feat(editor): ...`).
+- The summary is a **single short sentence**, imperative mood, **69 characters maximum** (so it stays readable in `git log`).
+- **No commit body and no bullet lists.** Keep detailed scope, rationale, and design notes in the linked **GitHub issue**, not in the commit message.
+
 
 <!-- development-guidelines-end -->
 

--- a/assets/css/_codemirror.css
+++ b/assets/css/_codemirror.css
@@ -93,6 +93,23 @@
   color: var(--mk-error);
 }
 
+/* ── Native text selection ────────────────────────────────────────────────
+   We dropped CodeMirror's drawSelection() so the browser paints selection.
+   Token-driven via --pri, so it tracks light/dark automatically. */
+.cm-editor .cm-content ::selection { background: color-mix(in srgb, var(--pri) 30%, transparent); }
+/* End-of-line marker for a selected trailing newline (so an otherwise-invisible
+   blank-line selection shows something). The widget span is a zero-size inline
+   anchor — it sits after the line's text but contributes nothing to the line
+   box, so it can't grow the line (no reflow, even on empty lines). Its
+   ::before, taken out of flow, paints the actual block at that spot. */
+/* The marker is just a transparent nbsp widget at the line end; the browser
+   paints ::selection over it exactly like selected text (same colour, height,
+   per-line rounding) since it sits inside the selection range. No own
+   background — that double-painted over the ::selection and looked darker. */
+.cm-editor .cm-eol-mark {
+  color: transparent;
+}
+
 /* ── Lint diagnostics (compile errors/warnings) ───────────────────────────── */
 /* @codemirror/lint draws the underline via an inline-SVG background-image and
    the gutter marker via the `content` property; null both, then theme to the

--- a/assets/css/_codemirror.css
+++ b/assets/css/_codemirror.css
@@ -111,13 +111,16 @@
 .cm-lintRange-info { text-decoration-color: var(--mk-fg3); }
 .cm-lintRange-active { background-color: var(--mk-warning-50); }
 
+/* Flex-center the marker in the gutter row so the dot sits on the line's
+   vertical center (a fixed margin drifts below center on tall line-heights). */
+.cm-gutter-lint .cm-gutterElement { padding: 0; display: flex; align-items: center; justify-content: center; }
 .cm-lint-marker {
   content: none;
+  background-image: none;
   width: 8px;
   height: 8px;
-  margin: 5px auto;
+  margin: 0;
   border-radius: 9999px;
-  background-image: none;
 }
 .cm-lint-marker-error { background-color: var(--mk-error); }
 .cm-lint-marker-warning { background-color: var(--mk-warning); border-radius: 2px; }
@@ -129,21 +132,40 @@
   border: 1px solid var(--mk-bd);
   border-radius: var(--mk-r);
   box-shadow: var(--mk-sh-lg);
-  padding: 4px;
+  padding: 0;
   max-width: 30rem;
   overflow: hidden;
 }
+/* A leading severity dot (flex item) instead of a left border — readable and
+   it stays aligned with the first line of multi-line messages. */
 .cm-tooltip.cm-tooltip-lint .cm-diagnostic {
-  border-left: 3px solid transparent;
-  border-radius: var(--mk-r-sm);
-  padding: 6px 10px;
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  border: 0;
+  border-radius: 0;
+  padding: 8px 12px;
   margin: 0;
 }
-.cm-tooltip.cm-tooltip-lint .cm-diagnostic-error { border-left-color: var(--mk-error); }
-.cm-tooltip.cm-tooltip-lint .cm-diagnostic-warning { border-left-color: var(--mk-warning); }
-.cm-tooltip.cm-tooltip-lint .cm-diagnostic-info { border-left-color: var(--mk-fg3); }
-.cm-diagnosticText { font: 13px/1.4 'Inter', system-ui, sans-serif; }
-.cm-diagnosticSource { font-size: 11px; opacity: 0.65; margin-top: 2px; }
+.cm-tooltip.cm-tooltip-lint .cm-diagnostic + .cm-diagnostic { border-top: 1px solid var(--mk-bd); }
+.cm-tooltip.cm-tooltip-lint .cm-diagnostic::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--mk-fg3);
+}
+.cm-tooltip.cm-tooltip-lint .cm-diagnostic-error::before { background: var(--mk-error); }
+.cm-tooltip.cm-tooltip-lint .cm-diagnostic-warning::before { background: var(--mk-warning); border-radius: 2px; }
+.cm-tooltip.cm-tooltip-lint .cm-diagnosticText {
+  flex: 1;
+  min-width: 0;
+  color: var(--mk-fg);
+  font: 13px/1.45 'Inter', system-ui, sans-serif;
+}
+.cm-tooltip.cm-tooltip-lint .cm-diagnosticSource { font-size: 11px; opacity: 0.65; margin-top: 2px; }
 .cm-tooltip.cm-tooltip-lint .cm-tooltip-arrow::after { border-top-color: var(--mk-bg); }
 
 /* Bottom lint panel (opened via the lint keymap) reuses .cm-diagnostic* rows. */

--- a/assets/css/_codemirror.css
+++ b/assets/css/_codemirror.css
@@ -126,18 +126,22 @@
 .cm-lint-marker-warning { background-color: var(--mk-warning); border-radius: 2px; }
 .cm-lint-marker-info { background-color: var(--mk-fg3); }
 
-/* `.cm-tooltip-lint` is the <ul> INSIDE the generic `.cm-tooltip` wrapper, not
-   the wrapper itself — so style the wrapper (card chrome) via :has, and the
-   <ul> as the card body. */
-.cm-tooltip:has(.cm-tooltip-lint) {
-  background: var(--mk-bg);
-  border: 1px solid var(--mk-bd);
-  border-radius: var(--mk-r);
-  box-shadow: var(--mk-sh-lg);
+/* Lint diagnostics show in a *hover* tooltip — the only hover tooltip in this
+   editor. CodeMirror puts the card chrome on the `.cm-tooltip-hover` element
+   (which may also be the `.cm-tooltip-lint` <ul> itself), so style that as the
+   rounded card. Triple class + !important to beat CM's themed `.cm-tooltip`
+   defaults regardless of stylesheet injection order. */
+.cm-tooltip-hover.cm-tooltip-hover.cm-tooltip-hover {
+  background: var(--mk-bg) !important;
+  color: var(--mk-fg) !important;
+  border: 1px solid var(--mk-bd) !important;
+  border-radius: var(--mk-r) !important;
+  box-shadow: var(--mk-sh-lg) !important;
   overflow: hidden;
+  padding: 0;
 }
 .cm-tooltip-lint {
-  background: var(--mk-bg);
+  background: transparent;
   color: var(--mk-fg);
   padding: 0;
   margin: 0;
@@ -173,8 +177,14 @@
   font: 13px/1.45 'Inter', system-ui, sans-serif;
 }
 .cm-tooltip-lint .cm-diagnosticSource { font-size: 11px; opacity: 0.65; margin-top: 2px; }
-.cm-tooltip:has(.cm-tooltip-lint) .cm-tooltip-arrow::after { border-top-color: var(--mk-bg); }
-.cm-tooltip:has(.cm-tooltip-lint) .cm-tooltip-arrow::before { border-top-color: var(--mk-bd); }
+.cm-tooltip-hover .cm-tooltip-arrow::after {
+  border-top-color: var(--mk-bg);
+  border-bottom-color: var(--mk-bg);
+}
+.cm-tooltip-hover .cm-tooltip-arrow::before {
+  border-top-color: var(--mk-bd);
+  border-bottom-color: var(--mk-bd);
+}
 
 /* Bottom lint panel (opened via the lint keymap) reuses .cm-diagnostic* rows. */
 .cm-panel.cm-panel-lint { background: var(--mk-bg2); border-top: 1px solid var(--mk-bd); }

--- a/assets/css/_codemirror.css
+++ b/assets/css/_codemirror.css
@@ -92,3 +92,60 @@
 .ts-cm-search--invalid .ts-cm-search__count {
   color: var(--mk-error);
 }
+
+/* ── Lint diagnostics (compile errors/warnings) ───────────────────────────── */
+/* @codemirror/lint draws the underline via an inline-SVG background-image and
+   the gutter marker via the `content` property; null both, then theme to the
+   design tokens (which are already light/dark aware). */
+.cm-lintRange {
+  background-image: none;
+  padding-bottom: 0;
+  text-decoration-line: underline;
+  text-decoration-style: wavy;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  text-decoration-skip-ink: none;
+}
+.cm-lintRange-error { text-decoration-color: var(--mk-error); }
+.cm-lintRange-warning { text-decoration-color: var(--mk-warning); }
+.cm-lintRange-info { text-decoration-color: var(--mk-fg3); }
+.cm-lintRange-active { background-color: var(--mk-warning-50); }
+
+.cm-lint-marker {
+  content: none;
+  width: 8px;
+  height: 8px;
+  margin: 5px auto;
+  border-radius: 9999px;
+  background-image: none;
+}
+.cm-lint-marker-error { background-color: var(--mk-error); }
+.cm-lint-marker-warning { background-color: var(--mk-warning); border-radius: 2px; }
+.cm-lint-marker-info { background-color: var(--mk-fg3); }
+
+.cm-tooltip.cm-tooltip-lint {
+  background: var(--mk-bg);
+  color: var(--mk-fg);
+  border: 1px solid var(--mk-bd);
+  border-radius: var(--mk-r);
+  box-shadow: var(--mk-sh-lg);
+  padding: 4px;
+  max-width: 30rem;
+  overflow: hidden;
+}
+.cm-tooltip.cm-tooltip-lint .cm-diagnostic {
+  border-left: 3px solid transparent;
+  border-radius: var(--mk-r-sm);
+  padding: 6px 10px;
+  margin: 0;
+}
+.cm-tooltip.cm-tooltip-lint .cm-diagnostic-error { border-left-color: var(--mk-error); }
+.cm-tooltip.cm-tooltip-lint .cm-diagnostic-warning { border-left-color: var(--mk-warning); }
+.cm-tooltip.cm-tooltip-lint .cm-diagnostic-info { border-left-color: var(--mk-fg3); }
+.cm-diagnosticText { font: 13px/1.4 'Inter', system-ui, sans-serif; }
+.cm-diagnosticSource { font-size: 11px; opacity: 0.65; margin-top: 2px; }
+.cm-tooltip.cm-tooltip-lint .cm-tooltip-arrow::after { border-top-color: var(--mk-bg); }
+
+/* Bottom lint panel (opened via the lint keymap) reuses .cm-diagnostic* rows. */
+.cm-panel.cm-panel-lint { background: var(--mk-bg2); border-top: 1px solid var(--mk-bd); }
+.cm-panel.cm-panel-lint ul [aria-selected] { background: var(--mk-bd2); }

--- a/assets/css/_codemirror.css
+++ b/assets/css/_codemirror.css
@@ -126,12 +126,14 @@
 .cm-lint-marker-warning { background-color: var(--mk-warning); border-radius: 2px; }
 .cm-lint-marker-info { background-color: var(--mk-fg3); }
 
-/* Lint diagnostics show in a *hover* tooltip — the only hover tooltip in this
-   editor. CodeMirror puts the card chrome on the `.cm-tooltip-hover` element
-   (which may also be the `.cm-tooltip-lint` <ul> itself), so style that as the
-   rounded card. Triple class + !important to beat CM's themed `.cm-tooltip`
-   defaults regardless of stylesheet injection order. */
-.cm-tooltip-hover.cm-tooltip-hover.cm-tooltip-hover {
+/* The lint card lives on two different elements depending on how it's shown:
+   - gutter-marker hover (showTooltip): `.cm-tooltip` is added to the
+     `.cm-tooltip-lint` <ul> itself → `.cm-tooltip.cm-tooltip-lint`.
+   - underline hover (hoverTooltip): a separate `.cm-tooltip-hover` wrapper.
+   Style both as the rounded card. Extra classes + !important beat CM's themed
+   `.cm-tooltip` defaults regardless of stylesheet injection order. */
+.cm-tooltip-hover.cm-tooltip-hover.cm-tooltip-hover,
+.cm-tooltip.cm-tooltip-lint.cm-tooltip-lint {
   background: var(--mk-bg) !important;
   color: var(--mk-fg) !important;
   border: 1px solid var(--mk-bd) !important;
@@ -140,6 +142,8 @@
   overflow: hidden;
   padding: 0;
 }
+/* The inner <ul> in the hover-wrapper case is transparent (wrapper paints the
+   card); the !important above wins for the gutter case where it IS the card. */
 .cm-tooltip-lint {
   background: transparent;
   color: var(--mk-fg);
@@ -177,11 +181,13 @@
   font: 13px/1.45 'Inter', system-ui, sans-serif;
 }
 .cm-tooltip-lint .cm-diagnosticSource { font-size: 11px; opacity: 0.65; margin-top: 2px; }
-.cm-tooltip-hover .cm-tooltip-arrow::after {
+.cm-tooltip-hover .cm-tooltip-arrow::after,
+.cm-tooltip.cm-tooltip-lint .cm-tooltip-arrow::after {
   border-top-color: var(--mk-bg);
   border-bottom-color: var(--mk-bg);
 }
-.cm-tooltip-hover .cm-tooltip-arrow::before {
+.cm-tooltip-hover .cm-tooltip-arrow::before,
+.cm-tooltip.cm-tooltip-lint .cm-tooltip-arrow::before {
   border-top-color: var(--mk-bd);
   border-bottom-color: var(--mk-bd);
 }

--- a/assets/css/_codemirror.css
+++ b/assets/css/_codemirror.css
@@ -126,19 +126,26 @@
 .cm-lint-marker-warning { background-color: var(--mk-warning); border-radius: 2px; }
 .cm-lint-marker-info { background-color: var(--mk-fg3); }
 
-.cm-tooltip.cm-tooltip-lint {
+/* `.cm-tooltip-lint` is the <ul> INSIDE the generic `.cm-tooltip` wrapper, not
+   the wrapper itself — so style the wrapper (card chrome) via :has, and the
+   <ul> as the card body. */
+.cm-tooltip:has(.cm-tooltip-lint) {
   background: var(--mk-bg);
-  color: var(--mk-fg);
   border: 1px solid var(--mk-bd);
   border-radius: var(--mk-r);
   box-shadow: var(--mk-sh-lg);
-  padding: 0;
-  max-width: 30rem;
   overflow: hidden;
 }
-/* A leading severity dot (flex item) instead of a left border — readable and
-   it stays aligned with the first line of multi-line messages. */
-.cm-tooltip.cm-tooltip-lint .cm-diagnostic {
+.cm-tooltip-lint {
+  background: var(--mk-bg);
+  color: var(--mk-fg);
+  padding: 0;
+  margin: 0;
+  max-width: 30rem;
+}
+/* A leading severity dot (flex item) instead of the default left border —
+   readable, and it stays aligned with the first line of multi-line messages. */
+.cm-tooltip-lint .cm-diagnostic {
   display: flex;
   gap: 8px;
   align-items: flex-start;
@@ -147,8 +154,8 @@
   padding: 8px 12px;
   margin: 0;
 }
-.cm-tooltip.cm-tooltip-lint .cm-diagnostic + .cm-diagnostic { border-top: 1px solid var(--mk-bd); }
-.cm-tooltip.cm-tooltip-lint .cm-diagnostic::before {
+.cm-tooltip-lint .cm-diagnostic + .cm-diagnostic { border-top: 1px solid var(--mk-bd); }
+.cm-tooltip-lint .cm-diagnostic::before {
   content: "";
   flex: 0 0 auto;
   width: 7px;
@@ -157,16 +164,17 @@
   border-radius: 50%;
   background: var(--mk-fg3);
 }
-.cm-tooltip.cm-tooltip-lint .cm-diagnostic-error::before { background: var(--mk-error); }
-.cm-tooltip.cm-tooltip-lint .cm-diagnostic-warning::before { background: var(--mk-warning); border-radius: 2px; }
-.cm-tooltip.cm-tooltip-lint .cm-diagnosticText {
+.cm-tooltip-lint .cm-diagnostic-error::before { background: var(--mk-error); }
+.cm-tooltip-lint .cm-diagnostic-warning::before { background: var(--mk-warning); border-radius: 2px; }
+.cm-tooltip-lint .cm-diagnosticText {
   flex: 1;
   min-width: 0;
   color: var(--mk-fg);
   font: 13px/1.45 'Inter', system-ui, sans-serif;
 }
-.cm-tooltip.cm-tooltip-lint .cm-diagnosticSource { font-size: 11px; opacity: 0.65; margin-top: 2px; }
-.cm-tooltip.cm-tooltip-lint .cm-tooltip-arrow::after { border-top-color: var(--mk-bg); }
+.cm-tooltip-lint .cm-diagnosticSource { font-size: 11px; opacity: 0.65; margin-top: 2px; }
+.cm-tooltip:has(.cm-tooltip-lint) .cm-tooltip-arrow::after { border-top-color: var(--mk-bg); }
+.cm-tooltip:has(.cm-tooltip-lint) .cm-tooltip-arrow::before { border-top-color: var(--mk-bd); }
 
 /* Bottom lint panel (opened via the lint keymap) reuses .cm-diagnostic* rows. */
 .cm-panel.cm-panel-lint { background: var(--mk-bg2); border-top: 1px solid var(--mk-bd); }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -261,6 +261,7 @@
   font: 500 13px 'JetBrains Mono', ui-monospace, monospace;
 }
 .ts-draft__input::placeholder { color: var(--fg4); }
+.ts-draft__dir { flex-shrink: 0; color: var(--fg3); user-select: none; font: 500 13px 'JetBrains Mono', ui-monospace, monospace; }
 .ts-exthint {
   flex-shrink: 0; user-select: none; cursor: pointer;
   padding: 2px 7px; border-radius: 6px;

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -235,12 +235,14 @@
 }
 .ts-draft__input::placeholder { color: var(--fg4); }
 .ts-exthint {
-  flex-shrink: 0; user-select: none;
+  flex-shrink: 0; user-select: none; cursor: pointer;
   padding: 2px 7px; border-radius: 6px;
   background: var(--bg2); border: 1px dashed var(--bd2);
   color: var(--fg3);
   font: 500 11px 'JetBrains Mono', ui-monospace, monospace;
+  transition: border-color 200ms var(--ease), color 200ms var(--ease), background 200ms var(--ease);
 }
+.ts-exthint:hover { border-color: var(--pri); border-style: solid; color: var(--fg); background: var(--bd2); }
 .ts-suggest { display: flex; flex-wrap: wrap; gap: 6px; padding: 6px 2px 2px; }
 .ts-suggest__chip {
   display: inline-flex; align-items: center; gap: 6px;

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -217,6 +217,11 @@
 .ts-tree__act:hover { background: var(--bd2); color: var(--fg); }
 .ts-tree__act.is-on { color: var(--pri); }
 .ts-tree__act--danger:hover { background: var(--mk-error-50); color: var(--mk-error); }
+.ts-tree__ficon { display: inline-flex; align-items: center; flex-shrink: 0; color: var(--fg2); }
+.ts-tree__ficon svg { width: 15px; height: 15px; }
+.ts-tree__pin-ind svg { width: 13px; height: 13px; }
+.ts-tree__act svg { width: 14px; height: 14px; }
+.ts-tab__pin svg { width: 13px; height: 13px; }
 
 /* ── Typed file-type chip (square glyph, colored by extension) ────────────── */
 .ts-filechip {

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -381,6 +381,20 @@ html:not(.is-mac) .ts-other { display: inline-flex; }
 .ts-tpl__drop { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 10px; border: 1.5px dashed var(--bd2); border-radius: var(--r-sm); color: var(--fg3); font: 12px 'Inter', system-ui, sans-serif; cursor: pointer; transition: border-color 150ms var(--ease), color 150ms var(--ease); }
 .ts-tpl__drop:hover { border-color: var(--pri); color: var(--fg); }
 
+/* ── Compile diagnostics panel (preview errors/warnings) ──────────────────── */
+.ts-diag { width: 100%; max-width: 560px; border: 1px solid var(--mk-error-bd); border-radius: var(--r); background: var(--bg); overflow: hidden; box-shadow: var(--sh-sm); }
+.ts-diag__head { display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-bottom: 1px solid var(--bd); font: 600 13px 'Inter', system-ui, sans-serif; color: var(--mk-error); }
+.ts-diag__list { display: flex; flex-direction: column; }
+.ts-diag__item { display: flex; gap: 10px; align-items: flex-start; padding: 10px 16px; border-bottom: 1px solid var(--bd); }
+.ts-diag__item:last-child { border-bottom: 0; }
+.ts-diag__dot { width: 8px; height: 8px; border-radius: 50%; margin-top: 6px; flex-shrink: 0; }
+.ts-diag__dot--error { background: var(--mk-error); }
+.ts-diag__dot--warn { background: var(--mk-warning); }
+.ts-diag__body { flex: 1; min-width: 0; }
+.ts-diag__loc { font: 500 11.5px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg4); margin-bottom: 2px; }
+.ts-diag__msg { font: 13px/1.5 'Inter', system-ui, sans-serif; color: var(--fg); overflow-wrap: anywhere; white-space: pre-wrap; }
+.ts-diag__hint { font: 12px 'Inter', system-ui, sans-serif; color: var(--fg3); margin-top: 3px; }
+
 /* ── Sidebar upload zone ──────────────────────────────────────────────────── */
 .ts-side__upload { padding: 8px 14px; border-top: 1px solid var(--bd); flex-shrink: 0; }
 

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -218,7 +218,7 @@
 .ts-tree__act.is-on { color: var(--pri); }
 .ts-tree__act--danger:hover { background: var(--mk-error-50); color: var(--mk-error); }
 .ts-tree__ficon { display: inline-flex; align-items: center; flex-shrink: 0; color: var(--fg2); }
-.ts-tree__ficon svg { width: 15px; height: 15px; }
+.ts-tree__ficon svg { width: 14px; height: 14px; }
 .ts-tree__pin-ind svg { width: 13px; height: 13px; }
 .ts-tree__act svg { width: 14px; height: 14px; }
 .ts-tab__pin svg { width: 13px; height: 13px; }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -295,9 +295,20 @@
 
 /* ── Source pane ──────────────────────────────────────────────────────────── */
 .ts-source { display: flex; flex-direction: column; border-right: 1px solid var(--bd); min-height: 0; overflow: hidden; background: var(--bg); }
-.ts-source__tabs { display: flex; border-bottom: 1px solid var(--bd); background: var(--bg2); padding: 0 8px; flex-shrink: 0; }
-.ts-tab { display: flex; align-items: center; gap: 6px; padding: 8px 12px; font: 13px 'Inter', system-ui, sans-serif; color: var(--fg2); border-radius: var(--r-sm) var(--r-sm) 0 0; border-bottom: 2px solid transparent; }
+.ts-source__tabs { display: flex; border-bottom: 1px solid var(--bd); background: var(--bg2); padding: 0 8px; flex-shrink: 0; overflow-x: auto; scrollbar-width: none; }
+.ts-source__tabs::-webkit-scrollbar { display: none; }
+.ts-tab { display: flex; align-items: center; gap: 6px; padding: 8px 10px; font: 13px 'Inter', system-ui, sans-serif; color: var(--fg2); border-radius: var(--r-sm) var(--r-sm) 0 0; border-bottom: 2px solid transparent; cursor: pointer; flex-shrink: 0; max-width: 220px; }
+.ts-tab:hover { background: var(--bd2); color: var(--fg); }
 .ts-tab.is-active { background: var(--bg); color: var(--fg); border-bottom-color: var(--pri); }
+.ts-tab--empty { color: var(--fg4); cursor: default; }
+.ts-tab--empty:hover { background: none; color: var(--fg4); }
+.ts-tab__label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.ts-tab__folder { color: var(--fg4); }
+.ts-tab.is-active .ts-tab__label { font-weight: 600; }
+.ts-tab__pin { display: inline-flex; align-items: center; color: var(--pri); flex-shrink: 0; }
+.ts-tab__close { display: inline-grid; place-items: center; width: 16px; height: 16px; border-radius: 4px; color: var(--fg4); flex-shrink: 0; opacity: 0; transition: opacity 120ms var(--ease); }
+.ts-tab:hover .ts-tab__close, .ts-tab.is-active .ts-tab__close { opacity: 1; }
+.ts-tab__close:hover { background: var(--bd2); color: var(--fg); }
 .ts-source__editor { flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
 .ts-source__editor .cm-editor { height: 100%; width: 100%; display: flex; flex-direction: column; }
 .ts-source__editor .cm-scroller { overflow: auto; flex: 1; }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -323,6 +323,31 @@
 
 /* ── Status bar (spans all editor panes) ───────────────────────────────────── */
 .ts-statusbar { grid-column: 1 / -1; display: flex; align-items: center; gap: 12px; height: 28px; padding: 0 14px; border-top: 1px solid var(--bd); background: var(--bg2); font: 500 11px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg3); }
+.ts-statusbar__btn { display: inline-flex; align-items: center; gap: 5px; border: 0; background: none; color: var(--fg3); font: inherit; cursor: pointer; padding: 0 4px; }
+.ts-statusbar__btn:hover { color: var(--fg); }
+.ts-statusbar__btn.is-error { color: var(--mk-error); }
+
+/* ── Compile log + problems drawer ────────────────────────────────────────── */
+.ts-drawer { grid-column: 1 / -1; display: flex; flex-direction: column; min-height: 150px; max-height: 260px; border-top: 1px solid var(--bd); background: var(--bg); }
+.ts-drawer__tabs { display: flex; align-items: center; gap: 4px; padding: 6px 10px; border-bottom: 1px solid var(--bd); flex-shrink: 0; }
+.ts-drawer__tab { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border: 0; background: none; border-radius: var(--r-sm); color: var(--fg3); font: 500 12px 'Inter', system-ui, sans-serif; cursor: pointer; }
+.ts-drawer__tab:hover { color: var(--fg); background: var(--bd2); }
+.ts-drawer__tab.is-active { color: var(--fg); background: var(--bd2); }
+.ts-drawer__count { min-width: 16px; height: 16px; padding: 0 4px; border-radius: 8px; background: var(--mk-error); color: #fff; font: 600 10px 'JetBrains Mono', ui-monospace, monospace; display: inline-grid; place-items: center; }
+.ts-drawer__body { flex: 1; overflow: auto; padding: 8px 0; }
+.ts-drawer__empty { padding: 12px 16px; color: var(--fg4); font: 12px 'Inter', system-ui, sans-serif; }
+.ts-log__row { display: flex; gap: 10px; padding: 2px 16px; font: 12px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg2); }
+.ts-log__time { color: var(--fg4); flex-shrink: 0; }
+.ts-log__row--ok .ts-log__text { color: var(--mk-success-h); }
+.ts-log__row--error .ts-log__text { color: var(--mk-error-h); }
+.ts-problem { display: flex; gap: 10px; align-items: flex-start; width: 100%; padding: 8px 16px; border: 0; border-bottom: 1px solid var(--bd); background: none; text-align: left; cursor: pointer; }
+.ts-problem:hover { background: var(--bd2); }
+.ts-problem__dot { width: 8px; height: 8px; border-radius: 50%; margin-top: 5px; flex-shrink: 0; }
+.ts-problem__dot--error { background: var(--mk-error); }
+.ts-problem__dot--warning { background: var(--mk-warning); }
+.ts-problem__body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.ts-problem__loc { font: 500 11.5px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg4); }
+.ts-problem__msg { font: 13px 'Inter', system-ui, sans-serif; color: var(--fg); }
 .ts-statusbar__item { display: inline-flex; align-items: center; gap: 6px; }
 .ts-statusbar__sep { width: 1px; height: 12px; background: var(--bd); flex-shrink: 0; }
 .ts-statusbar__dot { width: 6px; height: 6px; border-radius: 9999px; background: var(--mk-success); flex-shrink: 0; }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -201,6 +201,18 @@
 .ts-tree__count { margin-left: auto; font: 500 10px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg4); background: var(--bd2); padding: 1px 6px; border-radius: 9999px; }
 .ts-tree__smart { margin-left: 4px; color: var(--fg4); font: 11px 'JetBrains Mono', ui-monospace, monospace; flex-shrink: 0; }
 
+/* ── Pin indicator + hover row actions (pin / delete) ─────────────────────── */
+.ts-side__head--sub { padding-top: 4px; }
+.ts-tree__pin-ind { display: inline-flex; align-items: center; flex-shrink: 0; color: var(--pri); margin-left: 4px; }
+.ts-tree__item.is-active .ts-tree__pin-ind { color: var(--pri-h); }
+.ts-tree__item:hover .ts-tree__pin-ind { display: none; }
+.ts-tree__actions { display: inline-flex; align-items: center; gap: 2px; flex-shrink: 0; margin-left: 4px; opacity: 0; transition: opacity 150ms var(--ease); }
+.ts-tree__item:hover .ts-tree__actions { opacity: 1; }
+.ts-tree__act { display: inline-grid; place-items: center; width: 20px; height: 20px; border: 0; background: none; border-radius: 5px; color: var(--fg3); cursor: pointer; }
+.ts-tree__act:hover { background: var(--bd2); color: var(--fg); }
+.ts-tree__act.is-on { color: var(--pri); }
+.ts-tree__act--danger:hover { background: var(--mk-error-50); color: var(--mk-error); }
+
 /* ── Typed file-type chip (square glyph, colored by extension) ────────────── */
 .ts-filechip {
   width: 18px; height: 18px; flex-shrink: 0;

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -206,6 +206,19 @@
 .ts-tree__count { margin-left: auto; font: 500 10px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg4); background: var(--bd2); padding: 1px 6px; border-radius: 9999px; }
 .ts-tree__smart { margin-left: 4px; color: var(--fg4); font: 11px 'JetBrains Mono', ui-monospace, monospace; flex-shrink: 0; }
 
+/* ── Drag & drop: move a file onto a folder (or empty tree = root) ─────────── */
+/* Rows are selectable-looking but must not text-select while dragging. */
+.ts-tree__item { user-select: none; }
+.ts-tree__item[draggable="true"] { cursor: grab; }
+.ts-tree__item[draggable="true"]:active { cursor: grabbing; }
+.ts-tree__item.is-dnd-dragging { opacity: .45; }
+.ts-tree__dir.is-dnd-over {
+  background: var(--pri-50);
+  box-shadow: inset 0 0 0 1.5px var(--pri);
+  border-radius: var(--r-sm);
+  color: var(--pri-h);
+}
+
 /* ── Pin indicator + hover row actions (pin / delete) ─────────────────────── */
 .ts-side__head--sub { padding-top: 4px; }
 .ts-tree__pin-ind { display: inline-flex; align-items: center; flex-shrink: 0; color: var(--pri); margin-left: 4px; }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -201,6 +201,57 @@
 .ts-tree__count { margin-left: auto; font: 500 10px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg4); background: var(--bd2); padding: 1px 6px; border-radius: 9999px; }
 .ts-tree__smart { margin-left: 4px; color: var(--fg4); font: 11px 'JetBrains Mono', ui-monospace, monospace; flex-shrink: 0; }
 
+/* ── Typed file-type chip (square glyph, colored by extension) ────────────── */
+.ts-filechip {
+  width: 18px; height: 18px; flex-shrink: 0;
+  display: inline-grid; place-items: center;
+  border-radius: 5px;
+  font: 600 10px 'JetBrains Mono', ui-monospace, monospace;
+  background: var(--bd2); color: var(--fg3);
+}
+.ts-filechip--typ { background: var(--pri-50); color: var(--pri-h); }
+.ts-filechip--bib { background: color-mix(in oklab, var(--mk-warning) 16%, transparent); color: var(--mk-warning-h); }
+.ts-filechip--tex,
+.ts-filechip--latex,
+.ts-filechip--sty,
+.ts-filechip--cls { background: color-mix(in oklab, var(--mk-info) 16%, transparent); color: var(--mk-info-h); }
+.ts-filechip--md { background: color-mix(in oklab, var(--fg) 8%, transparent); color: var(--fg3); }
+
+/* ── Inline new-file draft row + smart extension hints ────────────────────── */
+.ts-tree__draft { list-style: none; padding: 2px 0; }
+.ts-tree__draft .ts-draft__row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 8px; margin: 2px 0;
+  border-radius: var(--r-sm);
+  background: var(--bg);
+  border: 1px solid var(--pri);
+  box-shadow: 0 0 0 3px var(--pri-50);
+}
+.ts-draft__input {
+  flex: 1; min-width: 0;
+  border: 0; outline: 0; background: transparent;
+  color: var(--fg);
+  font: 500 13px 'JetBrains Mono', ui-monospace, monospace;
+}
+.ts-draft__input::placeholder { color: var(--fg4); }
+.ts-exthint {
+  flex-shrink: 0; user-select: none;
+  padding: 2px 7px; border-radius: 6px;
+  background: var(--bg2); border: 1px dashed var(--bd2);
+  color: var(--fg3);
+  font: 500 11px 'JetBrains Mono', ui-monospace, monospace;
+}
+.ts-suggest { display: flex; flex-wrap: wrap; gap: 6px; padding: 6px 2px 2px; }
+.ts-suggest__chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 9px 4px 6px; border-radius: 9999px;
+  background: var(--bg2); border: 1px solid var(--bd);
+  color: var(--fg2); cursor: pointer;
+  font: 500 12px 'JetBrains Mono', ui-monospace, monospace;
+  transition: background 200ms var(--ease), border-color 200ms var(--ease), color 200ms var(--ease);
+}
+.ts-suggest__chip:hover { background: var(--bd2); border-color: var(--pri); color: var(--fg); }
+
 /* ── File-tree view-mode switcher ─────────────────────────────────────────── */
 /* The sidebar is a narrow `overflow:auto` scroller, so the menu renders in-flow
    (full width, pushing the tree down) rather than as an absolute overlay that

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -323,6 +323,16 @@
 /* ── Keyboard hints ───────────────────────────────────────────────────────── */
 .ts-kbd { display: inline-flex; align-items: center; height: 18px; padding: 0 5px; border-radius: 4px; background: var(--bd2); border: 1px solid var(--bd); border-bottom-width: 2px; color: var(--fg2); font: 500 10px 'JetBrains Mono', ui-monospace, monospace; }
 
+/* ── OS-aware shortcut hints ──────────────────────────────────────────────── */
+/* `<html>` gets `.is-mac` from app.js. Show ⌘/command on Apple, Ctrl/terminal
+   elsewhere. Default (pre-JS / SSR) assumes Apple, then JS corrects. */
+.ts-mac, .ts-other { display: inline-flex; align-items: center; }
+.ts-other { display: none; }
+html:not(.is-mac) .ts-mac { display: none; }
+html:not(.is-mac) .ts-other { display: inline-flex; }
+.ts-cmdk { gap: 6px; }
+.ts-cmdk__icon svg { width: 14px; height: 14px; }
+
 /* ── Sidebar upload zone ──────────────────────────────────────────────────── */
 .ts-side__upload { padding: 8px 14px; border-top: 1px solid var(--bd); flex-shrink: 0; }
 

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -379,6 +379,9 @@ html:not(.is-mac) .ts-other { display: inline-flex; }
 .ts-outline__item.is-active { color: var(--pri); border-left-color: var(--pri); background: var(--pri-50); }
 .ts-outline__item.level-2 { padding-left: 22px; font-size: 12px; }
 .ts-outline__item.level-3 { padding-left: 34px; font-size: 12px; color: var(--fg4); }
+.ts-outline__num { flex-shrink: 0; min-width: 20px; color: var(--fg4); font: 500 10px 'JetBrains Mono', ui-monospace, monospace; }
+.ts-outline__item.is-active .ts-outline__num { color: var(--pri); }
+.ts-side__count { font: 500 10px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg4); text-transform: none; letter-spacing: 0; }
 
 /* ── Project initial tile (serif, accent-tinted; --ts-icon overrides hue) ──── */
 .ts-project-icon { width: 40px; height: 40px; border-radius: var(--r-sm); display: grid; place-items: center; flex-shrink: 0; font-family: 'Instrument Serif', 'Times New Roman', serif; font-style: italic; font-weight: 400; font-size: 19px; background: color-mix(in srgb, var(--ts-icon, var(--pri)) 14%, transparent); color: var(--ts-icon, var(--pri)); }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -348,6 +348,8 @@
 .ts-problem__body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .ts-problem__loc { font: 500 11.5px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg4); }
 .ts-problem__msg { font: 13px 'Inter', system-ui, sans-serif; color: var(--fg); }
+.ts-drawer__delay { display: inline-flex; align-items: center; gap: 6px; font: 500 11px 'Inter', system-ui, sans-serif; color: var(--fg3); }
+.ts-drawer__delay select { font: 500 11px 'Inter', system-ui, sans-serif; color: var(--fg); background: var(--bg2); border: 1px solid var(--bd); border-radius: var(--r-sm); padding: 2px 6px; cursor: pointer; }
 .ts-statusbar__item { display: inline-flex; align-items: center; gap: 6px; }
 .ts-statusbar__sep { width: 1px; height: 12px; background: var(--bd); flex-shrink: 0; }
 .ts-statusbar__dot { width: 6px; height: 6px; border-radius: 9999px; background: var(--mk-success); flex-shrink: 0; }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -370,6 +370,8 @@ html:not(.is-mac) .ts-mac { display: none; }
 html:not(.is-mac) .ts-other { display: inline-flex; }
 .ts-cmdk { gap: 6px; }
 .ts-cmdk__icon svg { width: 14px; height: 14px; }
+.ts-kbd svg { width: 11px; height: 11px; }
+.ts-kbd--combo { gap: 3px; }
 
 /* ── Your templates ───────────────────────────────────────────────────────── */
 .ts-tpl { padding: 4px 12px 12px; display: flex; flex-direction: column; gap: 6px; }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -366,6 +366,13 @@ html:not(.is-mac) .ts-other { display: inline-flex; }
 .ts-cmdk { gap: 6px; }
 .ts-cmdk__icon svg { width: 14px; height: 14px; }
 
+/* ── Your templates ───────────────────────────────────────────────────────── */
+.ts-tpl { padding: 4px 12px 12px; display: flex; flex-direction: column; gap: 6px; }
+.ts-tpl__row { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: var(--r-sm); background: var(--bg2); border: 1px solid var(--bd); }
+.ts-tpl__name { flex: 1; min-width: 0; font: 500 12.5px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg); }
+.ts-tpl__drop { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 10px; border: 1.5px dashed var(--bd2); border-radius: var(--r-sm); color: var(--fg3); font: 12px 'Inter', system-ui, sans-serif; cursor: pointer; transition: border-color 150ms var(--ease), color 150ms var(--ease); }
+.ts-tpl__drop:hover { border-color: var(--pri); color: var(--fg); }
+
 /* ── Sidebar upload zone ──────────────────────────────────────────────────── */
 .ts-side__upload { padding: 8px 14px; border-top: 1px solid var(--bd); flex-shrink: 0; }
 

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -228,6 +228,11 @@
 .ts-filechip--sty,
 .ts-filechip--cls { background: color-mix(in oklab, var(--mk-info) 16%, transparent); color: var(--mk-info-h); }
 .ts-filechip--md { background: color-mix(in oklab, var(--fg) 8%, transparent); color: var(--fg3); }
+.ts-filechip--csv { background: color-mix(in oklab, var(--mk-info) 16%, transparent); color: var(--mk-info-h); }
+.ts-filechip--img { background: color-mix(in oklab, var(--mk-success) 16%, transparent); color: var(--mk-success-h); }
+.ts-filechip--data { background: color-mix(in oklab, var(--mk-warning) 12%, transparent); color: var(--mk-warning-h); }
+.ts-filechip--file { background: var(--bd2); color: var(--fg3); }
+.ts-filechip--folder { background: color-mix(in oklab, var(--fg) 8%, transparent); color: var(--fg3); }
 
 /* ── Inline new-file draft row + smart extension hints ────────────────────── */
 .ts-tree__draft { list-style: none; padding: 2px 0; }

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -172,6 +172,11 @@
 .ts-editor__bar { display: flex; align-items: center; gap: 8px; height: 44px; padding: 0 12px; border-bottom: 1px solid var(--bd); background: var(--bg); flex-shrink: 0; }
 .ts-crumb-sep { color: var(--fg4); }
 .ts-crumb-current { font: 500 13px 'Inter', system-ui, sans-serif; color: var(--fg); margin-right: 10px; }
+.ts-crumb { display: flex; align-items: center; gap: 2px; min-width: 0; overflow: hidden; }
+.ts-crumb > span { display: inline-flex; align-items: center; gap: 2px; min-width: 0; }
+.ts-crumb__seg { font: 500 13px 'Inter', system-ui, sans-serif; color: var(--fg3); padding: 2px 5px; border-radius: var(--r-sm); white-space: nowrap; }
+.ts-crumb__seg.is-active { color: var(--fg); font: 600 12.5px 'JetBrains Mono', ui-monospace, monospace; }
+.ts-crumb__sep { color: var(--fg4); padding: 0 1px; }
 .ts-savestat { display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 9999px; background: var(--bd2); font: 500 11px 'Inter', system-ui, sans-serif; color: var(--fg2); }
 .ts-savestat__dot { width: 6px; height: 6px; border-radius: 9999px; flex-shrink: 0; }
 .ts-savestat--saved .ts-savestat__dot { background: var(--mk-success); }

--- a/assets/e2e/editor_gutter.spec.mjs
+++ b/assets/e2e/editor_gutter.spec.mjs
@@ -1,0 +1,166 @@
+import { test, expect } from "@playwright/test"
+
+// Opens a fresh project's editor with an empty main.typ ready for typing.
+async function openEditor(page, name) {
+  await page.goto("/projects")
+  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
+  await page.locator("#new-project-button").click()
+  await page.locator('.ts-dialog input[name="name"]').fill(name)
+  await page.locator('.ts-dialog button[type="submit"]').click()
+  const row = page.locator(".ts-list__row").filter({ hasText: name })
+  await row.getByRole("link", { name: "Open" }).click()
+  await page.locator("#create-main-file-button").click()
+  const draft = page.locator('#new-file-form input[name="path"]')
+  await draft.fill("main.typ")
+  await draft.press("Enter")
+  const cm = page.locator("#editor-container .cm-content")
+  await cm.click({ timeout: 10_000 })
+  return cm
+}
+
+const firstGutter = (page) => page.locator(".cm-lineNumbers .cm-gutterElement").first()
+const gutterWidth = (page) => firstGutter(page).evaluate((el) => el.getBoundingClientRect().width)
+
+test.describe("Editor line-number gutter", () => {
+  test("line numbers are right-aligned", async ({ page }) => {
+    await openEditor(page, `Gutter Align ${Date.now()}`)
+    await page.keyboard.type("alpha\nbeta\ngamma")
+
+    await expect(firstGutter(page)).toHaveCSS("text-align", "right")
+  })
+
+  test("reserves room for 5 digits and holds steady up to 99999", async ({ page }) => {
+    const cm = await openEditor(page, `Gutter Reserve ${Date.now()}`)
+    await page.keyboard.type("one\ntwo\nthree")
+    await page.waitForTimeout(150)
+
+    // Width of a single monospace digit in the gutter, measured live.
+    const digit = await page.evaluate(() => {
+      const el = document.querySelector(".cm-lineNumbers .cm-gutterElement")
+      const cs = getComputedStyle(el)
+      const probe = document.createElement("span")
+      probe.textContent = "0"
+      probe.style.fontFamily = cs.fontFamily
+      probe.style.fontSize = cs.fontSize
+      probe.style.position = "absolute"
+      probe.style.visibility = "hidden"
+      document.body.appendChild(probe)
+      const w = probe.getBoundingClientRect().width
+      probe.remove()
+      return w
+    })
+
+    // Floor must fit 5 digits even though only single-digit numbers are shown.
+    const reserve = await gutterWidth(page)
+    expect(reserve).toBeGreaterThanOrEqual(5 * digit)
+
+    // Grow to 3-digit line numbers; the reserve must not shift, and numbers must
+    // not clip. (Past 99999 CM widens the gutter natively — min-width is a floor,
+    // not a cap — which is impractical to exercise with real keystrokes.)
+    await cm.click()
+    await page.keyboard.type("\n".repeat(140))
+    await page.waitForTimeout(200)
+
+    const maxDigits = await page.evaluate(() =>
+      Math.max(
+        ...[...document.querySelectorAll(".cm-lineNumbers .cm-gutterElement")].map(
+          (el) => (el.textContent || "").trim().length
+        )
+      )
+    )
+    expect(maxDigits).toBeGreaterThanOrEqual(3)
+
+    const after = await gutterWidth(page)
+    expect(Math.abs(after - reserve)).toBeLessThanOrEqual(1)
+
+    const clipped = await page.evaluate(() =>
+      [...document.querySelectorAll(".cm-lineNumbers .cm-gutterElement")].some(
+        (el) => el.scrollWidth > el.clientWidth + 1
+      )
+    )
+    expect(clipped).toBe(false)
+  })
+
+  test("selection uses the native browser selection, not a drawSelection layer", async ({
+    page
+  }) => {
+    const cm = await openEditor(page, `Gutter Selection ${Date.now()}`)
+    await page.keyboard.type("alpha line one\nbeta")
+
+    // No CodeMirror selection layer should exist (drawSelection removed).
+    await expect(page.locator(".cm-selectionLayer")).toHaveCount(0)
+
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+a" : "Control+a")
+    const selected = await page.evaluate(() => window.getSelection().toString())
+    expect(selected).toContain("alpha line one")
+    await cm.click() // collapse
+  })
+
+  test("marks every selected newline incl. blank lines, sized to the selection", async ({
+    page
+  }) => {
+    await openEditor(page, `Gutter EOL ${Date.now()}`)
+    const mod = process.platform === "darwin" ? "Meta" : "Control"
+    await page.keyboard.press(`${mod}+a`) // clear the seeded starter content
+    await page.keyboard.press("Backspace")
+    await page.keyboard.type("first line\n\nthird line") // line 2 is blank
+
+    // Select all: the newline after line 1 (text) and line 2 (blank) are in the
+    // selection → a marker on each; line 3 is last (no trailing newline) → none.
+    await page.keyboard.press(`${mod}+a`)
+    await expect(page.locator(".cm-eol-mark")).toHaveCount(2)
+
+    // Each marker is painted by an inline background, so it matches the native
+    // selection band's height pixel-for-pixel (≤1px), not the full line height.
+    const cmp = await page.evaluate(() => {
+      const selH = [...window.getSelection().getRangeAt(0).getClientRects()][0].height
+      const marks = [...document.querySelectorAll(".cm-eol-mark")].map((m) => {
+        const r = m.getBoundingClientRect()
+        return { w: r.width, h: r.height }
+      })
+      return { selH, marks }
+    })
+    for (const m of cmp.marks) {
+      expect(m.w).toBeGreaterThan(0)
+      expect(Math.abs(m.h - cmp.selH)).toBeLessThanOrEqual(1)
+    }
+
+    // The marker is selection-only: collapsing the selection removes it.
+    await page.keyboard.press("ArrowRight")
+    await expect(page.locator(".cm-eol-mark")).toHaveCount(0)
+  })
+
+  test("a selected text-line newline also gets a marker (VS Code parity)", async ({ page }) => {
+    await openEditor(page, `Gutter EOL Text ${Date.now()}`)
+    const mod = process.platform === "darwin" ? "Meta" : "Control"
+    await page.keyboard.press(`${mod}+a`) // clear the seeded starter content
+    await page.keyboard.press("Backspace")
+    await page.keyboard.type("alpha\nbeta") // two text lines, no blank line
+
+    // Newline after line 1 (a text line) is selected → it gets a marker too;
+    // line 2 is last (no trailing newline) → none.
+    await page.keyboard.press(`${mod}+a`)
+    await expect(page.locator(".cm-eol-mark")).toHaveCount(1)
+  })
+
+  test("end-of-line marker does not change line height (no reflow)", async ({ page }) => {
+    await openEditor(page, `Gutter Reflow ${Date.now()}`)
+    // Include a blank line — that's the case that grows when the marker is
+    // in-flow, since a blank line has no text to anchor the line box.
+    await page.keyboard.type("alpha\n\ngamma\ndelta")
+    await page.waitForTimeout(150)
+
+    const contentH = () =>
+      page.evaluate(() => document.querySelector(".cm-content").getBoundingClientRect().height)
+
+    const before = await contentH()
+    // Select everything → eol markers appear on every line but the last.
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+a" : "Control+a")
+    await expect(page.locator(".cm-eol-mark").first()).toBeAttached()
+    const during = await contentH()
+
+    // Out-of-flow markers must not grow the document (the bug grew a blank line
+    // by a full row); allow sub-pixel rounding only.
+    expect(Math.abs(during - before)).toBeLessThanOrEqual(1)
+  })
+})

--- a/assets/e2e/editor_load.spec.mjs
+++ b/assets/e2e/editor_load.spec.mjs
@@ -25,12 +25,12 @@ test.describe('Typster Editor Workflow', () => {
   test('should create a project and load the editor with a file', async ({ page }) => {
     await createProjectAndOpenEditor(page, 'E2E Smoke Test')
 
-    // Click the "+" sidebar button — opens the new-file dialog
+    // Click the "+" sidebar button — reveals the inline new-file draft row
     await page.locator('#create-main-file-button').click()
-    await expect(page.locator('.ts-dialog')).toBeVisible()
-    await page.locator('.ts-dialog input[name="path"]').fill('main.typ')
-    await page.locator('.ts-dialog button[type="submit"]').click()
-    await expect(page.locator('.ts-dialog')).not.toBeVisible()
+    const draftInput = page.locator('#new-file-form input[name="path"]')
+    await expect(draftInput).toBeVisible()
+    await draftInput.fill('main.typ')
+    await draftInput.press('Enter')
 
     // main.typ should appear in the file tree
     await expect(
@@ -45,12 +45,12 @@ test.describe('Typster Editor Workflow', () => {
   test('should edit content in CodeMirror, autosave, and persist after reload', async ({ page }) => {
     await createProjectAndOpenEditor(page, 'E2E Autosave Test')
 
-    // Create main.typ via the new-file dialog
+    // Create main.typ via the inline new-file draft row
     await page.locator('#create-main-file-button').click()
-    await expect(page.locator('.ts-dialog')).toBeVisible()
-    await page.locator('.ts-dialog input[name="path"]').fill('main.typ')
-    await page.locator('.ts-dialog button[type="submit"]').click()
-    await expect(page.locator('.ts-dialog')).not.toBeVisible()
+    const draftInput = page.locator('#new-file-form input[name="path"]')
+    await expect(draftInput).toBeVisible()
+    await draftInput.fill('main.typ')
+    await draftInput.press('Enter')
 
     // Wait for CodeMirror to initialize inside the container
     const cmContent = page.locator('#editor-container .cm-content')

--- a/assets/e2e/preview.spec.mjs
+++ b/assets/e2e/preview.spec.mjs
@@ -19,10 +19,10 @@ async function createProjectAndOpenEditor(page, name) {
 
 async function createFileAndOpenEditor(page) {
   await page.locator('#create-main-file-button').click()
-  await expect(page.locator('.ts-dialog')).toBeVisible()
-  await page.locator('.ts-dialog input[name="path"]').fill('main.typ')
-  await page.locator('.ts-dialog button[type="submit"]').click()
-  await expect(page.locator('.ts-dialog')).not.toBeVisible()
+  const draftInput = page.locator('#new-file-form input[name="path"]')
+  await expect(draftInput).toBeVisible()
+  await draftInput.fill('main.typ')
+  await draftInput.press('Enter')
   const cm = page.locator('#editor-container .cm-content')
   await expect(cm).toBeVisible({ timeout: 10_000 })
   return cm

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -17,10 +17,10 @@ async function createProjectAndOpenEditor(page, name) {
 
 async function addMainFile(page) {
   await page.locator('#create-main-file-button').click()
-  await expect(page.locator('.ts-dialog')).toBeVisible()
-  await page.locator('.ts-dialog input[name="path"]').fill('main.typ')
-  await page.locator('.ts-dialog button[type="submit"]').click()
-  await expect(page.locator('.ts-dialog')).not.toBeVisible()
+  const draftInput = page.locator('#new-file-form input[name="path"]')
+  await expect(draftInput).toBeVisible()
+  await draftInput.fill('main.typ')
+  await draftInput.press('Enter')
   await expect(page.locator('#editor-container .cm-content')).toBeVisible({ timeout: 10_000 })
 }
 
@@ -47,7 +47,7 @@ test.describe('Product UI redesign', () => {
     await createProjectAndOpenEditor(page, 'Palette E2E')
     await addMainFile(page)
 
-    await page.getByRole('button', { name: '⌘K' }).click()
+    await page.getByRole('button', { name: 'Open command palette' }).click()
     await expect(page.locator('#command-palette')).toBeVisible()
     await expect(page.locator('#palette-input')).toBeFocused()
 
@@ -56,6 +56,30 @@ test.describe('Product UI redesign', () => {
 
     await page.keyboard.press('Escape')
     await expect(page.locator('#command-palette')).not.toBeVisible()
+  })
+
+  test('command shortcut hint adapts to the OS (⌘ on Mac, Ctrl elsewhere)', async ({ page }) => {
+    // Force a Windows-class platform before any script runs.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'userAgentData', {
+        value: { platform: 'Windows' },
+        configurable: true
+      })
+    })
+
+    await createProjectAndOpenEditor(page, 'Shortcut OS E2E')
+    await addMainFile(page)
+
+    await expect(page.locator('html')).not.toHaveClass(/is-mac/)
+    // Non-mac: terminal icon + "Ctrl K" shown, ⌘ variant hidden.
+    await expect(page.locator('.ts-cmdk .ts-kbd.ts-other')).toBeVisible()
+    await expect(page.locator('.ts-cmdk .ts-kbd.ts-other')).toHaveText('Ctrl K')
+    await expect(page.locator('.ts-cmdk .ts-kbd.ts-mac')).toBeHidden()
+    await expect(page.locator('.ts-cmdk__icon.ts-mac')).toBeHidden()
+
+    // The button still opens the palette regardless of platform labelling.
+    await page.getByRole('button', { name: 'Open command palette' }).click()
+    await expect(page.locator('#command-palette')).toBeVisible()
   })
 
   test('applies Shiki Typst syntax highlighting', async ({ page }) => {

--- a/assets/e2e/search_panel.spec.mjs
+++ b/assets/e2e/search_panel.spec.mjs
@@ -23,10 +23,10 @@ async function createProjectAndOpenEditor(page, name) {
 // New files seed a default template, so clear the doc before typing our own.
 async function addMainFileWith(page, text) {
   await page.locator('#create-main-file-button').click()
-  await expect(page.locator('.ts-dialog')).toBeVisible()
-  await page.locator('.ts-dialog input[name="path"]').fill('main.typ')
-  await page.locator('.ts-dialog button[type="submit"]').click()
-  await expect(page.locator('.ts-dialog')).not.toBeVisible()
+  const draftInput = page.locator('#new-file-form input[name="path"]')
+  await expect(draftInput).toBeVisible()
+  await draftInput.fill('main.typ')
+  await draftInput.press('Enter')
 
   const cm = page.locator('#editor-container .cm-content')
   await expect(cm).toBeVisible({ timeout: 10_000 })

--- a/assets/e2e/wasm.spec.mjs
+++ b/assets/e2e/wasm.spec.mjs
@@ -49,10 +49,10 @@ test.describe('Typst WASM compilation pipeline', () => {
     await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
 
     await page.locator('#create-main-file-button').click()
-    await expect(page.locator('.ts-dialog')).toBeVisible()
-    await page.locator('.ts-dialog input[name="path"]').fill('main.typ')
-    await page.locator('.ts-dialog button[type="submit"]').click()
-    await expect(page.locator('.ts-dialog')).not.toBeVisible()
+    const draftInput = page.locator('#new-file-form input[name="path"]')
+    await expect(draftInput).toBeVisible()
+    await draftInput.fill('main.typ')
+    await draftInput.press('Enter')
 
     const cmContent = page.locator('#editor-container .cm-content')
     await expect(cmContent).toBeVisible({ timeout: 10_000 })

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -50,7 +50,8 @@ const liveSocket = new LiveSocket("/live", Socket, {
     Palette: Hooks.Palette,
     SlashFocus: Hooks.SlashFocus,
     LucideIcons: Hooks.LucideIcons,
-    CompileDelay: Hooks.CompileDelay
+    CompileDelay: Hooks.CompileDelay,
+    FileTreeDnD: Hooks.FileTreeDnD
   },
 })
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -49,7 +49,8 @@ const liveSocket = new LiveSocket("/live", Socket, {
     CommandPalette: Hooks.CommandPalette,
     Palette: Hooks.Palette,
     SlashFocus: Hooks.SlashFocus,
-    LucideIcons: Hooks.LucideIcons
+    LucideIcons: Hooks.LucideIcons,
+    CompileDelay: Hooks.CompileDelay
   },
 })
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,7 +18,7 @@
 // To load it, simply add a second `<link>` to your `root.html.heex` file.
 
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
-import { createIcons, ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
+import { createIcons, ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
 import { siGithub, siGoogle } from "simple-icons"
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
@@ -48,7 +48,8 @@ const liveSocket = new LiveSocket("/live", Socket, {
     PreviewZoom: Hooks.PreviewZoom,
     CommandPalette: Hooks.CommandPalette,
     Palette: Hooks.Palette,
-    SlashFocus: Hooks.SlashFocus
+    SlashFocus: Hooks.SlashFocus,
+    LucideIcons: Hooks.LucideIcons
   },
 })
 
@@ -68,7 +69,7 @@ window.liveSocket = liveSocket
 
 const Github = [["path", { d: siGithub.path, fill: "currentColor", stroke: "none" }]]
 const Google = [["path", { d: siGoogle.path, fill: "currentColor", stroke: "none" }]]
-const mkIconSet = { ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
+const mkIconSet = { ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
 const mkIcons = (root = document) => {
   createIcons({ icons: mkIconSet, root })
   root.querySelectorAll("svg[data-lucide]").forEach((svg) => svg.removeAttribute("data-lucide"))

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,7 +18,7 @@
 // To load it, simply add a second `<link>` to your `root.html.heex` file.
 
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
-import { createIcons, ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
+import { createIcons, ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
 import { siGithub, siGoogle } from "simple-icons"
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
@@ -27,6 +27,14 @@ import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/typster"
 import topbar from "../vendor/topbar"
 import * as Hooks from "./hooks"
+
+// Tag the document with the OS family so shortcut hints can show ⌘ on Apple
+// platforms and Ctrl everywhere else (CSS toggles `.ts-mac` / `.ts-other`).
+// Prefer the modern UA-Client-Hints API, fall back to the (deprecated)
+// navigator.platform, then the UA string.
+const platformHint =
+  navigator.userAgentData?.platform || navigator.platform || navigator.userAgent || ""
+document.documentElement.classList.toggle("is-mac", /mac/i.test(platformHint))
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
@@ -60,7 +68,7 @@ window.liveSocket = liveSocket
 
 const Github = [["path", { d: siGithub.path, fill: "currentColor", stroke: "none" }]]
 const Google = [["path", { d: siGoogle.path, fill: "currentColor", stroke: "none" }]]
-const mkIconSet = { ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
+const mkIconSet = { ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
 const mkIcons = (root = document) => {
   createIcons({ icons: mkIconSet, root })
   root.querySelectorAll("svg[data-lucide]").forEach((svg) => svg.removeAttribute("data-lucide"))

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,7 +18,7 @@
 // To load it, simply add a second `<link>` to your `root.html.heex` file.
 
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
-import { createIcons, ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
+import { createIcons, ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
 import { siGithub, siGoogle } from "simple-icons"
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
@@ -69,7 +69,7 @@ window.liveSocket = liveSocket
 
 const Github = [["path", { d: siGithub.path, fill: "currentColor", stroke: "none" }]]
 const Google = [["path", { d: siGoogle.path, fill: "currentColor", stroke: "none" }]]
-const mkIconSet = { ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
+const mkIconSet = { ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
 const mkIcons = (root = document) => {
   createIcons({ icons: mkIconSet, root })
   root.querySelectorAll("svg[data-lucide]").forEach((svg) => svg.removeAttribute("data-lucide"))

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -8,11 +8,11 @@ import {
   lineNumbers,
   highlightActiveLineGutter,
   highlightSpecialChars,
-  drawSelection,
   dropCursor,
-  rectangularSelection,
-  crosshairCursor,
-  highlightActiveLine
+  highlightActiveLine,
+  Decoration,
+  ViewPlugin,
+  WidgetType
 } from "@codemirror/view"
 import { EditorState, Compartment } from "@codemirror/state"
 import {
@@ -40,14 +40,81 @@ import { yaml } from "@codemirror/lang-yaml"
 import { stex } from "@codemirror/legacy-modes/mode/stex"
 import { compileTypst, downloadTypstPdf } from "./typst_worker"
 
+// Native selection paints nothing visible for a selected trailing newline (an
+// empty line shows nothing, a text line ends right at the glyphs). VS Code draws
+// a small block at the line's end to show the break is selected. We do the same
+// on every line whose newline is in the selection — including blank lines.
+//
+// The marker is an inline span holding a transparent non-breaking space: its
+// *background* therefore paints the exact same inline content box the browser
+// uses for ::selection on that line, so it matches the selection band's height
+// and per-line rounding pixel-for-pixel (a fixed-size box never could).
+class EolMarkWidget extends WidgetType {
+  eq() {
+    return true
+  }
+  toDOM() {
+    const span = document.createElement("span")
+    span.className = "cm-eol-mark"
+    span.textContent = " "
+    span.setAttribute("aria-hidden", "true")
+    return span
+  }
+  ignoreEvent() {
+    return true
+  }
+}
+const eolSelectionMark = Decoration.widget({ widget: new EolMarkWidget(), side: 1 })
+
+const eolSelection = ViewPlugin.fromClass(
+  class {
+    constructor(view) {
+      this.decorations = this.build(view)
+    }
+    update(u) {
+      // Deliberately not on geometryChanged: the marker must not feed back into
+      // layout (it's out of flow), and reacting to geometry would flicker.
+      if (u.selectionSet || u.docChanged || u.viewportChanged)
+        this.decorations = this.build(u.view)
+    }
+    build(view) {
+      const seen = new Set()
+      const deco = []
+      for (const range of view.state.selection.ranges) {
+        if (range.empty) continue
+        for (const vr of view.visibleRanges) {
+          let pos = Math.max(vr.from, range.from)
+          const end = Math.min(vr.to, range.to)
+          while (pos <= end) {
+            const line = view.state.doc.lineAt(pos)
+            // line.to < range.to ⇒ this line's newline is inside the selection.
+            if (line.to < range.to && !seen.has(line.to)) {
+              seen.add(line.to)
+              deco.push(eolSelectionMark.range(line.to))
+            }
+            pos = line.to + 1
+          }
+        }
+      }
+      deco.sort((a, b) => a.from - b.from)
+      return Decoration.set(deco)
+    }
+  },
+  { decorations: (v) => v.decorations }
+)
+
 // Equivalent of `codemirror`'s `basicSetup`, assembled from granular packages.
 const basicSetup = [
+  eolSelection,
   lineNumbers(),
   highlightActiveLineGutter(),
   highlightSpecialChars(),
   history(),
   foldGutter(),
-  drawSelection(),
+  // No drawSelection(): its custom selection layer extends a selected newline
+  // to the full editor width (a giant bar) and mis-measures single glyphs.
+  // Native browser selection hugs the text and shows the newline as a small
+  // trailing mark — styled via `::selection` in _codemirror.css.
   dropCursor(),
   EditorState.allowMultipleSelections.of(true),
   indentOnInput(),
@@ -55,8 +122,6 @@ const basicSetup = [
   bracketMatching(),
   closeBrackets(),
   autocompletion(),
-  rectangularSelection(),
-  crosshairCursor(),
   highlightActiveLine(),
   // Don't spray match boxes for 1-char selections (every `i`/`2` lit up).
   highlightSelectionMatches({ minSelectionLength: 2 }),
@@ -108,8 +173,8 @@ const lightTheme = EditorView.theme({
     padding: "16px",
     minHeight: "100%",
     lineHeight: "1.6",
-    // Ligatures (=>, !=, ->) skew CM's per-char coordinate measurement and make
-    // selection rects/cursor drift; disable them in the editor.
+    caretColor: "#09090b",
+    // Ligatures (=>, !=, ->) skew per-char coordinate measurement; disable them.
     fontVariantLigatures: "none"
   },
   ".cm-focused": { outline: "none" },
@@ -118,23 +183,22 @@ const lightTheme = EditorView.theme({
     fontFamily: "'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace"
   },
   ".cm-gutters": { backgroundColor: "#f4f4f5", color: "#a1a1aa", border: "none" },
-  ".cm-lineNumbers .cm-gutterElement": { minWidth: "3ch", padding: "0 8px 0 16px" },
-  // Translucent so the selection layer (rendered behind the content) shows
-  // through on the cursor's line — an opaque fill hid the selection there.
+  // Reserve room for 5 digits (≤ 99999), right-aligned; CM auto-grows past that.
+  // box-sizing is border-box, so add the horizontal padding into the floor.
+  ".cm-lineNumbers .cm-gutterElement": {
+    minWidth: "calc(5ch + 24px)",
+    padding: "0 8px 0 16px",
+    textAlign: "right"
+  },
   ".cm-activeLine": { backgroundColor: "rgba(9, 9, 11, 0.045)" },
   ".cm-activeLineGutter": { backgroundColor: "#ececee", color: "#09090b" },
-  // Match highlights must NOT share the selection's indigo hue or the two read
-  // as one — a neutral bordered box reads clearly as "other occurrences".
+  // Match highlights use a neutral bordered box so they read as "other
+  // occurrences", distinct from the (indigo) native ::selection.
   ".cm-selectionMatch": {
     backgroundColor: "rgba(9, 9, 11, 0.06)",
     outline: "1px solid rgba(9, 9, 11, 0.28)",
     borderRadius: "2px"
-  },
-  ".cm-cursor": { borderLeftColor: "#09090b" },
-  // Saturated enough to clearly read as "selected" against the activeLine gray.
-  // !important to outrank CM's base `&light.cm-focused > … .cm-selectionBackground`.
-  ".cm-selectionLayer .cm-selectionBackground, &.cm-focused .cm-selectionLayer .cm-selectionBackground":
-    { backgroundColor: "rgba(79, 70, 229, 0.42) !important" }
+  }
 })
 
 const darkTheme = EditorView.theme({
@@ -148,6 +212,7 @@ const darkTheme = EditorView.theme({
     padding: "16px",
     minHeight: "100%",
     lineHeight: "1.6",
+    caretColor: "#fafafa",
     fontVariantLigatures: "none"
   },
   ".cm-focused": { outline: "none" },
@@ -156,17 +221,18 @@ const darkTheme = EditorView.theme({
     fontFamily: "'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace"
   },
   ".cm-gutters": { backgroundColor: "#18181b", color: "#71717a", border: "none" },
-  ".cm-lineNumbers .cm-gutterElement": { minWidth: "3ch", padding: "0 8px 0 16px" },
+  ".cm-lineNumbers .cm-gutterElement": {
+    minWidth: "calc(5ch + 24px)",
+    padding: "0 8px 0 16px",
+    textAlign: "right"
+  },
   ".cm-activeLine": { backgroundColor: "rgba(250, 250, 250, 0.06)" },
   ".cm-activeLineGutter": { backgroundColor: "#27272a", color: "#fafafa" },
   ".cm-selectionMatch": {
     backgroundColor: "rgba(250, 250, 250, 0.10)",
     outline: "1px solid rgba(250, 250, 250, 0.35)",
     borderRadius: "2px"
-  },
-  ".cm-cursor": { borderLeftColor: "#fafafa" },
-  ".cm-selectionLayer .cm-selectionBackground, &.cm-focused .cm-selectionLayer .cm-selectionBackground":
-    { backgroundColor: "rgba(99, 102, 241, 0.46) !important" }
+  }
 })
 
 function getThemeExtension() {

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -33,7 +33,7 @@ import {
   closeBrackets,
   closeBracketsKeymap
 } from "@codemirror/autocomplete"
-import { lintKeymap } from "@codemirror/lint"
+import { lintKeymap, lintGutter, setDiagnostics } from "@codemirror/lint"
 import { typst, setTypstTheme, registerTypstView } from "./typst_highlight"
 import { markdown } from "@codemirror/lang-markdown"
 import { yaml } from "@codemirror/lang-yaml"
@@ -271,6 +271,36 @@ function getLanguageExtension(lang) {
   }
 }
 
+// Convert Typst diagnostics (1-based line/col, optional end) into CodeMirror
+// lint diagnostics with absolute from/to offsets, clamped to the document.
+function toCmDiagnostics(view, diags) {
+  const doc = view.state.doc
+
+  const offset = (line, col) => {
+    const n = Math.min(Math.max(line || 1, 1), doc.lines)
+    const l = doc.line(n)
+    return Math.min(l.from + Math.max((col || 1) - 1, 0), l.to)
+  }
+
+  return (diags || [])
+    .filter((d) => d.location && d.location.line != null)
+    .map((d) => {
+      const loc = d.location
+      const from = offset(loc.line, loc.col)
+      let to = loc.endLine != null ? offset(loc.endLine, loc.endCol) : from
+      if (to <= from) {
+        const l = doc.line(Math.min(Math.max(loc.line, 1), doc.lines))
+        to = Math.min(l.to, from + 1)
+      }
+      return {
+        from,
+        to,
+        severity: d.severity === "warning" ? "warning" : "error",
+        message: d.message || "Compilation error"
+      }
+    })
+}
+
 export function initEditor(container, initialContent, socket, fileId, options = {}) {
   let autosaveTimer = null
   let compileTimer = null
@@ -333,6 +363,7 @@ export function initEditor(container, initialContent, socket, fileId, options = 
     doc: initialContent || "",
     extensions: [
       basicSetup,
+      lintGutter(),
       themeCompartment.of(getThemeExtension()),
       languageCompartment.of(getLanguageExtension(language)),
       ...(language === "typst" ? typst() : []),
@@ -380,6 +411,8 @@ export function initEditor(container, initialContent, socket, fileId, options = 
     updateLanguage,
     runCommand: (cmd, arg) => runEditorCommand(editor, language, cmd, arg),
     openSearch: () => openSearchPanel(editor),
+    setDiagnostics: (diags) =>
+      editor.dispatch(setDiagnostics(editor.state, toCmDiagnostics(editor, diags))),
     compile: () => {
       // Only Typst files compile; the worker treats the active buffer as main.typ.
       if (language === "typst") compileTypst(editor.state.doc.toString(), options.project || {})

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -71,6 +71,22 @@ const basicSetup = [
   ])
 ]
 
+// Auto-recompile debounce (ms from the last keystroke). Configurable via
+// localStorage so a single keystroke doesn't thrash the WASM compiler; a
+// negative value disables auto-compile (manual ⌘↵ / Compile only).
+export const DEFAULT_COMPILE_DELAY = 700
+
+export function compileDelay() {
+  try {
+    const raw = localStorage.getItem("typster:compile_delay")
+    if (raw === null) return DEFAULT_COMPILE_DELAY
+    const v = parseInt(raw, 10)
+    return Number.isFinite(v) ? v : DEFAULT_COMPILE_DELAY
+  } catch (_e) {
+    return DEFAULT_COMPILE_DELAY
+  }
+}
+
 function getCurrentTheme() {
   const html = document.documentElement
   const theme = html.getAttribute("data-theme")
@@ -348,10 +364,13 @@ export function initEditor(container, initialContent, socket, fileId, options = 
 
       if (language === "typst") {
         clearTimeout(compileTimer)
-        compileTimer = setTimeout(() => {
-          if (socket) socket.pushEvent("compile_started", {})
-          compileTypst(content, options.project || {})
-        }, 300)
+        const delay = compileDelay()
+        if (delay >= 0) {
+          compileTimer = setTimeout(() => {
+            if (socket) socket.pushEvent("compile_started", {})
+            compileTypst(content, options.project || {})
+          }, delay)
+        }
       }
 
       clearTimeout(outlineTimer)

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -58,7 +58,8 @@ const basicSetup = [
   rectangularSelection(),
   crosshairCursor(),
   highlightActiveLine(),
-  highlightSelectionMatches(),
+  // Don't spray match boxes for 1-char selections (every `i`/`2` lit up).
+  highlightSelectionMatches({ minSelectionLength: 2 }),
   ...searchPanelExtensions,
   keymap.of([
     ...closeBracketsKeymap,
@@ -106,7 +107,10 @@ const lightTheme = EditorView.theme({
   ".cm-content": {
     padding: "16px",
     minHeight: "100%",
-    lineHeight: "1.6"
+    lineHeight: "1.6",
+    // Ligatures (=>, !=, ->) skew CM's per-char coordinate measurement and make
+    // selection rects/cursor drift; disable them in the editor.
+    fontVariantLigatures: "none"
   },
   ".cm-focused": { outline: "none" },
   ".cm-editor": { height: "100%" },
@@ -115,12 +119,22 @@ const lightTheme = EditorView.theme({
   },
   ".cm-gutters": { backgroundColor: "#f4f4f5", color: "#a1a1aa", border: "none" },
   ".cm-lineNumbers .cm-gutterElement": { minWidth: "3ch", padding: "0 8px 0 16px" },
-  ".cm-activeLine": { backgroundColor: "#fafafa" },
-  ".cm-activeLineGutter": { backgroundColor: "#fafafa", color: "#09090b" },
-  ".cm-selectionMatch": { backgroundColor: "rgba(79, 70, 229, 0.2)" },
-  "&.cm-focused .cm-selectionBackground": { backgroundColor: "rgba(79, 70, 229, 0.2)" },
+  // Translucent so the selection layer (rendered behind the content) shows
+  // through on the cursor's line — an opaque fill hid the selection there.
+  ".cm-activeLine": { backgroundColor: "rgba(9, 9, 11, 0.045)" },
+  ".cm-activeLineGutter": { backgroundColor: "#ececee", color: "#09090b" },
+  // Match highlights must NOT share the selection's indigo hue or the two read
+  // as one — a neutral bordered box reads clearly as "other occurrences".
+  ".cm-selectionMatch": {
+    backgroundColor: "rgba(9, 9, 11, 0.06)",
+    outline: "1px solid rgba(9, 9, 11, 0.28)",
+    borderRadius: "2px"
+  },
   ".cm-cursor": { borderLeftColor: "#09090b" },
-  ".cm-selectionBackground": { backgroundColor: "rgba(79, 70, 229, 0.2)" }
+  // Saturated enough to clearly read as "selected" against the activeLine gray.
+  // !important to outrank CM's base `&light.cm-focused > … .cm-selectionBackground`.
+  ".cm-selectionLayer .cm-selectionBackground, &.cm-focused .cm-selectionLayer .cm-selectionBackground":
+    { backgroundColor: "rgba(79, 70, 229, 0.42) !important" }
 })
 
 const darkTheme = EditorView.theme({
@@ -133,7 +147,8 @@ const darkTheme = EditorView.theme({
   ".cm-content": {
     padding: "16px",
     minHeight: "100%",
-    lineHeight: "1.6"
+    lineHeight: "1.6",
+    fontVariantLigatures: "none"
   },
   ".cm-focused": { outline: "none" },
   ".cm-editor": { height: "100%" },
@@ -142,12 +157,16 @@ const darkTheme = EditorView.theme({
   },
   ".cm-gutters": { backgroundColor: "#18181b", color: "#71717a", border: "none" },
   ".cm-lineNumbers .cm-gutterElement": { minWidth: "3ch", padding: "0 8px 0 16px" },
-  ".cm-activeLine": { backgroundColor: "#27272a" },
+  ".cm-activeLine": { backgroundColor: "rgba(250, 250, 250, 0.06)" },
   ".cm-activeLineGutter": { backgroundColor: "#27272a", color: "#fafafa" },
-  ".cm-selectionMatch": { backgroundColor: "rgba(99, 102, 241, 0.2)" },
-  "&.cm-focused .cm-selectionBackground": { backgroundColor: "rgba(99, 102, 241, 0.2)" },
+  ".cm-selectionMatch": {
+    backgroundColor: "rgba(250, 250, 250, 0.10)",
+    outline: "1px solid rgba(250, 250, 250, 0.35)",
+    borderRadius: "2px"
+  },
   ".cm-cursor": { borderLeftColor: "#fafafa" },
-  ".cm-selectionBackground": { backgroundColor: "rgba(99, 102, 241, 0.2)" }
+  ".cm-selectionLayer .cm-selectionBackground, &.cm-focused .cm-selectionLayer .cm-selectionBackground":
+    { backgroundColor: "rgba(99, 102, 241, 0.46) !important" }
 })
 
 function getThemeExtension() {

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -278,7 +278,10 @@ export function initEditor(container, initialContent, socket, fileId, options = 
   let lastOutline = ""
   const themeCompartment = new Compartment()
   const languageCompartment = new Compartment()
-  const language = options.language || "typst"
+  // Mutable: switching files reconfigures the editor in place, so the current
+  // language must follow — otherwise the compile/outline gates go stale and a
+  // non-Typst file (e.g. .csv) would be compiled as Typst.
+  let language = options.language || "typst"
   const onCursor = typeof options.onCursor === "function" ? options.onCursor : null
   const onOutline = typeof options.onOutline === "function" ? options.onOutline : null
 
@@ -364,10 +367,11 @@ export function initEditor(container, initialContent, socket, fileId, options = 
   }
 
   const updateLanguage = (newLang) => {
+    language = newLang || "plain"
     editor.dispatch({
-      effects: languageCompartment.reconfigure(getLanguageExtension(newLang))
+      effects: languageCompartment.reconfigure(getLanguageExtension(language))
     })
-    if (newLang === "typst") registerTypstView(editor)
+    if (language === "typst") registerTypstView(editor)
   }
 
   return {
@@ -376,13 +380,15 @@ export function initEditor(container, initialContent, socket, fileId, options = 
     updateLanguage,
     runCommand: (cmd, arg) => runEditorCommand(editor, language, cmd, arg),
     openSearch: () => openSearchPanel(editor),
-    compile: () => compileTypst(editor.state.doc.toString(), options.project || {}),
-    download: () =>
-      downloadTypstPdf(
-        editor.state.doc.toString(),
-        options.project || {},
-        container.dataset.fileName
-      ),
+    compile: () => {
+      // Only Typst files compile; the worker treats the active buffer as main.typ.
+      if (language === "typst") compileTypst(editor.state.doc.toString(), options.project || {})
+    },
+    download: () => {
+      if (language === "typst") {
+        downloadTypstPdf(editor.state.doc.toString(), options.project || {}, container.dataset.fileName)
+      }
+    },
     destroy: () => {
       if (autosaveTimer) clearTimeout(autosaveTimer)
       if (compileTimer) clearTimeout(compileTimer)

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -378,3 +378,14 @@ export const LucideIcons = {
   mounted() { window.mkIcons?.(this.el) },
   updated() { window.mkIcons?.(this.el) }
 }
+
+// Persist the auto-recompile debounce (read by editor.js' compileDelay()).
+export const CompileDelay = {
+  mounted() {
+    const stored = localStorage.getItem("typster:compile_delay")
+    if (stored !== null) this.el.value = stored
+    this.el.addEventListener("change", () => {
+      localStorage.setItem("typster:compile_delay", this.el.value)
+    })
+  }
+}

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -52,6 +52,19 @@ export const CodeMirror = {
       }
     }
     window.addEventListener("phx:editor-command", this.commandHandler)
+
+    // The Typst worker emits diagnostics for the compiled buffer (reported as
+    // "main.typ"); highlight those in the active editor and clear on success.
+    this.diagnosticsHandler = (event) => {
+      if (!this.editorInstance) return
+      const all = (event.detail && event.detail.diagnostics) || []
+      const own = all.filter((d) => {
+        const file = d.location && d.location.file
+        return !file || file === "main.typ"
+      })
+      this.editorInstance.setDiagnostics(own)
+    }
+    window.addEventListener("typst:diagnostics", this.diagnosticsHandler)
   },
 
   mounted() {
@@ -186,6 +199,10 @@ export const CodeMirror = {
     if (this.commandHandler) {
       window.removeEventListener("phx:editor-command", this.commandHandler)
       this.commandHandler = null
+    }
+    if (this.diagnosticsHandler) {
+      window.removeEventListener("typst:diagnostics", this.diagnosticsHandler)
+      this.diagnosticsHandler = null
     }
     if (this.editorInstance) {
       destroyEditor(this.editorInstance)

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -353,3 +353,11 @@ export const PreviewZoom = {
     if (this.clickHandler) this.el.removeEventListener("click", this.clickHandler)
   }
 }
+
+// Re-render lucide `<i data-lucide>` icons inside a container that LiveView
+// patches (the file tree and tab bar). The global mkIcons() only runs on full
+// page loads, so without this, icons inside diffed regions would not paint.
+export const LucideIcons = {
+  mounted() { window.mkIcons?.(this.el) },
+  updated() { window.mkIcons?.(this.el) }
+}

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -389,3 +389,51 @@ export const CompileDelay = {
     })
   }
 }
+
+// Drag a file row onto a folder row (or the empty tree area = project root) to
+// move it. Listeners are delegated on the <ul>, so they survive LiveView
+// re-renders without managing any child DOM (no phx-update="ignore" needed).
+// Internal moves are tracked via this.dragId; external file drags (which have
+// no dragId) are ignored so the asset-upload drop target keeps working.
+export const FileTreeDnD = {
+  mounted() {
+    this.dragId = null
+    const root = this.el
+
+    const clearOver = () =>
+      root.querySelectorAll(".is-dnd-over").forEach((n) => n.classList.remove("is-dnd-over"))
+
+    root.addEventListener("dragstart", (e) => {
+      const li = e.target.closest("[data-dnd-file]")
+      if (!li) return
+      this.dragId = li.dataset.dndFile
+      e.dataTransfer.effectAllowed = "move"
+      e.dataTransfer.setData("text/plain", this.dragId)
+      li.classList.add("is-dnd-dragging")
+    })
+
+    root.addEventListener("dragend", () => {
+      root.querySelectorAll(".is-dnd-dragging").forEach((n) => n.classList.remove("is-dnd-dragging"))
+      clearOver()
+      this.dragId = null
+    })
+
+    root.addEventListener("dragover", (e) => {
+      if (!this.dragId) return // not our drag (e.g. a file from the OS)
+      e.preventDefault()
+      e.dataTransfer.dropEffect = "move"
+      clearOver()
+      const dir = e.target.closest("[data-dnd-dir]")
+      if (dir) dir.classList.add("is-dnd-over")
+    })
+
+    root.addEventListener("drop", (e) => {
+      if (!this.dragId) return
+      e.preventDefault()
+      const dir = e.target.closest("[data-dnd-dir]")
+      this.pushEvent("move_file", { id: this.dragId, dir: dir ? dir.dataset.dndDir : "" })
+      clearOver()
+      this.dragId = null
+    })
+  }
+}

--- a/assets/js/typst_worker.js
+++ b/assets/js/typst_worker.js
@@ -47,6 +47,11 @@ export function parseTypstDiagnostics(message) {
   return diags
 }
 
+// Let the editor highlight (or clear) the error locations in the gutter/text.
+function dispatchEditorDiagnostics(diags) {
+  window.dispatchEvent(new CustomEvent("typst:diagnostics", { detail: { diagnostics: diags } }))
+}
+
 function diagnosticSummary(diags) {
   const errors = diags.filter((d) => d.severity === "error").length
   const warnings = diags.filter((d) => d.severity === "warning").length
@@ -168,6 +173,8 @@ export function initTypstWorker(hook) {
 
             svgContainer.innerHTML = data.svg
 
+            dispatchEditorDiagnostics([])
+
             if (pushEvent) {
               const ms = compileStartedAt ? Math.round(performance.now() - compileStartedAt) : null
               pushEvent("update_preview", { ms, pages: countPages(data.svg) })
@@ -187,6 +194,7 @@ export function initTypstWorker(hook) {
                 ? data.diagnostics
                 : parseTypstDiagnostics(data.message)
             renderDiagnostics(errEl, diags)
+            dispatchEditorDiagnostics(diags)
             errEl.style.display = ""
 
             const svgContainer = previewContainer.querySelector("#typst-svg-output")

--- a/assets/js/typst_worker.js
+++ b/assets/js/typst_worker.js
@@ -81,10 +81,14 @@ function renderDiagnostics(errEl, diags) {
     const body = document.createElement("div")
     body.className = "ts-diag__body"
 
-    if (d.location) {
+    if (d.location && d.location.file) {
+      const file = String(d.location.file).replace(/^\/+/, "")
       const loc = document.createElement("div")
       loc.className = "ts-diag__loc"
-      loc.textContent = `${d.location.file} : ${d.location.line} : ${d.location.col}`
+      loc.textContent =
+        d.location.line != null
+          ? `${file} : ${d.location.line} : ${d.location.col}`
+          : file
       body.appendChild(loc)
     }
 
@@ -178,7 +182,10 @@ export function initTypstWorker(hook) {
               errEl.className = "ts-diag"
               previewContainer.appendChild(errEl)
             }
-            const diags = parseTypstDiagnostics(data.message)
+            const diags =
+              Array.isArray(data.diagnostics) && data.diagnostics.length
+                ? data.diagnostics
+                : parseTypstDiagnostics(data.message)
             renderDiagnostics(errEl, diags)
             errEl.style.display = ""
 

--- a/assets/js/typst_worker.js
+++ b/assets/js/typst_worker.js
@@ -5,6 +5,108 @@ let compileStartedAt = null
 let pdfRequestSeq = 0
 const pendingPdfRequests = new Map()
 
+// Typst diagnostics arrive as one multi-line string (the same text the CLI
+// prints). Parse it into structured items so the preview can show a readable
+// list (severity, file:line:col, message, hint) instead of a raw dump.
+const DIAG_LOC = /([\w./-]+\.(?:typ|bib|md|tex|latex|sty|cls|csv|tsv|ya?ml)):(\d+):(\d+)/i
+
+export function parseTypstDiagnostics(message) {
+  const text = String(message || "").trim()
+  if (!text) return [{ severity: "error", message: "Typst preview failed", location: null }]
+
+  const diags = []
+  let current = null
+
+  for (const line of text.split("\n")) {
+    const head = line.match(/^\s*(error|warning):\s*(.*)$/i)
+    if (head) {
+      if (current) diags.push(current)
+      current = { severity: head[1].toLowerCase(), message: head[2].trim(), location: null, hint: null }
+      continue
+    }
+    if (!current) continue
+    const loc = line.match(DIAG_LOC)
+    if (loc && !current.location) {
+      current.location = { file: loc[1], line: Number(loc[2]), col: Number(loc[3]) }
+    }
+    const hint = line.match(/^\s*hint:\s*(.*)$/i)
+    if (hint && !current.hint) current.hint = hint[1].trim()
+  }
+  if (current) diags.push(current)
+
+  if (diags.length === 0) {
+    const loc = text.match(DIAG_LOC)
+    diags.push({
+      severity: "error",
+      message: text.split("\n")[0],
+      location: loc && { file: loc[1], line: Number(loc[2]), col: Number(loc[3]) },
+      hint: null
+    })
+  }
+
+  return diags
+}
+
+function diagnosticSummary(diags) {
+  const errors = diags.filter((d) => d.severity === "error").length
+  const warnings = diags.filter((d) => d.severity === "warning").length
+  const parts = []
+  if (errors) parts.push(`${errors} error${errors === 1 ? "" : "s"}`)
+  if (warnings) parts.push(`${warnings} warning${warnings === 1 ? "" : "s"}`)
+  return { errors, warnings, label: parts.join(" · ") || "Compile failed" }
+}
+
+// Build the diagnostics panel with the DOM API (textContent everywhere, so
+// compiler output can never inject markup).
+function renderDiagnostics(errEl, diags) {
+  errEl.textContent = ""
+  const { label } = diagnosticSummary(diags)
+
+  const head = document.createElement("div")
+  head.className = "ts-diag__head"
+  head.textContent = label
+  errEl.appendChild(head)
+
+  const list = document.createElement("div")
+  list.className = "ts-diag__list"
+
+  for (const d of diags) {
+    const item = document.createElement("div")
+    item.className = "ts-diag__item"
+
+    const dot = document.createElement("span")
+    dot.className = `ts-diag__dot ts-diag__dot--${d.severity === "warning" ? "warn" : "error"}`
+    item.appendChild(dot)
+
+    const body = document.createElement("div")
+    body.className = "ts-diag__body"
+
+    if (d.location) {
+      const loc = document.createElement("div")
+      loc.className = "ts-diag__loc"
+      loc.textContent = `${d.location.file} : ${d.location.line} : ${d.location.col}`
+      body.appendChild(loc)
+    }
+
+    const msg = document.createElement("div")
+    msg.className = "ts-diag__msg"
+    msg.textContent = d.message
+    body.appendChild(msg)
+
+    if (d.hint) {
+      const hint = document.createElement("div")
+      hint.className = "ts-diag__hint"
+      hint.textContent = `hint: ${d.hint}`
+      body.appendChild(hint)
+    }
+
+    item.appendChild(body)
+    list.appendChild(item)
+  }
+
+  errEl.appendChild(list)
+}
+
 function triggerBrowserDownload(bytes, filename) {
   const blob = new Blob([bytes], { type: "application/pdf" })
   const url = URL.createObjectURL(blob)
@@ -73,11 +175,11 @@ export function initTypstWorker(hook) {
             if (!errEl) {
               errEl = document.createElement("div")
               errEl.id = "preview-error"
-              errEl.className = "ts-card"
-              errEl.style.cssText = "border-color:var(--mk-error-bd);background:var(--mk-error-50);color:var(--mk-error);padding:16px;font-size:13px;font-family:'JetBrains Mono',monospace;width:100%;max-width:520px;"
+              errEl.className = "ts-diag"
               previewContainer.appendChild(errEl)
             }
-            errEl.textContent = data.message || "Typst preview failed"
+            const diags = parseTypstDiagnostics(data.message)
+            renderDiagnostics(errEl, diags)
             errEl.style.display = ""
 
             const svgContainer = previewContainer.querySelector("#typst-svg-output")
@@ -85,8 +187,18 @@ export function initTypstWorker(hook) {
 
             const placeholder = previewContainer.querySelector("#preview-placeholder")
             if (placeholder) placeholder.style.display = "none"
+
+            if (pushEvent) {
+              const { errors, warnings } = diagnosticSummary(diags)
+              pushEvent("preview_error", {
+                message: data.message || "Typst preview failed",
+                errors: errors,
+                warnings: warnings
+              })
+            }
+          } else if (pushEvent) {
+            pushEvent("preview_error", { message: data.message || "Typst preview failed" })
           }
-          if (pushEvent) pushEvent("preview_error", { message: data.message || "Typst preview failed" })
           console.error("Typst compilation error:", data)
         } else if (type === "pdf") {
           const pending = pendingPdfRequests.get(data.requestId)

--- a/assets/js/typst_worker.js
+++ b/assets/js/typst_worker.js
@@ -208,7 +208,8 @@ export function initTypstWorker(hook) {
               pushEvent("preview_error", {
                 message: data.message || "Typst preview failed",
                 errors: errors,
-                warnings: warnings
+                warnings: warnings,
+                diagnostics: diags
               })
             }
           } else if (pushEvent) {

--- a/assets/js/typst_worker_impl.js
+++ b/assets/js/typst_worker_impl.js
@@ -16,6 +16,61 @@ setRendererWasmModule(wasmLoader)
 let initialized = false
 let latestCompileId = 0
 
+// typst.ts doesn't always throw a standard Error — a compile failure may surface
+// as a plain string (the formatted diagnostic), an array of diagnostics, or an
+// object. Coerce any of these into readable text so the message is never lost.
+function formatError(error) {
+  if (error == null) return "Typst preview failed"
+  if (typeof error === "string") return error
+
+  if (Array.isArray(error)) {
+    const parts = error.map(formatError).filter(Boolean)
+    if (parts.length) return parts.join("\n")
+  }
+
+  if (typeof error.message === "string" && error.message) return error.message
+
+  if (typeof error.toString === "function") {
+    const str = error.toString()
+    if (str && str !== "[object Object]") return str
+  }
+
+  try {
+    const json = JSON.stringify(error)
+    if (json && json !== "{}") return json
+  } catch (_ignored) {
+    // fall through
+  }
+
+  return "Typst preview failed"
+}
+
+// `diagnostics: 'full'` yields the same text Typst's CLI prints (one string per
+// diagnostic, with `error: …` and a `file:line:col` location). Join them so the
+// preview can parse and present a readable list.
+function formatDiagnostics(diagnostics) {
+  if (!diagnostics) return null
+  const list = Array.isArray(diagnostics) ? diagnostics : [diagnostics]
+
+  const parts = list
+    .map((d) => {
+      if (typeof d === "string") return d
+      if (d && typeof d === "object") {
+        const sev = d.severity || "error"
+        const msg = d.message || formatError(d)
+        const path = d.path || (d.span && d.span.path)
+        const range = d.range || (d.span && d.span.range)
+        const line = range && (range.start?.line ?? range.startLine ?? range.start)
+        const loc = path && line != null ? ` (${path}:${Number(line) + 1})` : path ? ` (${path})` : ""
+        return `${sev}: ${msg}${loc}`
+      }
+      return String(d)
+    })
+    .filter(Boolean)
+
+  return parts.length ? parts.join("\n\n") : null
+}
+
 async function ensureInitialized() {
   if (initialized) return
   initialized = true
@@ -53,7 +108,26 @@ self.onmessage = async function (event) {
       self.postMessage({ type: "render", data: { svg } })
     } catch (error) {
       if (myId !== latestCompileId) return
-      self.postMessage({ type: "error", data: { message: error.message } })
+      console.error("typst compile failed (raw):", error)
+
+      // The high-level svg() suppresses diagnostics, so the caught error is
+      // opaque. Recompile once with full diagnostics to recover the real
+      // error text (sources are re-mapped first in case state was reset).
+      let message = formatError(error)
+      try {
+        await loadSources(content, project)
+        const compiler = await $typst.getCompiler()
+        const { diagnostics } = await compiler.compile({
+          mainFilePath: "/main.typ",
+          diagnostics: "full"
+        })
+        const formatted = formatDiagnostics(diagnostics)
+        if (formatted) message = formatted
+      } catch (diagError) {
+        console.error("typst diagnostics recompile failed:", diagError)
+      }
+
+      self.postMessage({ type: "error", data: { message } })
     }
   } else if (type === "pdf") {
     // Export bypasses latestCompileId: a download is an explicit one-off and must
@@ -65,7 +139,7 @@ self.onmessage = async function (event) {
       const pdf = await $typst.pdf({ mainFilePath: "/main.typ" })
       self.postMessage({ type: "pdf", data: { pdf, requestId } }, [pdf.buffer])
     } catch (error) {
-      self.postMessage({ type: "pdf-error", data: { message: error.message, requestId } })
+      self.postMessage({ type: "pdf-error", data: { message: formatError(error), requestId } })
     }
   }
 }

--- a/assets/js/typst_worker_impl.js
+++ b/assets/js/typst_worker_impl.js
@@ -57,15 +57,16 @@ function structureDiagnostics(diagnostics) {
     const severity = String((d && d.severity) || "error").toLowerCase().includes("warn")
       ? "warning"
       : "error"
-    // range is "line:col" or "line:col-endline:endcol" (1-based).
+    // range is "line:col" or "line:col-endline:endcol", 0-based - shift to
+    // the 1-based line/col humans and the editor goto expect.
     const m = String((d && d.range) || "").match(/(\d+):(\d+)(?:-(\d+):(\d+))?/)
     const location = file
       ? {
           file,
-          line: m ? Number(m[1]) : null,
-          col: m ? Number(m[2]) : null,
-          endLine: m && m[3] ? Number(m[3]) : null,
-          endCol: m && m[4] ? Number(m[4]) : null
+          line: m ? Number(m[1]) + 1 : null,
+          col: m ? Number(m[2]) + 1 : null,
+          endLine: m && m[3] ? Number(m[3]) + 1 : null,
+          endCol: m && m[4] ? Number(m[4]) + 1 : null
         }
       : null
 

--- a/assets/js/typst_worker_impl.js
+++ b/assets/js/typst_worker_impl.js
@@ -45,30 +45,25 @@ function formatError(error) {
   return "Typst preview failed"
 }
 
-// `diagnostics: 'full'` yields the same text Typst's CLI prints (one string per
-// diagnostic, with `error: …` and a `file:line:col` location). Join them so the
-// preview can parse and present a readable list.
-function formatDiagnostics(diagnostics) {
-  if (!diagnostics) return null
-  const list = Array.isArray(diagnostics) ? diagnostics : [diagnostics]
+// `diagnostics: 'full'` returns DiagnosticMessage objects:
+//   { package, path: "/main.typ", severity, range: "2:9-3:15", message }
+// Turn them into structured items the preview can render directly (clean path,
+// numeric line/col), rather than re-parsing formatted text.
+function structureDiagnostics(diagnostics) {
+  if (!Array.isArray(diagnostics) || diagnostics.length === 0) return null
 
-  const parts = list
-    .map((d) => {
-      if (typeof d === "string") return d
-      if (d && typeof d === "object") {
-        const sev = d.severity || "error"
-        const msg = d.message || formatError(d)
-        const path = d.path || (d.span && d.span.path)
-        const range = d.range || (d.span && d.span.range)
-        const line = range && (range.start?.line ?? range.startLine ?? range.start)
-        const loc = path && line != null ? ` (${path}:${Number(line) + 1})` : path ? ` (${path})` : ""
-        return `${sev}: ${msg}${loc}`
-      }
-      return String(d)
-    })
-    .filter(Boolean)
+  return diagnostics.map((d) => {
+    const file = String((d && d.path) || "").replace(/^\/+/, "") || null
+    const severity = String((d && d.severity) || "error").toLowerCase().includes("warn")
+      ? "warning"
+      : "error"
+    const m = String((d && d.range) || "").match(/(\d+):(\d+)/)
+    const location = file
+      ? { file, line: m ? Number(m[1]) : null, col: m ? Number(m[2]) : null }
+      : null
 
-  return parts.length ? parts.join("\n\n") : null
+    return { severity, location, message: (d && d.message) || "Compilation error" }
+  })
 }
 
 async function ensureInitialized() {
@@ -113,7 +108,7 @@ self.onmessage = async function (event) {
       // The high-level svg() suppresses diagnostics, so the caught error is
       // opaque. Recompile once with full diagnostics to recover the real
       // error text (sources are re-mapped first in case state was reset).
-      let message = formatError(error)
+      let structured = null
       try {
         await loadSources(content, project)
         const compiler = await $typst.getCompiler()
@@ -121,13 +116,13 @@ self.onmessage = async function (event) {
           mainFilePath: "/main.typ",
           diagnostics: "full"
         })
-        const formatted = formatDiagnostics(diagnostics)
-        if (formatted) message = formatted
+        structured = structureDiagnostics(diagnostics)
       } catch (diagError) {
         console.error("typst diagnostics recompile failed:", diagError)
       }
 
-      self.postMessage({ type: "error", data: { message } })
+      const message = (structured && structured[0] && structured[0].message) || formatError(error)
+      self.postMessage({ type: "error", data: { message, diagnostics: structured } })
     }
   } else if (type === "pdf") {
     // Export bypasses latestCompileId: a download is an explicit one-off and must

--- a/assets/js/typst_worker_impl.js
+++ b/assets/js/typst_worker_impl.js
@@ -57,9 +57,16 @@ function structureDiagnostics(diagnostics) {
     const severity = String((d && d.severity) || "error").toLowerCase().includes("warn")
       ? "warning"
       : "error"
-    const m = String((d && d.range) || "").match(/(\d+):(\d+)/)
+    // range is "line:col" or "line:col-endline:endcol" (1-based).
+    const m = String((d && d.range) || "").match(/(\d+):(\d+)(?:-(\d+):(\d+))?/)
     const location = file
-      ? { file, line: m ? Number(m[1]) : null, col: m ? Number(m[2]) : null }
+      ? {
+          file,
+          line: m ? Number(m[1]) : null,
+          col: m ? Number(m[2]) : null,
+          endLine: m && m[3] ? Number(m[3]) : null,
+          endCol: m && m[4] ? Number(m[4]) : null
+        }
       : null
 
     return { severity, location, message: (d && d.message) || "Compilation error" }

--- a/assets/playwright.config.mjs
+++ b/assets/playwright.config.mjs
@@ -38,7 +38,8 @@ export default defineConfig({
         /wasm\.spec\.mjs/,
         /preview\.spec\.mjs/,
         /redesign\.spec\.mjs/,
-        /search_panel\.spec\.mjs/
+        /search_panel\.spec\.mjs/,
+        /editor_gutter\.spec\.mjs/
       ]
     },
     {
@@ -47,7 +48,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         storageState: authFile
       },
-      testMatch: [/editor_load\.spec\.mjs/, /wasm\.spec\.mjs/, /preview\.spec\.mjs/, /redesign\.spec\.mjs/, /search_panel\.spec\.mjs/],
+      testMatch: [/editor_load\.spec\.mjs/, /wasm\.spec\.mjs/, /preview\.spec\.mjs/, /redesign\.spec\.mjs/, /search_panel\.spec\.mjs/, /editor_gutter\.spec\.mjs/],
       dependencies: ["setup"]
     }
   ]

--- a/docs/os-aware-shortcuts.md
+++ b/docs/os-aware-shortcuts.md
@@ -1,0 +1,47 @@
+# OS-aware keyboard shortcut hints
+
+How Typster shows keyboard-shortcut hints that match the user's operating
+system — ⌘ on Apple platforms, **Ctrl** everywhere else.
+
+## Convention
+
+The common keyboard modifier is the **Meta / ⌘ (Command)** key on macOS (and
+related Apple platforms) and the **Control** key on Windows and Linux. UI that
+advertises a shortcut should reflect the platform so the hint matches the key
+the user actually presses. This is the de-facto standard across editors
+(VS Code), and productivity apps (GitHub, Linear, Notion).
+
+## Detection
+
+Platform is detected once in `assets/js/app.js`, before the LiveSocket
+connects, and recorded as a class on `<html>`:
+
+```js
+const platformHint =
+  navigator.userAgentData?.platform || navigator.platform || navigator.userAgent || ""
+document.documentElement.classList.toggle("is-mac", /mac/i.test(platformHint))
+```
+
+We prefer the modern UA-Client-Hints API (`navigator.userAgentData.platform`,
+Chromium-only and experimental), fall back to the deprecated
+`navigator.platform`, then the UA string. Together these three give a reliable
+enough answer for a cosmetic hint; the actual key handler is platform-agnostic
+and listens for `event.metaKey || event.ctrlKey`.
+
+## Rendering
+
+Hints render both variants and let CSS pick one based on `html.is-mac`
+(see `assets/css/_typster_ui.css`):
+
+- `.ts-mac` — shown on Apple platforms (default before JS runs).
+- `.ts-other` — shown everywhere else.
+
+The command-palette button (`editor_live/index.html.heex`) uses the lucide
+`command` icon on macOS and `square-terminal` elsewhere. The ⌘ icon already
+conveys the modifier, so the Mac key cap is just `K` (no duplicated ⌘); the
+non-Mac variant spells out `Ctrl K` beside the terminal icon.
+
+## Sources
+
+- [Command or Control — Austin Poor](https://austinpoor.com/blog/command-or-control)
+- [Capturing Keyboard Event Modifiers Across Operating Systems in JavaScript — Ben Nadel](https://www.bennadel.com/blog/4090-capturing-keyboard-event-modifiers-across-operating-systems-in-javascript.htm)

--- a/lib/typster/assets.ex
+++ b/lib/typster/assets.ex
@@ -115,7 +115,20 @@ defmodule Typster.Assets do
   defp put_object(object_key, body, content_type) do
     bucket = Application.get_env(:typster, :s3_bucket, "typster-assets")
 
-    ExAws.S3.put_object(bucket, object_key, body, content_type: content_type)
-    |> ExAws.request()
+    put = fn ->
+      ExAws.S3.put_object(bucket, object_key, body, content_type: content_type)
+      |> ExAws.request()
+    end
+
+    case put.() do
+      # Bucket missing (e.g. a fresh MinIO): create it once, then retry.
+      {:error, {:http_error, 404, _}} ->
+        region = Application.get_env(:ex_aws, :region, "us-east-1")
+        _ = ExAws.S3.put_bucket(bucket, region) |> ExAws.request()
+        put.()
+
+      result ->
+        result
+    end
   end
 end

--- a/lib/typster/files.ex
+++ b/lib/typster/files.ex
@@ -56,6 +56,14 @@ defmodule Typster.Files do
     Repo.delete(file)
   end
 
+  @doc "Pin or unpin a file (controls whether it appears in the sidebar's Pinned section)."
+  def set_pinned(%Scope{} = scope, %File{} = file, pinned) when is_boolean(pinned) do
+    scope
+    |> get_file!(file.id)
+    |> Ecto.Changeset.change(pinned: pinned)
+    |> Repo.update()
+  end
+
   def get_file_tree(%Scope{} = scope, project_id) do
     _project = Typster.Projects.get_project!(scope, project_id)
 

--- a/lib/typster/files.ex
+++ b/lib/typster/files.ex
@@ -8,7 +8,7 @@ defmodule Typster.Files do
   alias Typster.Repo
   alias Typster.Projects.File
 
-  @editable_extensions ~w(.typ .bib .md .yaml .yml .tex .latex .sty .cls)
+  @editable_extensions ~w(.typ .bib .md .yaml .yml .tex .latex .sty .cls .csv .tsv)
   @asset_extensions ~w(.pdf .png .jpg .jpeg .svg .webp .ttf .otf .woff .woff2)
 
   def get_file!(%Scope{user: user}, id) do

--- a/lib/typster/files.ex
+++ b/lib/typster/files.ex
@@ -108,6 +108,100 @@ defmodule Typster.Files do
 
   def editor_language(_), do: "plain"
 
+  # ── Smart new-file suggestions ────────────────────────────────────────────
+  #
+  # When the user types a name without an extension we suggest one based on the
+  # project's composition rather than a fixed default:
+  #
+  #   * mostly LaTeX sources → `.tex`, otherwise → `.typ`
+  #   * a name that reads like a known bibliography file (references/refs/
+  #     bibliography/local/library) offers `.bib` **first** when the project has
+  #     no bibliography yet, then the project's majority source type.
+
+  @latex_extensions ~w(.tex .latex .sty .cls)
+  @bib_basenames ~w(references refs bibliography local library)
+  # Minimum typed length before a name counts as "most of" a bibliography name.
+  @bib_match_min 3
+
+  @doc """
+  Extension to suggest for a new source file: `".tex"` when the project is
+  LaTeX-heavy, otherwise `".typ"`. Ties favor Typst.
+  """
+  def majority_source_extension(files) do
+    {latex, typst} =
+      Enum.reduce(files, {0, 0}, fn file, {latex, typst} ->
+        case extension(path_of(file)) do
+          ext when ext in @latex_extensions -> {latex + 1, typst}
+          ".typ" -> {latex, typst + 1}
+          _ -> {latex, typst}
+        end
+      end)
+
+    if latex > typst, do: ".tex", else: ".typ"
+  end
+
+  @doc "Whether the project already contains a `.bib` file."
+  def has_bibliography?(files), do: Enum.any?(files, &(extension(path_of(&1)) == ".bib"))
+
+  @doc """
+  Ordered full-name suggestions for a partially typed file name.
+
+  Returns `[]` when nothing is typed or the user already typed an extension
+  (their explicit choice wins). Otherwise the first element is the default that
+  pressing Enter resolves to; a bibliography-like name with no existing `.bib`
+  yields two options (`.bib` then the majority source type).
+  """
+  def new_file_suggestions(files, typed) do
+    typed = String.trim(typed || "")
+
+    cond do
+      typed == "" ->
+        []
+
+      extension(typed) != "" ->
+        []
+
+      bib_name_match?(typed) and not has_bibliography?(files) ->
+        [typed <> ".bib", typed <> majority_source_extension(files)]
+
+      true ->
+        [typed <> majority_source_extension(files)]
+    end
+  end
+
+  @doc """
+  Resolve the final path to create from a typed name: keep an explicit
+  extension, otherwise apply the first smart suggestion.
+  """
+  def resolve_new_file_path(files, typed) do
+    typed = String.trim(typed || "")
+
+    cond do
+      typed == "" ->
+        ""
+
+      extension(typed) != "" ->
+        typed
+
+      true ->
+        case new_file_suggestions(files, typed) do
+          [first | _] -> first
+          [] -> typed <> majority_source_extension(files)
+        end
+    end
+  end
+
+  defp bib_name_match?(typed) do
+    stem = typed |> Path.basename() |> String.downcase()
+
+    String.length(stem) >= @bib_match_min and
+      Enum.any?(@bib_basenames, &String.starts_with?(&1, stem))
+  end
+
+  defp path_of(%File{path: path}), do: path
+  defp path_of(%{path: path}), do: path
+  defp path_of(path) when is_binary(path), do: path
+
   defp editable_path?(path), do: extension(path) in @editable_extensions
   defp asset_path?(path), do: extension(path) in @asset_extensions
   defp extension(path), do: path |> Path.extname() |> String.downcase()

--- a/lib/typster/projects/file.ex
+++ b/lib/typster/projects/file.ex
@@ -9,6 +9,7 @@ defmodule Typster.Projects.File do
   schema "files" do
     field :path, :string
     field :content, :string
+    field :pinned, :boolean, default: false
     belongs_to :project, Typster.Projects.Project
     belongs_to :parent, Typster.Projects.File
     has_many :children, Typster.Projects.File, foreign_key: :parent_id

--- a/lib/typster/projects/file.ex
+++ b/lib/typster/projects/file.ex
@@ -22,5 +22,9 @@ defmodule Typster.Projects.File do
     |> cast(attrs, [:path, :content, :parent_id])
     |> validate_required([:path, :project_id])
     |> assoc_constraint(:project)
+    |> unique_constraint(:path,
+      name: :files_project_id_path_index,
+      message: "already exists in this project"
+    )
   end
 end

--- a/lib/typster/templates.ex
+++ b/lib/typster/templates.ex
@@ -1,0 +1,33 @@
+defmodule Typster.Templates do
+  @moduledoc """
+  The Templates context: a user's own reusable starting points for new files.
+  """
+
+  import Ecto.Query, warn: false
+  alias Typster.Accounts.Scope
+  alias Typster.Repo
+  alias Typster.Templates.Template
+
+  @doc "List the current user's templates, newest first."
+  def list_templates(%Scope{user: user}) do
+    from(t in Template, where: t.user_id == ^user.id, order_by: [desc: t.updated_at])
+    |> Repo.all()
+  end
+
+  def get_template!(%Scope{user: user}, id) do
+    from(t in Template, where: t.id == ^id and t.user_id == ^user.id)
+    |> Repo.one!()
+  end
+
+  @doc "Save a new template owned by the current user."
+  def create_template(%Scope{user: user}, attrs) do
+    %Template{user_id: user.id}
+    |> Template.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def delete_template(%Scope{} = scope, %Template{} = template) do
+    template = get_template!(scope, template.id)
+    Repo.delete(template)
+  end
+end

--- a/lib/typster/templates/template.ex
+++ b/lib/typster/templates/template.ex
@@ -1,0 +1,23 @@
+defmodule Typster.Templates.Template do
+  @moduledoc "Schema for a user's reusable new-file templates."
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "templates" do
+    field :name, :string
+    field :content, :string
+    belongs_to :user, Typster.Accounts.User
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(template, attrs) do
+    template
+    |> cast(attrs, [:name, :content])
+    |> validate_required([:name])
+    |> validate_length(:name, max: 255)
+  end
+end

--- a/lib/typster_web/file_tree.ex
+++ b/lib/typster_web/file_tree.ex
@@ -147,14 +147,12 @@ defmodule TypsterWeb.FileTree do
             }
             class="size-3"
           />
-          <i
-            class="ts-tree__ficon"
-            data-lucide={
+          <span class="ts-tree__ficon" aria-hidden="true">
+            <i data-lucide={
               if expanded?(@collapsed, node.path), do: "folder-open", else: "folder-closed"
-            }
-            aria-hidden="true"
-          >
-          </i>
+            }>
+            </i>
+          </span>
           <span class="truncate flex-1">{node.name}</span>
           <span class="ts-tree__count">{length(node.children)}</span>
         </li>

--- a/lib/typster_web/file_tree.ex
+++ b/lib/typster_web/file_tree.ex
@@ -101,6 +101,30 @@ defmodule TypsterWeb.FileTree do
   defp leaf_dom_id(%{asset?: true, id: id}), do: "asset-entry-#{id}"
   defp leaf_dom_id(%{id: id}), do: "select-file-#{id}"
 
+  @doc "Color/glyph bucket for a file's typed chip, from its extension."
+  def file_chip_kind(name) do
+    case name |> Path.extname() |> String.downcase() do
+      ".typ" -> "typ"
+      ".bib" -> "bib"
+      ext when ext in ~w(.tex .latex .sty .cls) -> "tex"
+      ".md" -> "md"
+      ext when ext in ~w(.csv .tsv) -> "csv"
+      ext when ext in ~w(.png .jpg .jpeg .gif .svg .webp) -> "img"
+      ext when ext in ~w(.yaml .yml .toml .json) -> "data"
+      _ -> "file"
+    end
+  end
+
+  @doc "Single-character glyph shown inside a file's typed chip."
+  def chip_glyph("typ"), do: "T"
+  def chip_glyph("bib"), do: "B"
+  def chip_glyph("tex"), do: "L"
+  def chip_glyph("md"), do: "M"
+  def chip_glyph("csv"), do: "≡"
+  def chip_glyph("img"), do: "▢"
+  def chip_glyph("data"), do: "{}"
+  def chip_glyph(_), do: "·"
+
   attr :nodes, :list, required: true
   attr :depth, :integer, default: 0
   attr :collapsed, :any, required: true
@@ -123,10 +147,7 @@ defmodule TypsterWeb.FileTree do
             }
             class="size-3"
           />
-          <.icon
-            name={if expanded?(@collapsed, node.path), do: "hero-folder-open", else: "hero-folder"}
-            class="size-3.5"
-          />
+          <span class="ts-filechip ts-filechip--folder" aria-hidden="true"></span>
           <span class="truncate flex-1">{node.name}</span>
           <span class="ts-tree__count">{length(node.children)}</span>
         </li>
@@ -149,7 +170,8 @@ defmodule TypsterWeb.FileTree do
           ]}
           style={"padding-left: #{6 + @depth * 14 + 14}px"}
         >
-          <.icon name={if node.asset?, do: "hero-photo", else: "hero-document-text"} class="size-3.5" />
+          <% kind = if node.asset?, do: "img", else: file_chip_kind(node.name) %>
+          <span class={["ts-filechip", "ts-filechip--#{kind}"]}>{chip_glyph(kind)}</span>
           <span class="truncate flex-1">{node.name}</span>
           <span :if={Map.get(node, :smart)} class="ts-tree__smart">↳</span>
           <span :if={Map.get(node, :meta, "") != ""} class="ts-tree__pill">{node.meta}</span>

--- a/lib/typster_web/file_tree.ex
+++ b/lib/typster_web/file_tree.ex
@@ -130,6 +130,7 @@ defmodule TypsterWeb.FileTree do
   attr :collapsed, :any, required: true
   attr :current_id, :any, default: nil
   attr :id_prefix, :string, default: ""
+  attr :dnd, :boolean, default: false
 
   @doc "Recursively render tree rows (siblings share one `<ul>`, indented by depth)."
   def tree_rows(assigns) do
@@ -141,6 +142,7 @@ defmodule TypsterWeb.FileTree do
           style={"padding-left: #{6 + @depth * 14}px"}
           phx-click="toggle_dir"
           phx-value-path={node.path}
+          data-dnd-dir={if @dnd, do: node.path}
         >
           <.icon
             name={
@@ -164,12 +166,16 @@ defmodule TypsterWeb.FileTree do
           collapsed={@collapsed}
           current_id={@current_id}
           id_prefix={@id_prefix}
+          dnd={@dnd}
         />
       <% else %>
+        <% can_drag = @dnd and not node.asset? and node.editable %>
         <li
           id={leaf_dom_id(node, @id_prefix)}
           phx-click={if not node.asset? and node.editable, do: "select_file"}
           phx-value-file-id={node.id}
+          draggable={can_drag && "true"}
+          data-dnd-file={if can_drag, do: node.id}
           class={[
             "ts-tree__item",
             (node.asset? or not node.editable) && "is-disabled",

--- a/lib/typster_web/file_tree.ex
+++ b/lib/typster_web/file_tree.ex
@@ -98,8 +98,8 @@ defmodule TypsterWeb.FileTree do
 
   defp expanded?(collapsed, path), do: not MapSet.member?(collapsed, path)
 
-  defp leaf_dom_id(%{asset?: true, id: id}), do: "asset-entry-#{id}"
-  defp leaf_dom_id(%{id: id}), do: "select-file-#{id}"
+  defp leaf_dom_id(%{asset?: true, id: id}, prefix), do: "#{prefix}asset-entry-#{id}"
+  defp leaf_dom_id(%{id: id}, prefix), do: "#{prefix}select-file-#{id}"
 
   @doc "Color/glyph bucket for a file's typed chip, from its extension."
   def file_chip_kind(name) do
@@ -129,6 +129,7 @@ defmodule TypsterWeb.FileTree do
   attr :depth, :integer, default: 0
   attr :collapsed, :any, required: true
   attr :current_id, :any, default: nil
+  attr :id_prefix, :string, default: ""
 
   @doc "Recursively render tree rows (siblings share one `<ul>`, indented by depth)."
   def tree_rows(assigns) do
@@ -162,10 +163,11 @@ defmodule TypsterWeb.FileTree do
           depth={@depth + 1}
           collapsed={@collapsed}
           current_id={@current_id}
+          id_prefix={@id_prefix}
         />
       <% else %>
         <li
-          id={leaf_dom_id(node)}
+          id={leaf_dom_id(node, @id_prefix)}
           phx-click={if not node.asset? and node.editable, do: "select_file"}
           phx-value-file-id={node.id}
           class={[

--- a/lib/typster_web/file_tree.ex
+++ b/lib/typster_web/file_tree.ex
@@ -21,7 +21,13 @@ defmodule TypsterWeb.FileTree do
   def file_nodes(files, mode) do
     files
     |> Enum.map(fn f ->
-      %{path: f.path, id: f.id, editable: Typster.Files.editable_file?(f), asset?: false}
+      %{
+        path: f.path,
+        id: f.id,
+        editable: Typster.Files.editable_file?(f),
+        asset?: false,
+        pinned: Map.get(f, :pinned, false)
+      }
     end)
     |> by_mode(mode)
   end
@@ -147,6 +153,42 @@ defmodule TypsterWeb.FileTree do
           <span class="truncate flex-1">{node.name}</span>
           <span :if={Map.get(node, :smart)} class="ts-tree__smart">↳</span>
           <span :if={Map.get(node, :meta, "") != ""} class="ts-tree__pill">{node.meta}</span>
+          <span
+            :if={Map.get(node, :pinned, false)}
+            class="ts-tree__pin-ind"
+            title={gettext("editor.tree.pinned")}
+          >
+            <.icon name="hero-map-pin-solid" class="size-3" />
+          </span>
+          <span class="ts-tree__actions">
+            <button
+              :if={not node.asset?}
+              type="button"
+              class={["ts-tree__act", Map.get(node, :pinned, false) && "is-on"]}
+              phx-click="toggle_pin"
+              phx-value-id={node.id}
+              onclick="event.stopPropagation()"
+              aria-label={
+                if(Map.get(node, :pinned, false),
+                  do: gettext("editor.tree.unpin"),
+                  else: gettext("editor.tree.pin")
+                )
+              }
+            >
+              <.icon name="hero-map-pin" class="size-3" />
+            </button>
+            <button
+              type="button"
+              class="ts-tree__act ts-tree__act--danger"
+              phx-click={if node.asset?, do: "delete_asset", else: "delete_file"}
+              phx-value-id={node.id}
+              phx-confirm={gettext("editor.tree.delete_confirm")}
+              onclick="event.stopPropagation()"
+              aria-label={gettext("editor.tree.delete")}
+            >
+              <.icon name="hero-trash" class="size-3" />
+            </button>
+          </span>
         </li>
       <% end %>
     <% end %>

--- a/lib/typster_web/file_tree.ex
+++ b/lib/typster_web/file_tree.ex
@@ -147,7 +147,14 @@ defmodule TypsterWeb.FileTree do
             }
             class="size-3"
           />
-          <span class="ts-filechip ts-filechip--folder" aria-hidden="true"></span>
+          <i
+            class="ts-tree__ficon"
+            data-lucide={
+              if expanded?(@collapsed, node.path), do: "folder-open", else: "folder-closed"
+            }
+            aria-hidden="true"
+          >
+          </i>
           <span class="truncate flex-1">{node.name}</span>
           <span class="ts-tree__count">{length(node.children)}</span>
         </li>
@@ -180,7 +187,7 @@ defmodule TypsterWeb.FileTree do
             class="ts-tree__pin-ind"
             title={gettext("editor.tree.pinned")}
           >
-            <.icon name="hero-map-pin-solid" class="size-3" />
+            <i data-lucide="pin" aria-hidden="true"></i>
           </span>
           <span class="ts-tree__actions">
             <button
@@ -197,7 +204,11 @@ defmodule TypsterWeb.FileTree do
                 )
               }
             >
-              <.icon name="hero-map-pin" class="size-3" />
+              <i
+                data-lucide={if Map.get(node, :pinned, false), do: "pin-off", else: "pin"}
+                aria-hidden="true"
+              >
+              </i>
             </button>
             <button
               type="button"

--- a/lib/typster_web/file_tree.ex
+++ b/lib/typster_web/file_tree.ex
@@ -196,7 +196,6 @@ defmodule TypsterWeb.FileTree do
               class={["ts-tree__act", Map.get(node, :pinned, false) && "is-on"]}
               phx-click="toggle_pin"
               phx-value-id={node.id}
-              onclick="event.stopPropagation()"
               aria-label={
                 if(Map.get(node, :pinned, false),
                   do: gettext("editor.tree.unpin"),
@@ -216,7 +215,6 @@ defmodule TypsterWeb.FileTree do
               phx-click={if node.asset?, do: "delete_asset", else: "delete_file"}
               phx-value-id={node.id}
               phx-confirm={gettext("editor.tree.delete_confirm")}
-              onclick="event.stopPropagation()"
               aria-label={gettext("editor.tree.delete")}
             >
               <.icon name="hero-trash" class="size-3" />

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -484,6 +484,15 @@ defmodule TypsterWeb.EditorLive.Index do
   defp save_status_label("error"), do: gettext("editor.status.error")
   defp save_status_label(status), do: status
 
+  # Breadcrumb segments from the active file's path; the filename is `last`.
+  defp path_segments(nil), do: []
+
+  defp path_segments(%{path: path}) do
+    parts = String.split(path, "/")
+    count = length(parts)
+    parts |> Enum.with_index(1) |> Enum.map(fn {p, i} -> %{name: p, last: i == count} end)
+  end
+
   defp pinned_files(file_tree), do: Enum.filter(file_tree, & &1.pinned)
   defp unpinned_files(file_tree), do: Enum.reject(file_tree, & &1.pinned)
 

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -622,6 +622,8 @@ defmodule TypsterWeb.EditorLive.Index do
   defp save_status_label(status), do: status
 
   # Auto-save a dropped/selected template file once its bytes finish uploading.
+  # File.read! reads a LiveView-managed upload temp path, not user input.
+  # sobelow_skip ["Traversal.FileModule"]
   defp handle_template_progress(:template, entry, socket) do
     if entry.done? do
       scope = socket.assigns.current_scope
@@ -645,6 +647,8 @@ defmodule TypsterWeb.EditorLive.Index do
     if entry.done?, do: {:noreply, consume_dropped(socket)}, else: {:noreply, socket}
   end
 
+  # File.read! reads a LiveView-managed upload temp path, not user input.
+  # sobelow_skip ["Traversal.FileModule"]
   defp consume_dropped(socket) do
     scope = socket.assigns.current_scope
     project_id = socket.assigns.project.id

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -22,6 +22,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:assets, assets)
      |> assign(:current_file, main_file)
      |> assign(:active_dir, file_dir(main_file))
+     |> assign(:create_dir, "")
      |> assign(:open_file_ids, if(main_file, do: [main_file.id], else: []))
      |> assign(:content, if(main_file, do: main_file.content || "", else: ""))
      |> assign(:editor_language, editor_language(main_file))
@@ -276,6 +277,7 @@ defmodule TypsterWeb.EditorLive.Index do
      socket
      |> assign(:creating?, true)
      |> assign(:new_kind, :file)
+     |> assign(:create_dir, socket.assigns.active_dir)
      |> assign(:new_file_name, stem)
      |> assign(
        :new_file_suggestions,
@@ -294,10 +296,11 @@ defmodule TypsterWeb.EditorLive.Index do
 
   @impl true
   def handle_event("create_folder_from_dialog", %{"path" => typed}, socket) do
-    folder = typed |> String.trim() |> String.trim("/")
+    name = typed |> String.trim() |> String.trim("/")
+    folder = socket.assigns.create_dir |> join_dir(name) |> String.trim("/")
 
     cond do
-      folder == "" ->
+      name == "" ->
         {:noreply, socket}
 
       folder_taken?(socket.assigns.file_tree, folder) ->
@@ -330,20 +333,25 @@ defmodule TypsterWeb.EditorLive.Index do
 
   @impl true
   def handle_event("create_file_from_dialog", %{"path" => typed}, socket) do
-    path = Files.resolve_new_file_path(socket.assigns.file_tree, typed)
+    name = String.trim(typed)
+    full = join_dir(socket.assigns.create_dir, name)
+    path = Files.resolve_new_file_path(socket.assigns.file_tree, full)
 
     cond do
+      name == "" ->
+        {:noreply, socket}
+
       not Files.editable_file?(path) ->
         {:noreply, put_flash(socket, :error, gettext("editor.flash.unsupported_file"))}
 
       path_taken?(socket.assigns.file_tree, path) ->
-        # Keep the draft open with what was typed so the name can be fixed.
+        # Keep the draft open with the typed name (folder prefix shown separately).
         {:noreply,
          socket
-         |> assign(:new_file_name, typed)
+         |> assign(:new_file_name, name)
          |> assign(
            :new_file_suggestions,
-           Files.new_file_suggestions(socket.assigns.file_tree, typed)
+           Files.new_file_suggestions(socket.assigns.file_tree, name)
          )
          |> put_flash(:error, gettext("editor.flash.file_exists"))}
 
@@ -652,22 +660,23 @@ defmodule TypsterWeb.EditorLive.Index do
     end
   end
 
-  defp dir_prefix(""), do: ""
-  defp dir_prefix(dir), do: dir <> "/"
-
-  # Open the inline draft, seeded with the active folder so the new file/folder
-  # lands there, and expand that folder so the result is visible.
+  # Open the inline draft targeting the active folder (shown as a static prefix,
+  # not editable text) and expand that folder so the result is visible.
   defp start_create(socket, kind) do
     active_dir = socket.assigns.active_dir
 
     socket
     |> assign(:creating?, true)
     |> assign(:new_kind, kind)
-    |> assign(:new_file_name, dir_prefix(active_dir))
+    |> assign(:create_dir, active_dir)
+    |> assign(:new_file_name, "")
     |> assign(:new_file_suggestions, [])
     |> assign(:template_content, nil)
     |> assign(:collapsed_dirs, MapSet.delete(socket.assigns.collapsed_dirs, active_dir))
   end
+
+  defp join_dir("", name), do: name
+  defp join_dir(dir, name), do: "#{dir}/#{name}"
 
   # Breadcrumb segments from the active file's path; the filename is `last`.
   defp path_segments(nil), do: []
@@ -709,7 +718,6 @@ defmodule TypsterWeb.EditorLive.Index do
   end
 
   defp pinned_files(file_tree), do: Enum.filter(file_tree, & &1.pinned)
-  defp unpinned_files(file_tree), do: Enum.reject(file_tree, & &1.pinned)
 
   # Hierarchical section numbers, with the level-1 title left unnumbered and
   # numbering starting at level 2 (1, 2, 2.1, …) per the OutlineV2 design.

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -21,6 +21,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:file_tree, file_tree)
      |> assign(:assets, assets)
      |> assign(:current_file, main_file)
+     |> assign(:active_dir, file_dir(main_file))
      |> assign(:open_file_ids, if(main_file, do: [main_file.id], else: []))
      |> assign(:content, if(main_file, do: main_file.content || "", else: ""))
      |> assign(:editor_language, editor_language(main_file))
@@ -163,6 +164,7 @@ defmodule TypsterWeb.EditorLive.Index do
        socket
        |> open_tab(file_id)
        |> assign(:current_file, file)
+       |> assign(:active_dir, file_dir(file))
        |> assign(:content, file.content || "")
        |> assign(:editor_language, editor_language(file))
        |> assign(:save_status, "saved")
@@ -227,29 +229,18 @@ defmodule TypsterWeb.EditorLive.Index do
         do: MapSet.delete(collapsed, path),
         else: MapSet.put(collapsed, path)
 
-    {:noreply, assign(socket, :collapsed_dirs, collapsed)}
+    # Clicking a folder makes it the active directory for new files/folders.
+    {:noreply, socket |> assign(:collapsed_dirs, collapsed) |> assign(:active_dir, path)}
   end
 
   @impl true
   def handle_event("new_file", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(:creating?, true)
-     |> assign(:new_kind, :file)
-     |> assign(:new_file_name, "")
-     |> assign(:new_file_suggestions, [])
-     |> assign(:template_content, nil)}
+    {:noreply, start_create(socket, :file)}
   end
 
   @impl true
   def handle_event("new_folder", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(:creating?, true)
-     |> assign(:new_kind, :folder)
-     |> assign(:new_file_name, "")
-     |> assign(:new_file_suggestions, [])
-     |> assign(:template_content, nil)}
+    {:noreply, start_create(socket, :folder)}
   end
 
   @impl true
@@ -592,6 +583,34 @@ defmodule TypsterWeb.EditorLive.Index do
   defp save_status_label("saving"), do: gettext("editor.status.saving")
   defp save_status_label("error"), do: gettext("editor.status.error")
   defp save_status_label(status), do: status
+
+  # The directory a file lives in ("" for project root), used as the target
+  # folder when creating new files/folders.
+  defp file_dir(nil), do: ""
+
+  defp file_dir(%{path: path}) do
+    case Path.dirname(path) do
+      "." -> ""
+      dir -> dir
+    end
+  end
+
+  defp dir_prefix(""), do: ""
+  defp dir_prefix(dir), do: dir <> "/"
+
+  # Open the inline draft, seeded with the active folder so the new file/folder
+  # lands there, and expand that folder so the result is visible.
+  defp start_create(socket, kind) do
+    active_dir = socket.assigns.active_dir
+
+    socket
+    |> assign(:creating?, true)
+    |> assign(:new_kind, kind)
+    |> assign(:new_file_name, dir_prefix(active_dir))
+    |> assign(:new_file_suggestions, [])
+    |> assign(:template_content, nil)
+    |> assign(:collapsed_dirs, MapSet.delete(socket.assigns.collapsed_dirs, active_dir))
+  end
 
   # Breadcrumb segments from the active file's path; the filename is `last`.
   defp path_segments(nil), do: []

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -622,14 +622,13 @@ defmodule TypsterWeb.EditorLive.Index do
   defp save_status_label(status), do: status
 
   # Auto-save a dropped/selected template file once its bytes finish uploading.
-  # File.read! reads a LiveView-managed upload temp path, not user input.
-  # sobelow_skip ["Traversal.FileModule"]
   defp handle_template_progress(:template, entry, socket) do
     if entry.done? do
       scope = socket.assigns.current_scope
 
       consume_uploaded_entries(socket, :template, fn %{path: path}, e ->
-        {:ok, Templates.create_template(scope, %{name: e.client_name, content: File.read!(path)})}
+        {:ok,
+         Templates.create_template(scope, %{name: e.client_name, content: read_upload!(path)})}
       end)
 
       {:noreply,
@@ -647,8 +646,6 @@ defmodule TypsterWeb.EditorLive.Index do
     if entry.done?, do: {:noreply, consume_dropped(socket)}, else: {:noreply, socket}
   end
 
-  # File.read! reads a LiveView-managed upload temp path, not user input.
-  # sobelow_skip ["Traversal.FileModule"]
   defp consume_dropped(socket) do
     scope = socket.assigns.current_scope
     project_id = socket.assigns.project.id
@@ -668,7 +665,7 @@ defmodule TypsterWeb.EditorLive.Index do
             {:ok, :asset}
 
           Files.editable_file?(name) ->
-            Files.create_file(scope, project_id, %{path: name, content: File.read!(tmp)})
+            Files.create_file(scope, project_id, %{path: name, content: read_upload!(tmp)})
             {:ok, :file}
 
           true ->
@@ -690,6 +687,23 @@ defmodule TypsterWeb.EditorLive.Index do
         do: put_flash(s, :error, gettext("editor.flash.unsupported_file")),
         else: put_flash(s, :info, gettext("editor.flash.dropped_added"))
     end)
+  end
+
+  # Read an upload's temp file, confined to the system temp dir where LiveView
+  # writes uploads — defense in depth against path traversal. Reads the
+  # validated, expanded path.
+  defp read_upload!(path) do
+    tmp = Path.expand(System.tmp_dir!())
+    expanded = Path.expand(path)
+
+    unless String.starts_with?(expanded, tmp <> "/") do
+      raise ArgumentError, "upload path is outside the temp directory"
+    end
+
+    case :file.read_file(expanded) do
+      {:ok, content} -> content
+      {:error, reason} -> raise "could not read upload (#{:file.format_error(reason)})"
+    end
   end
 
   # The directory a file lives in ("" for project root), used as the target

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -29,6 +29,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:preview_error, nil)
      |> assign(:preview_compiling, false)
      |> assign(:creating?, false)
+     |> assign(:new_kind, :file)
      |> assign(:new_file_name, "")
      |> assign(:new_file_suggestions, [])
      |> assign(:file_view_mode, :tree)
@@ -188,13 +189,53 @@ defmodule TypsterWeb.EditorLive.Index do
     {:noreply,
      socket
      |> assign(:creating?, true)
+     |> assign(:new_kind, :file)
+     |> assign(:new_file_name, "")
+     |> assign(:new_file_suggestions, [])}
+  end
+
+  @impl true
+  def handle_event("new_folder", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:creating?, true)
+     |> assign(:new_kind, :folder)
      |> assign(:new_file_name, "")
      |> assign(:new_file_suggestions, [])}
   end
 
   @impl true
   def handle_event("cancel_new_file", _params, socket) do
-    {:noreply, assign(socket, creating?: false, new_file_name: "", new_file_suggestions: [])}
+    {:noreply,
+     socket
+     |> assign(creating?: false, new_file_name: "", new_file_suggestions: [])
+     |> assign(:new_kind, :file)}
+  end
+
+  @impl true
+  def handle_event("create_folder_from_dialog", %{"path" => typed}, socket) do
+    folder = typed |> String.trim() |> String.trim("/")
+
+    cond do
+      folder == "" ->
+        {:noreply, socket}
+
+      folder_taken?(socket.assigns.file_tree, folder) ->
+        {:noreply,
+         socket
+         |> assign(:new_file_name, typed)
+         |> put_flash(:error, gettext("editor.flash.file_exists"))}
+
+      true ->
+        # Folders are path-derived, so a new folder is seeded with a starter file
+        # using the project's majority source type.
+        ext = Files.majority_source_extension(socket.assigns.file_tree)
+        path = "#{folder}/untitled#{ext}"
+
+        socket
+        |> assign(creating?: false, new_kind: :file, new_file_name: "", new_file_suggestions: [])
+        |> create_text_file(path, default_file_content(path))
+    end
   end
 
   @impl true
@@ -370,6 +411,9 @@ defmodule TypsterWeb.EditorLive.Index do
   end
 
   defp path_taken?(file_tree, path), do: Enum.any?(file_tree, &(&1.path == path))
+
+  defp folder_taken?(file_tree, folder),
+    do: Enum.any?(file_tree, &String.starts_with?(&1.path, folder <> "/"))
 
   defp path_taken_error?(changeset) do
     Enum.any?(changeset.errors, fn {field, _} -> field == :path end)

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -20,6 +20,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:file_tree, file_tree)
      |> assign(:assets, assets)
      |> assign(:current_file, main_file)
+     |> assign(:open_file_ids, if(main_file, do: [main_file.id], else: []))
      |> assign(:content, if(main_file, do: main_file.content || "", else: ""))
      |> assign(:editor_language, editor_language(main_file))
      |> assign(:project_sources, project_sources(file_tree))
@@ -152,6 +153,7 @@ defmodule TypsterWeb.EditorLive.Index do
     if Files.editable_file?(file) do
       {:noreply,
        socket
+       |> open_tab(file_id)
        |> assign(:current_file, file)
        |> assign(:content, file.content || "")
        |> assign(:editor_language, editor_language(file))
@@ -164,6 +166,42 @@ defmodule TypsterWeb.EditorLive.Index do
        |> push_event("content_updated", %{content: file.content || ""})}
     else
       {:noreply, put_flash(socket, :error, gettext("editor.flash.binary_asset"))}
+    end
+  end
+
+  @impl true
+  def handle_event("close_tab", %{"id" => file_id}, socket) do
+    remaining = Enum.reject(socket.assigns.open_file_ids, &(&1 == file_id))
+    socket = assign(socket, :open_file_ids, remaining)
+    current = socket.assigns.current_file
+
+    if current && current.id == file_id do
+      # Activate the nearest remaining tab, or clear the editor when none remain.
+      case remaining |> List.last() |> next_open_file(socket) do
+        nil ->
+          {:noreply,
+           socket
+           |> assign(:current_file, nil)
+           |> assign(:content, "")
+           |> assign(:editor_language, "plain")
+           |> push_event("file_changed", %{file_id: nil, content: "", language: "plain"})
+           |> push_event("content_updated", %{content: ""})}
+
+        file ->
+          {:noreply,
+           socket
+           |> assign(:current_file, file)
+           |> assign(:content, file.content || "")
+           |> assign(:editor_language, editor_language(file))
+           |> push_event("file_changed", %{
+             file_id: file.id,
+             content: file.content || "",
+             language: editor_language(file)
+           })
+           |> push_event("content_updated", %{content: file.content || ""})}
+      end
+    else
+      {:noreply, socket}
     end
   end
 
@@ -301,13 +339,21 @@ defmodule TypsterWeb.EditorLive.Index do
     {:ok, _} = Files.delete_file(scope, file)
     file_tree = Files.get_file_tree(scope, socket.assigns.project.id)
 
+    open_ids = Enum.reject(socket.assigns.open_file_ids, &(&1 == file.id))
     current = socket.assigns.current_file
     was_open? = current && current.id == file.id
-    next_file = if was_open?, do: initial_file(file_tree), else: current
+
+    next_file =
+      cond do
+        not was_open? -> current
+        open_ids != [] -> Enum.find(file_tree, &(&1.id == List.last(open_ids)))
+        true -> initial_file(file_tree)
+      end
 
     socket =
       socket
       |> assign(:file_tree, file_tree)
+      |> assign(:open_file_ids, open_ids)
       |> assign(:project_sources, project_sources(file_tree))
       |> assign(:current_file, next_file)
       |> put_flash(:info, gettext("editor.flash.file_deleted"))
@@ -390,6 +436,7 @@ defmodule TypsterWeb.EditorLive.Index do
          |> assign(creating?: false, new_file_name: "", new_file_suggestions: [])
          |> assign(:file_tree, file_tree)
          |> assign(:project_sources, project_sources(file_tree))
+         |> open_tab(file.id)
          |> assign(:current_file, file)
          |> assign(:content, content)
          |> assign(:editor_language, editor_language(file))
@@ -491,6 +538,36 @@ defmodule TypsterWeb.EditorLive.Index do
     parts = String.split(path, "/")
     count = length(parts)
     parts |> Enum.with_index(1) |> Enum.map(fn {p, i} -> %{name: p, last: i == count} end)
+  end
+
+  # Append a file id to the open-tabs list (keeping order, no duplicates).
+  defp open_tab(socket, file_id) do
+    ids = socket.assigns.open_file_ids
+    if file_id in ids, do: socket, else: assign(socket, :open_file_ids, ids ++ [file_id])
+  end
+
+  defp next_open_file(nil, _socket), do: nil
+
+  defp next_open_file(file_id, socket),
+    do: Enum.find(socket.assigns.file_tree, &(&1.id == file_id))
+
+  # Open files as structs, in tab order, dropping any that no longer exist.
+  defp open_tabs(file_tree, open_file_ids) do
+    Enum.flat_map(open_file_ids, fn id ->
+      case Enum.find(file_tree, &(&1.id == id)),
+        do: (
+          nil -> []
+          file -> [file]
+        )
+    end)
+  end
+
+  # Split a path into {folder_or_nil, filename} for tab/crumb labels.
+  defp split_path(path) do
+    case Path.dirname(path) do
+      "." -> {nil, path}
+      dir -> {dir, Path.basename(path)}
+    end
   end
 
   defp pinned_files(file_tree), do: Enum.filter(file_tree, & &1.pinned)

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -33,6 +33,10 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:preview_error, nil)
      |> assign(:preview_error_count, 0)
      |> assign(:preview_compiling, false)
+     |> assign(:diagnostics, [])
+     |> assign(:compile_log, [])
+     |> assign(:drawer_open, false)
+     |> assign(:drawer_tab, "log")
      |> assign(:creating?, false)
      |> assign(:new_kind, :file)
      |> assign(:new_file_name, "")
@@ -111,21 +115,51 @@ defmodule TypsterWeb.EditorLive.Index do
 
   @impl true
   def handle_event("update_preview", params, socket) do
+    pages = params["pages"] || 1
+    sources = length(socket.assigns.project_sources)
+
+    log =
+      log_entry(:ok, "compiled · #{params["ms"]}ms · #{pages} page(s) · #{sources} sources")
+
     {:noreply,
-     assign(socket,
-       preview_stats: %{ms: params["ms"], pages: params["pages"]},
-       preview_compiling: false,
-       preview_error: nil
-     )}
+     socket
+     |> assign(:preview_stats, %{ms: params["ms"], pages: pages})
+     |> assign(:preview_compiling, false)
+     |> assign(:preview_error, nil)
+     |> assign(:preview_error_count, 0)
+     |> assign(:diagnostics, [])
+     |> push_log(log)}
   end
 
   @impl true
   def handle_event("preview_error", %{"message" => message} = params, socket) do
+    diagnostics = normalize_diagnostics(params["diagnostics"])
+    errors = params["errors"] || length(diagnostics)
+    warnings = params["warnings"] || 0
+
     {:noreply,
      socket
      |> assign(:preview_error, message)
-     |> assign(:preview_error_count, params["errors"] || 0)
-     |> assign(:preview_compiling, false)}
+     |> assign(:preview_error_count, errors)
+     |> assign(:preview_compiling, false)
+     |> assign(:diagnostics, diagnostics)
+     |> push_log(log_entry(:error, error_log_text(errors, warnings)))}
+  end
+
+  @impl true
+  def handle_event("toggle_drawer", _params, socket) do
+    {:noreply, assign(socket, :drawer_open, not socket.assigns.drawer_open)}
+  end
+
+  @impl true
+  def handle_event("set_drawer_tab", %{"tab" => tab}, socket) do
+    tab = if tab == "problems", do: "problems", else: "log"
+    {:noreply, assign(socket, drawer_open: true, drawer_tab: tab)}
+  end
+
+  @impl true
+  def handle_event("clear_log", _params, socket) do
+    {:noreply, assign(socket, :compile_log, [])}
   end
 
   @impl true
@@ -720,6 +754,49 @@ defmodule TypsterWeb.EditorLive.Index do
       "." -> {nil, path}
       dir -> {dir, Path.basename(path)}
     end
+  end
+
+  # ── Compile log + diagnostics ─────────────────────────────────────────────
+  defp normalize_diagnostics(nil), do: []
+
+  defp normalize_diagnostics(list) when is_list(list) do
+    Enum.map(list, fn d ->
+      loc = d["location"] || %{}
+
+      %{
+        severity: if(d["severity"] == "warning", do: "warning", else: "error"),
+        file: loc["file"],
+        line: loc["line"],
+        col: loc["col"],
+        message: d["message"] || ""
+      }
+    end)
+  end
+
+  defp normalize_diagnostics(_), do: []
+
+  defp log_entry(kind, text) do
+    %{kind: kind, text: text, at: Calendar.strftime(Time.utc_now(), "%H:%M:%S")}
+  end
+
+  # Keep the most recent 40 entries so the log can't grow unbounded.
+  defp push_log(socket, entry) do
+    assign(socket, :compile_log, Enum.take(socket.assigns.compile_log ++ [entry], -40))
+  end
+
+  defp error_log_text(errors, warnings) do
+    parts =
+      [errors > 0 && ngettext("%{count} error", "%{count} errors", errors)]
+      |> Enum.concat([
+        warnings > 0 && ngettext("%{count} warning", "%{count} warnings", warnings)
+      ])
+      |> Enum.filter(& &1)
+
+    if parts == [], do: gettext("editor.compile_failed"), else: Enum.join(parts, " · ")
+  end
+
+  defp first_error_line(diagnostics) do
+    Enum.find_value(diagnostics, fn d -> d.line end)
   end
 
   defp pinned_files(file_tree), do: Enum.filter(file_tree, & &1.pinned)

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -36,6 +36,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:show_palette, false)
      |> assign(:palette_query, "")
      |> stream(:outline, [])
+     |> assign(:outline_count, 0)
      |> assign(:page_title, project.name)
      |> allow_upload(:asset,
        accept: ~w(.pdf .png .jpg .jpeg .svg .webp .ttf .otf .woff .woff2),
@@ -103,19 +104,28 @@ defmodule TypsterWeb.EditorLive.Index do
 
   @impl true
   def handle_event("outline_parsed", %{"items" => items}, socket) do
-    outline =
+    {outline, _counters} =
       items
       |> Enum.with_index()
-      |> Enum.map(fn {item, idx} ->
-        %{
+      |> Enum.map_reduce(%{}, fn {item, idx}, counters ->
+        level = item["level"] || 1
+        {num, counters} = section_number(level, counters)
+
+        node = %{
           id: "outline-#{idx}",
-          level: item["level"] || 1,
+          level: level,
+          num: num,
           text: item["text"] || "",
           line: item["line"] || 1
         }
+
+        {node, counters}
       end)
 
-    {:noreply, stream(socket, :outline, outline, reset: true)}
+    {:noreply,
+     socket
+     |> assign(:outline_count, length(outline))
+     |> stream(:outline, outline, reset: true)}
   end
 
   @impl true
@@ -432,6 +442,20 @@ defmodule TypsterWeb.EditorLive.Index do
 
   defp pinned_files(file_tree), do: Enum.filter(file_tree, & &1.pinned)
   defp unpinned_files(file_tree), do: Enum.reject(file_tree, & &1.pinned)
+
+  # Hierarchical section numbers, with the level-1 title left unnumbered and
+  # numbering starting at level 2 (1, 2, 2.1, …) per the OutlineV2 design.
+  defp section_number(1, _counters), do: {"", %{}}
+
+  defp section_number(level, counters) do
+    counters =
+      counters
+      |> Map.update(level, 1, &(&1 + 1))
+      |> Map.reject(fn {l, _} -> l > level end)
+
+    num = 2..level |> Enum.map(&Map.get(counters, &1, 1)) |> Enum.join(".")
+    {num, counters}
+  end
 
   defp project_sources(file_tree) do
     file_tree

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -5,6 +5,7 @@ defmodule TypsterWeb.EditorLive.Index do
   alias Typster.Files
   alias Typster.Projects
   alias Typster.Revisions
+  alias Typster.Templates
 
   @impl true
   def mount(%{"id" => project_id}, _session, socket) do
@@ -33,6 +34,8 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:new_kind, :file)
      |> assign(:new_file_name, "")
      |> assign(:new_file_suggestions, [])
+     |> assign(:template_content, nil)
+     |> assign(:templates, Templates.list_templates(scope))
      |> assign(:file_view_mode, :tree)
      |> assign(:collapsed_dirs, MapSet.new())
      |> assign(:show_palette, false)
@@ -44,6 +47,11 @@ defmodule TypsterWeb.EditorLive.Index do
        accept: ~w(.pdf .png .jpg .jpeg .svg .webp .ttf .otf .woff .woff2),
        max_entries: 5,
        max_file_size: 20_000_000
+     )
+     |> allow_upload(:template,
+       accept: :any,
+       max_entries: 1,
+       max_file_size: 2_000_000
      )}
   end
 
@@ -229,7 +237,8 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:creating?, true)
      |> assign(:new_kind, :file)
      |> assign(:new_file_name, "")
-     |> assign(:new_file_suggestions, [])}
+     |> assign(:new_file_suggestions, [])
+     |> assign(:template_content, nil)}
   end
 
   @impl true
@@ -239,7 +248,8 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:creating?, true)
      |> assign(:new_kind, :folder)
      |> assign(:new_file_name, "")
-     |> assign(:new_file_suggestions, [])}
+     |> assign(:new_file_suggestions, [])
+     |> assign(:template_content, nil)}
   end
 
   @impl true
@@ -247,7 +257,58 @@ defmodule TypsterWeb.EditorLive.Index do
     {:noreply,
      socket
      |> assign(creating?: false, new_file_name: "", new_file_suggestions: [])
-     |> assign(:new_kind, :file)}
+     |> assign(:new_kind, :file)
+     |> assign(:template_content, nil)}
+  end
+
+  @impl true
+  def handle_event("validate_template", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("save_template", _params, socket) do
+    scope = socket.assigns.current_scope
+
+    results =
+      consume_uploaded_entries(socket, :template, fn %{path: path}, entry ->
+        Templates.create_template(scope, %{
+          name: entry.client_name,
+          content: File.read!(path)
+        })
+      end)
+
+    if Enum.any?(results, &match?({:error, _}, &1)) do
+      {:noreply, put_flash(socket, :error, gettext("editor.flash.template_failed"))}
+    else
+      {:noreply,
+       socket
+       |> assign(:templates, Templates.list_templates(scope))
+       |> put_flash(:info, gettext("editor.flash.template_saved"))}
+    end
+  end
+
+  @impl true
+  def handle_event("use_template", %{"id" => id}, socket) do
+    template = Templates.get_template!(socket.assigns.current_scope, id)
+    stem = Path.rootname(template.name)
+
+    {:noreply,
+     socket
+     |> assign(:creating?, true)
+     |> assign(:new_kind, :file)
+     |> assign(:new_file_name, stem)
+     |> assign(
+       :new_file_suggestions,
+       Files.new_file_suggestions(socket.assigns.file_tree, stem)
+     )
+     |> assign(:template_content, template.content || "")}
+  end
+
+  @impl true
+  def handle_event("delete_template", %{"id" => id}, socket) do
+    scope = socket.assigns.current_scope
+    template = Templates.get_template!(scope, id)
+    {:ok, _} = Templates.delete_template(scope, template)
+    {:noreply, assign(socket, :templates, Templates.list_templates(scope))}
   end
 
   @impl true
@@ -306,7 +367,8 @@ defmodule TypsterWeb.EditorLive.Index do
          |> put_flash(:error, gettext("editor.flash.file_exists"))}
 
       true ->
-        create_text_file(socket, path, default_file_content(path))
+        content = socket.assigns.template_content || default_file_content(path)
+        create_text_file(assign(socket, :template_content, nil), path, content)
     end
   end
 

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -31,6 +31,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:save_status, "saved")
      |> assign(:preview_stats, nil)
      |> assign(:preview_error, nil)
+     |> assign(:preview_error_count, 0)
      |> assign(:preview_compiling, false)
      |> assign(:creating?, false)
      |> assign(:new_kind, :file)
@@ -119,8 +120,12 @@ defmodule TypsterWeb.EditorLive.Index do
   end
 
   @impl true
-  def handle_event("preview_error", %{"message" => message}, socket) do
-    {:noreply, assign(socket, preview_error: message, preview_compiling: false)}
+  def handle_event("preview_error", %{"message" => message} = params, socket) do
+    {:noreply,
+     socket
+     |> assign(:preview_error, message)
+     |> assign(:preview_error_count, params["errors"] || 0)
+     |> assign(:preview_compiling, false)}
   end
 
   @impl true

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -28,7 +28,9 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:preview_stats, nil)
      |> assign(:preview_error, nil)
      |> assign(:preview_compiling, false)
-     |> assign(:show_new_file_dialog, false)
+     |> assign(:creating?, false)
+     |> assign(:new_file_name, "")
+     |> assign(:new_file_suggestions, [])
      |> assign(:file_view_mode, :tree)
      |> assign(:collapsed_dirs, MapSet.new())
      |> assign(:show_palette, false)
@@ -173,20 +175,35 @@ defmodule TypsterWeb.EditorLive.Index do
 
   @impl true
   def handle_event("new_file", _params, socket) do
-    {:noreply, assign(socket, :show_new_file_dialog, true)}
+    {:noreply,
+     socket
+     |> assign(:creating?, true)
+     |> assign(:new_file_name, "")
+     |> assign(:new_file_suggestions, [])}
   end
 
   @impl true
-  def handle_event("close_file_dialog", _params, socket) do
-    {:noreply, assign(socket, :show_new_file_dialog, false)}
+  def handle_event("cancel_new_file", _params, socket) do
+    {:noreply, assign(socket, creating?: false, new_file_name: "", new_file_suggestions: [])}
   end
 
   @impl true
-  def handle_event("create_file_from_dialog", %{"path" => path}, socket) do
+  def handle_event("suggest_new_file", %{"path" => name}, socket) do
+    suggestions = Files.new_file_suggestions(socket.assigns.file_tree, name)
+
+    {:noreply,
+     socket
+     |> assign(:new_file_name, name)
+     |> assign(:new_file_suggestions, suggestions)}
+  end
+
+  @impl true
+  def handle_event("create_file_from_dialog", %{"path" => typed}, socket) do
+    path = Files.resolve_new_file_path(socket.assigns.file_tree, typed)
+
     if Files.editable_file?(path) do
-      default_content = default_file_content(path)
-      socket = assign(socket, :show_new_file_dialog, false)
-      create_text_file(socket, path, default_content)
+      socket = assign(socket, creating?: false, new_file_name: "", new_file_suggestions: [])
+      create_text_file(socket, path, default_file_content(path))
     else
       {:noreply, put_flash(socket, :error, gettext("editor.flash.unsupported_file"))}
     end
@@ -262,9 +279,45 @@ defmodule TypsterWeb.EditorLive.Index do
   end
 
   defp default_file_content(path) do
-    case Path.extname(path) do
-      ".typ" -> "#set page(margin: 2cm)\n\n= Introduction\n\nHello from Typster!"
-      _ -> ""
+    case path |> Path.extname() |> String.downcase() do
+      ".typ" ->
+        "#set page(margin: 2cm)\n\n= Introduction\n\nHello from Typster!"
+
+      ".tex" ->
+        "\\documentclass{article}\n\n\\begin{document}\n\n\\section{Introduction}\n\n\\end{document}\n"
+
+      _ ->
+        ""
+    end
+  end
+
+  # Glyph + color bucket for the live file-type chip in the inline create row.
+  defp draft_chip_ext(name, suggestions) do
+    cond do
+      ext_label(name) != "" -> ext_label(name)
+      suggestions != [] -> ext_label(hd(suggestions))
+      true -> "typ"
+    end
+  end
+
+  # Extension that pressing Enter will append, or `nil` when the name already
+  # carries one (so the "+ .ext" hint pill stays hidden).
+  defp draft_hint(name, suggestions) do
+    if ext_label(String.trim(name)) == "" and suggestions != [] do
+      Path.extname(hd(suggestions))
+    end
+  end
+
+  defp ext_label(path),
+    do: path |> Path.extname() |> String.trim_leading(".") |> String.downcase()
+
+  defp chip_glyph(ext) do
+    case ext do
+      "typ" -> "T"
+      "bib" -> "B"
+      "md" -> "M"
+      e when e in ~w(tex latex sty cls) -> "L"
+      e -> e |> String.first() |> Kernel.||("·") |> String.upcase()
     end
   end
 

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -423,6 +423,19 @@ defmodule TypsterWeb.EditorLive.Index do
   end
 
   @impl true
+  def handle_event("move_file", %{"id" => file_id, "dir" => dir}, socket) do
+    scope = socket.assigns.current_scope
+    file = Files.get_file!(scope, file_id)
+    new_path = moved_path(file.path, dir)
+
+    if new_path == file.path do
+      {:noreply, socket}
+    else
+      {:noreply, do_move(socket, scope, file, new_path)}
+    end
+  end
+
+  @impl true
   def handle_event("delete_file", %{"id" => file_id}, socket) do
     scope = socket.assigns.current_scope
     file = Files.get_file!(scope, file_id)
@@ -715,6 +728,35 @@ defmodule TypsterWeb.EditorLive.Index do
       "." -> ""
       dir -> dir
     end
+  end
+
+  # Destination path for a file dropped onto `dir` ("" / root = project root).
+  defp moved_path(path, dir) do
+    base = Path.basename(path)
+    if dir in [nil, "", "."], do: base, else: dir <> "/" <> base
+  end
+
+  defp do_move(socket, scope, file, new_path) do
+    case Files.update_file(scope, file, %{path: new_path}) do
+      {:ok, moved} -> apply_moved(socket, scope, moved)
+      {:error, _changeset} -> put_flash(socket, :error, gettext("editor.flash.move_conflict"))
+    end
+  end
+
+  # Refresh the tree (and the active file struct, whose path just changed).
+  defp apply_moved(socket, scope, moved) do
+    file_tree = Files.get_file_tree(scope, socket.assigns.project.id)
+    current = socket.assigns.current_file
+
+    socket =
+      socket
+      |> assign(:file_tree, file_tree)
+      |> assign(:project_sources, project_sources(file_tree))
+      |> put_flash(:info, gettext("editor.flash.file_moved"))
+
+    if current && current.id == moved.id,
+      do: assign(socket, :current_file, moved),
+      else: socket
   end
 
   # Open the inline draft targeting the active folder (shown as a static prefix,

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -231,6 +231,69 @@ defmodule TypsterWeb.EditorLive.Index do
   end
 
   @impl true
+  def handle_event("toggle_pin", %{"id" => file_id}, socket) do
+    scope = socket.assigns.current_scope
+    file = Files.get_file!(scope, file_id)
+    {:ok, _} = Files.set_pinned(scope, file, not file.pinned)
+    file_tree = Files.get_file_tree(scope, socket.assigns.project.id)
+
+    {:noreply,
+     socket
+     |> assign(:file_tree, file_tree)
+     |> assign(:project_sources, project_sources(file_tree))}
+  end
+
+  @impl true
+  def handle_event("delete_file", %{"id" => file_id}, socket) do
+    scope = socket.assigns.current_scope
+    file = Files.get_file!(scope, file_id)
+    {:ok, _} = Files.delete_file(scope, file)
+    file_tree = Files.get_file_tree(scope, socket.assigns.project.id)
+
+    current = socket.assigns.current_file
+    was_open? = current && current.id == file.id
+    next_file = if was_open?, do: initial_file(file_tree), else: current
+
+    socket =
+      socket
+      |> assign(:file_tree, file_tree)
+      |> assign(:project_sources, project_sources(file_tree))
+      |> assign(:current_file, next_file)
+      |> put_flash(:info, gettext("editor.flash.file_deleted"))
+
+    if was_open? do
+      content = if next_file, do: next_file.content || "", else: ""
+
+      {:noreply,
+       socket
+       |> assign(:content, content)
+       |> assign(:editor_language, editor_language(next_file))
+       |> push_event("file_changed", %{
+         file_id: next_file && next_file.id,
+         content: content,
+         language: editor_language(next_file)
+       })
+       |> push_event("content_updated", %{content: content})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("delete_asset", %{"id" => asset_id}, socket) do
+    scope = socket.assigns.current_scope
+    asset = Assets.get_asset!(scope, asset_id)
+    {:ok, _} = Assets.delete_asset(scope, asset)
+    assets = Assets.list_assets(scope, socket.assigns.project.id)
+
+    {:noreply,
+     socket
+     |> assign(:assets, assets)
+     |> assign(:project_assets, project_assets(assets))
+     |> put_flash(:info, gettext("editor.flash.asset_deleted"))}
+  end
+
+  @impl true
   def handle_event("validate_upload", _params, socket) do
     {:noreply, socket}
   end
@@ -366,6 +429,9 @@ defmodule TypsterWeb.EditorLive.Index do
   defp save_status_label("saving"), do: gettext("editor.status.saving")
   defp save_status_label("error"), do: gettext("editor.status.error")
   defp save_status_label(status), do: status
+
+  defp pinned_files(file_tree), do: Enum.filter(file_tree, & &1.pinned)
+  defp unpinned_files(file_tree), do: Enum.reject(file_tree, & &1.pinned)
 
   defp project_sources(file_tree) do
     file_tree

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -811,7 +811,7 @@ defmodule TypsterWeb.EditorLive.Index do
       |> Map.update(level, 1, &(&1 + 1))
       |> Map.reject(fn {l, _} -> l > level end)
 
-    num = 2..level |> Enum.map(&Map.get(counters, &1, 1)) |> Enum.join(".")
+    num = Enum.map_join(2..level, ".", &Map.get(counters, &1, 1))
     {num, counters}
   end
 

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -201,11 +201,23 @@ defmodule TypsterWeb.EditorLive.Index do
   def handle_event("create_file_from_dialog", %{"path" => typed}, socket) do
     path = Files.resolve_new_file_path(socket.assigns.file_tree, typed)
 
-    if Files.editable_file?(path) do
-      socket = assign(socket, creating?: false, new_file_name: "", new_file_suggestions: [])
-      create_text_file(socket, path, default_file_content(path))
-    else
-      {:noreply, put_flash(socket, :error, gettext("editor.flash.unsupported_file"))}
+    cond do
+      not Files.editable_file?(path) ->
+        {:noreply, put_flash(socket, :error, gettext("editor.flash.unsupported_file"))}
+
+      path_taken?(socket.assigns.file_tree, path) ->
+        # Keep the draft open with what was typed so the name can be fixed.
+        {:noreply,
+         socket
+         |> assign(:new_file_name, typed)
+         |> assign(
+           :new_file_suggestions,
+           Files.new_file_suggestions(socket.assigns.file_tree, typed)
+         )
+         |> put_flash(:error, gettext("editor.flash.file_exists"))}
+
+      true ->
+        create_text_file(socket, path, default_file_content(path))
     end
   end
 
@@ -261,6 +273,7 @@ defmodule TypsterWeb.EditorLive.Index do
 
         {:noreply,
          socket
+         |> assign(creating?: false, new_file_name: "", new_file_suggestions: [])
          |> assign(:file_tree, file_tree)
          |> assign(:project_sources, project_sources(file_tree))
          |> assign(:current_file, file)
@@ -273,9 +286,20 @@ defmodule TypsterWeb.EditorLive.Index do
          })
          |> push_event("content_updated", %{content: content})}
 
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, gettext("editor.flash.create_failed"))}
+      {:error, changeset} ->
+        message =
+          if path_taken_error?(changeset),
+            do: gettext("editor.flash.file_exists"),
+            else: gettext("editor.flash.create_failed")
+
+        {:noreply, put_flash(socket, :error, message)}
     end
+  end
+
+  defp path_taken?(file_tree, path), do: Enum.any?(file_tree, &(&1.path == path))
+
+  defp path_taken_error?(changeset) do
+    Enum.any?(changeset.errors, fn {field, _} -> field == :path end)
   end
 
   defp default_file_content(path) do

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -52,7 +52,16 @@ defmodule TypsterWeb.EditorLive.Index do
      |> allow_upload(:template,
        accept: :any,
        max_entries: 1,
-       max_file_size: 2_000_000
+       max_file_size: 2_000_000,
+       auto_upload: true,
+       progress: &handle_template_progress/3
+     )
+     |> allow_upload(:dropped,
+       accept: :any,
+       max_entries: 10,
+       max_file_size: 20_000_000,
+       auto_upload: true,
+       progress: &handle_dropped_progress/3
      )}
   end
 
@@ -256,26 +265,7 @@ defmodule TypsterWeb.EditorLive.Index do
   def handle_event("validate_template", _params, socket), do: {:noreply, socket}
 
   @impl true
-  def handle_event("save_template", _params, socket) do
-    scope = socket.assigns.current_scope
-
-    results =
-      consume_uploaded_entries(socket, :template, fn %{path: path}, entry ->
-        Templates.create_template(scope, %{
-          name: entry.client_name,
-          content: File.read!(path)
-        })
-      end)
-
-    if Enum.any?(results, &match?({:error, _}, &1)) do
-      {:noreply, put_flash(socket, :error, gettext("editor.flash.template_failed"))}
-    else
-      {:noreply,
-       socket
-       |> assign(:templates, Templates.list_templates(scope))
-       |> put_flash(:info, gettext("editor.flash.template_saved"))}
-    end
-  end
+  def handle_event("validate_dropped", _params, socket), do: {:noreply, socket}
 
   @impl true
   def handle_event("use_template", %{"id" => id}, socket) do
@@ -583,6 +573,73 @@ defmodule TypsterWeb.EditorLive.Index do
   defp save_status_label("saving"), do: gettext("editor.status.saving")
   defp save_status_label("error"), do: gettext("editor.status.error")
   defp save_status_label(status), do: status
+
+  # Auto-save a dropped/selected template file once its bytes finish uploading.
+  defp handle_template_progress(:template, entry, socket) do
+    if entry.done? do
+      scope = socket.assigns.current_scope
+
+      consume_uploaded_entries(socket, :template, fn %{path: path}, e ->
+        {:ok, Templates.create_template(scope, %{name: e.client_name, content: File.read!(path)})}
+      end)
+
+      {:noreply,
+       socket
+       |> assign(:templates, Templates.list_templates(scope))
+       |> put_flash(:info, gettext("editor.flash.template_saved"))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # Route a file dropped onto the editor/assets: asset types upload as assets,
+  # editable types become new files, anything else is rejected.
+  defp handle_dropped_progress(:dropped, entry, socket) do
+    if entry.done?, do: {:noreply, consume_dropped(socket)}, else: {:noreply, socket}
+  end
+
+  defp consume_dropped(socket) do
+    scope = socket.assigns.current_scope
+    project_id = socket.assigns.project.id
+
+    results =
+      consume_uploaded_entries(socket, :dropped, fn %{path: tmp}, entry ->
+        name = entry.client_name
+
+        cond do
+          Files.asset_file?(name) ->
+            Assets.upload_entry(scope, project_id, %{
+              path: tmp,
+              client_name: name,
+              client_type: entry.client_type
+            })
+
+            {:ok, :asset}
+
+          Files.editable_file?(name) ->
+            Files.create_file(scope, project_id, %{path: name, content: File.read!(tmp)})
+            {:ok, :file}
+
+          true ->
+            {:ok, {:unsupported, name}}
+        end
+      end)
+
+    file_tree = Files.get_file_tree(scope, project_id)
+    assets = Assets.list_assets(scope, project_id)
+    unsupported = Enum.any?(results, &match?({:unsupported, _}, &1))
+
+    socket
+    |> assign(:file_tree, file_tree)
+    |> assign(:project_sources, project_sources(file_tree))
+    |> assign(:assets, assets)
+    |> assign(:project_assets, project_assets(assets))
+    |> then(fn s ->
+      if unsupported,
+        do: put_flash(s, :error, gettext("editor.flash.unsupported_file")),
+        else: put_flash(s, :info, gettext("editor.flash.dropped_added"))
+    end)
+  end
 
   # The directory a file lives in ("" for project root), used as the target
   # folder when creating new files/folders.

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -301,6 +301,68 @@
               </button>
             </.form>
           </div>
+
+          <div class="ts-side__head">
+            <span>{gettext("editor.templates")}</span>
+            <span :if={@templates != []} class="ts-side__count">{length(@templates)}</span>
+          </div>
+
+          <div class="ts-tpl">
+            <div :for={tpl <- @templates} class="ts-tpl__row">
+              <% kind = TypsterWeb.FileTree.file_chip_kind(tpl.name) %>
+              <span class={["ts-filechip", "ts-filechip--#{kind}"]}>
+                {TypsterWeb.FileTree.chip_glyph(kind)}
+              </span>
+              <span class="ts-tpl__name truncate">{tpl.name}</span>
+              <button
+                type="button"
+                class="ts-tree__act"
+                phx-click="use_template"
+                phx-value-id={tpl.id}
+                aria-label={gettext("editor.tpl.use")}
+                title={gettext("editor.tpl.use")}
+              >
+                <.icon name="hero-arrow-right" class="size-3" />
+              </button>
+              <button
+                type="button"
+                class="ts-tree__act ts-tree__act--danger"
+                phx-click="delete_template"
+                phx-value-id={tpl.id}
+                phx-confirm={gettext("editor.tpl.delete_confirm")}
+                aria-label={gettext("editor.tree.delete")}
+                title={gettext("editor.tree.delete")}
+              >
+                <.icon name="hero-trash" class="size-3" />
+              </button>
+            </div>
+
+            <.form
+              id="template-upload-form"
+              for={%{}}
+              phx-change="validate_template"
+              phx-submit="save_template"
+            >
+              <.live_file_input
+                upload={@uploads.template}
+                id="template-file-input"
+                class="hidden"
+              />
+              <label for="template-file-input" class="ts-tpl__drop">
+                <.icon name="hero-arrow-up-tray" class="size-3.5" />
+                <span>{gettext("editor.tpl.upload")}</span>
+              </label>
+              <button
+                :if={@uploads.template.entries != []}
+                id="save-template-button"
+                type="submit"
+                class="ts-btn ts-btn--primary ts-btn--sm"
+                style="width: 100%; margin-top: 6px;"
+              >
+                {gettext("editor.tpl.save")}
+              </button>
+            </.form>
+          </div>
         </aside>
 
         <%!-- Source pane: tab bar + formatting toolbar + CodeMirror --%>

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -593,6 +593,97 @@
           </div>
         </section>
 
+        <%!-- Compile log + problems drawer — spans all panes --%>
+        <div :if={@drawer_open} class="ts-drawer">
+          <div class="ts-drawer__tabs">
+            <button
+              type="button"
+              class={["ts-drawer__tab", @drawer_tab == "log" && "is-active"]}
+              phx-click="set_drawer_tab"
+              phx-value-tab="log"
+            >
+              <.icon name="hero-play" class="size-3" /> {gettext("editor.drawer.log")}
+            </button>
+            <button
+              type="button"
+              class={["ts-drawer__tab", @drawer_tab == "problems" && "is-active"]}
+              phx-click="set_drawer_tab"
+              phx-value-tab="problems"
+            >
+              <.icon name="hero-exclamation-triangle" class="size-3" />
+              {gettext("editor.drawer.problems")}
+              <span :if={@preview_error_count > 0} class="ts-drawer__count">
+                {@preview_error_count}
+              </span>
+            </button>
+            <div class="ts-spacer" />
+            <button
+              :if={@drawer_tab == "problems" and first_error_line(@diagnostics)}
+              type="button"
+              class="ts-btn ts-btn--ghost ts-btn--sm"
+              phx-click={
+                JS.dispatch("phx:editor-command",
+                  detail: %{cmd: "goto", line: first_error_line(@diagnostics)}
+                )
+              }
+            >
+              {gettext("editor.drawer.jump_first")}
+            </button>
+            <button
+              :if={@drawer_tab == "log"}
+              type="button"
+              class="ts-btn ts-btn--ghost ts-btn--sm"
+              phx-click="clear_log"
+            >
+              {gettext("editor.drawer.clear")}
+            </button>
+            <button
+              type="button"
+              class="ts-btn ts-btn--ghost ts-btn--icon ts-btn--sm"
+              phx-click="toggle_drawer"
+              aria-label={gettext("editor.drawer.close")}
+            >
+              <.icon name="hero-chevron-down" class="size-3" />
+            </button>
+          </div>
+
+          <div :if={@drawer_tab == "log"} class="ts-drawer__body ts-log">
+            <div :if={@compile_log == []} class="ts-drawer__empty">
+              {gettext("editor.drawer.log_empty")}
+            </div>
+            <div
+              :for={entry <- @compile_log}
+              class={["ts-log__row", "ts-log__row--#{entry.kind}"]}
+            >
+              <span class="ts-log__time">{entry.at}</span>
+              <span class="ts-log__text">{entry.text}</span>
+            </div>
+          </div>
+
+          <div :if={@drawer_tab == "problems"} class="ts-drawer__body ts-problems">
+            <div :if={@diagnostics == []} class="ts-drawer__empty">
+              {gettext("editor.drawer.no_problems")}
+            </div>
+            <button
+              :for={d <- @diagnostics}
+              type="button"
+              class="ts-problem"
+              phx-click={
+                d.line &&
+                  JS.dispatch("phx:editor-command", detail: %{cmd: "goto", line: d.line})
+              }
+            >
+              <span class={["ts-problem__dot", "ts-problem__dot--#{d.severity}"]}></span>
+              <span class="ts-problem__body">
+                <span :if={d.file} class="ts-problem__loc">
+                  {String.trim_leading(d.file, "/")}<span :if={d.line}>{" : #{d.line} : #{d.col}"}</span>
+                </span>
+                <span class="ts-problem__msg">{d.message}</span>
+              </span>
+            </button>
+          </div>
+        </div>
+
         <%!-- Status bar — spans all panes --%>
         <div class="ts-statusbar">
           <span class="ts-statusbar__item">
@@ -607,7 +698,22 @@
           <span class="ts-statusbar__sep"></span>
           <span class="ts-statusbar__item">LF</span>
           <div class="ts-spacer" />
-          <span class="ts-statusbar__item">{gettext("editor.command_hint")}</span>
+          <button
+            type="button"
+            class={["ts-statusbar__btn", @preview_error_count > 0 && "is-error"]}
+            phx-click="toggle_drawer"
+            aria-label={gettext("editor.drawer.toggle")}
+          >
+            <.icon
+              name={if @preview_error_count > 0, do: "hero-x-circle", else: "hero-check-circle"}
+              class="size-3.5"
+            />
+            <%= if @preview_error_count > 0 do %>
+              {ngettext("%{count} error", "%{count} errors", @preview_error_count)}
+            <% else %>
+              {gettext("editor.drawer.log")}
+            <% end %>
+          </button>
         </div>
       </div>
     </div>

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -663,7 +663,11 @@
         >
           <.icon name="hero-play" class="size-4" />
           <span>{gettext("editor.palette.compile")}</span>
-          <span class="ts-kbd">⌘↵</span>
+          <span class="ts-kbd ts-kbd--combo">
+            <span class="ts-mac" aria-hidden="true"><i data-lucide="command"></i></span>
+            <span class="ts-other">Ctrl</span>
+            <i data-lucide="corner-down-left" aria-hidden="true"></i>
+          </span>
         </button>
         <button
           :if={palette_match?(@palette_query, gettext("editor.palette.settings"))}

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -19,8 +19,18 @@
 
       <div class="ts-spacer" />
 
-      <button type="button" class="ts-btn ts-btn--ghost ts-btn--sm" phx-click="open_palette">
-        <.icon name="hero-command-line" class="size-3" /> {gettext("editor.command")}
+      <button
+        type="button"
+        class="ts-btn ts-btn--ghost ts-btn--sm ts-cmdk"
+        phx-click="open_palette"
+        aria-label={gettext("editor.command_open")}
+      >
+        <span class="ts-cmdk__icon ts-mac" aria-hidden="true"><i data-lucide="command"></i></span>
+        <span class="ts-cmdk__icon ts-other" aria-hidden="true">
+          <i data-lucide="square-terminal"></i>
+        </span>
+        <span class="ts-kbd ts-mac">⌘K</span>
+        <span class="ts-kbd ts-other">Ctrl K</span>
       </button>
       <button
         type="button"

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -277,14 +277,14 @@
             </div>
           </div>
 
-          <ul class="ts-tree">
+          <ul class="ts-tree" phx-drop-target={@uploads.dropped.ref}>
             <TypsterWeb.FileTree.tree_rows
               nodes={TypsterWeb.FileTree.asset_nodes(@assets, @file_view_mode)}
               collapsed={@collapsed_dirs}
             />
           </ul>
 
-          <div class="ts-side__upload">
+          <div class="ts-side__upload" phx-drop-target={@uploads.dropped.ref}>
             <.form
               id="asset-upload-form"
               for={%{}}
@@ -338,36 +338,29 @@
               </button>
             </div>
 
-            <.form
-              id="template-upload-form"
-              for={%{}}
-              phx-change="validate_template"
-              phx-submit="save_template"
-            >
+            <.form id="template-upload-form" for={%{}} phx-change="validate_template">
               <.live_file_input
                 upload={@uploads.template}
                 id="template-file-input"
                 class="hidden"
               />
-              <label for="template-file-input" class="ts-tpl__drop">
+              <label
+                for="template-file-input"
+                class="ts-tpl__drop"
+                phx-drop-target={@uploads.template.ref}
+              >
                 <.icon name="hero-arrow-up-tray" class="size-3.5" />
                 <span>{gettext("editor.tpl.upload")}</span>
               </label>
-              <button
-                :if={@uploads.template.entries != []}
-                id="save-template-button"
-                type="submit"
-                class="ts-btn ts-btn--primary ts-btn--sm"
-                style="width: 100%; margin-top: 6px;"
-              >
-                {gettext("editor.tpl.save")}
-              </button>
             </.form>
           </div>
         </aside>
 
         <%!-- Source pane: tab bar + formatting toolbar + CodeMirror --%>
-        <section class="ts-source">
+        <section class="ts-source" phx-drop-target={@uploads.dropped.ref}>
+          <.form id="dropped-upload-form" for={%{}} phx-change="validate_dropped" class="hidden">
+            <.live_file_input upload={@uploads.dropped} id="dropped-file-input" />
+          </.form>
           <div class="ts-source__tabs" id="editor-tabs" phx-hook="LucideIcons">
             <%= for file <- open_tabs(@file_tree, @open_file_ids) do %>
               <% {folder, name} = split_path(file.path) %>

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -65,7 +65,7 @@
     <div class="ts-editor__body">
       <div class="ts-window ts-editor__panes">
         <%!-- Sidebar: file tree + outline + assets --%>
-        <aside class="ts-side">
+        <aside class="ts-side" id="editor-sidebar" phx-hook="LucideIcons">
           <div class="ts-side__search">
             <div class="ts-search ts-search--sm">
               <.icon name="hero-magnifying-glass" class="size-3.5" />
@@ -174,8 +174,13 @@
                   phx-click-away="cancel_new_file"
                 >
                   <div class="ts-draft__row">
-                    <span :if={@new_kind == :folder} class="ts-filechip ts-filechip--folder">
-                    </span>
+                    <i
+                      :if={@new_kind == :folder}
+                      class="ts-tree__ficon"
+                      data-lucide="folder"
+                      aria-hidden="true"
+                    >
+                    </i>
                     <span
                       :if={@new_kind == :file}
                       class={[
@@ -367,7 +372,7 @@
 
         <%!-- Source pane: tab bar + formatting toolbar + CodeMirror --%>
         <section class="ts-source">
-          <div class="ts-source__tabs" id="editor-tabs">
+          <div class="ts-source__tabs" id="editor-tabs" phx-hook="LucideIcons">
             <%= for file <- open_tabs(@file_tree, @open_file_ids) do %>
               <% {folder, name} = split_path(file.path) %>
               <% kind = TypsterWeb.FileTree.file_chip_kind(file.path) %>
@@ -377,7 +382,7 @@
                 phx-value-file-id={file.id}
               >
                 <span :if={file.pinned} class="ts-tab__pin" title={gettext("editor.tree.pinned")}>
-                  <.icon name="hero-map-pin-solid" class="size-3" />
+                  <i data-lucide="pin" aria-hidden="true"></i>
                 </span>
                 <span class={["ts-filechip", "ts-filechip--#{kind}"]}>
                   {TypsterWeb.FileTree.chip_glyph(kind)}

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -529,7 +529,12 @@
             <%= cond do %>
               <% @preview_error -> %>
                 <span class="ts-pill ts-pill--error">
-                  <span class="ts-pill__dot"></span>{gettext("editor.preview_failed")}
+                  <span class="ts-pill__dot"></span>
+                  <%= if @preview_error_count > 0 do %>
+                    {ngettext("%{count} error", "%{count} errors", @preview_error_count)}
+                  <% else %>
+                    {gettext("editor.preview_failed")}
+                  <% end %>
                 </span>
               <% @preview_compiling -> %>
                 <span class="ts-pill ts-pill--accent">

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -120,6 +120,18 @@
             </button>
           </div>
 
+          <div :if={pinned_files(@file_tree) != []}>
+            <div class="ts-side__head ts-side__head--sub">{gettext("editor.pinned")}</div>
+            <ul class="ts-tree">
+              <TypsterWeb.FileTree.tree_rows
+                nodes={TypsterWeb.FileTree.file_nodes(pinned_files(@file_tree), :flat)}
+                collapsed={@collapsed_dirs}
+                current_id={@current_file && @current_file.id}
+              />
+            </ul>
+            <div class="ts-side__head ts-side__head--sub">{gettext("editor.files")}</div>
+          </div>
+
           <%= if Enum.empty?(@file_tree) and Enum.empty?(@assets) and not @creating? do %>
             <div class="ts-empty" style="margin: 8px 14px; padding: 20px 12px;">
               {gettext("editor.no_files")}
@@ -180,7 +192,9 @@
                 </.form>
               </li>
               <TypsterWeb.FileTree.tree_rows
-                nodes={TypsterWeb.FileTree.file_nodes(@file_tree, @file_view_mode)}
+                nodes={
+                  TypsterWeb.FileTree.file_nodes(unpinned_files(@file_tree), @file_view_mode)
+                }
                 collapsed={@collapsed_dirs}
                 current_id={@current_file && @current_file.id}
               />

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -110,12 +110,62 @@
             </button>
           </div>
 
-          <%= if Enum.empty?(@file_tree) and Enum.empty?(@assets) do %>
+          <%= if Enum.empty?(@file_tree) and Enum.empty?(@assets) and not @creating? do %>
             <div class="ts-empty" style="margin: 8px 14px; padding: 20px 12px;">
               {gettext("editor.no_files")}
             </div>
           <% else %>
             <ul class="ts-tree">
+              <li :if={@creating?} class="ts-tree__draft" id="new-file-draft">
+                <.form
+                  for={%{}}
+                  id="new-file-form"
+                  phx-change="suggest_new_file"
+                  phx-submit="create_file_from_dialog"
+                  phx-window-keydown="cancel_new_file"
+                  phx-key="Escape"
+                  phx-click-away="cancel_new_file"
+                >
+                  <div class="ts-draft__row">
+                    <span class={[
+                      "ts-filechip",
+                      "ts-filechip--#{draft_chip_ext(@new_file_name, @new_file_suggestions)}"
+                    ]}>
+                      {chip_glyph(draft_chip_ext(@new_file_name, @new_file_suggestions))}
+                    </span>
+                    <input
+                      class="ts-draft__input"
+                      name="path"
+                      value={@new_file_name}
+                      placeholder={gettext("editor.newfile.placeholder")}
+                      autocomplete="off"
+                      spellcheck="false"
+                      phx-mounted={JS.focus()}
+                    />
+                    <span
+                      :if={draft_hint(@new_file_name, @new_file_suggestions)}
+                      class="ts-exthint"
+                      title={gettext("editor.newfile.append_hint")}
+                    >
+                      + {draft_hint(@new_file_name, @new_file_suggestions)}
+                    </span>
+                  </div>
+                  <div :if={length(@new_file_suggestions) > 1} class="ts-suggest">
+                    <button
+                      :for={suggestion <- @new_file_suggestions}
+                      type="button"
+                      class="ts-suggest__chip"
+                      phx-click="create_file_from_dialog"
+                      phx-value-path={suggestion}
+                    >
+                      <span class={["ts-filechip", "ts-filechip--#{ext_label(suggestion)}"]}>
+                        {chip_glyph(ext_label(suggestion))}
+                      </span>
+                      {Path.basename(suggestion)}
+                    </button>
+                  </div>
+                </.form>
+              </li>
               <TypsterWeb.FileTree.tree_rows
                 nodes={TypsterWeb.FileTree.file_nodes(@file_tree, @file_view_mode)}
                 collapsed={@collapsed_dirs}
@@ -512,36 +562,4 @@
       </div>
     </div>
   </div>
-
-  <%= if @show_new_file_dialog do %>
-    <div class="ts-overlay" phx-click="close_file_dialog">
-      <div class="ts-dialog" phx-click="" phx-window-keydown="close_file_dialog" phx-key="Escape">
-        <div class="ts-dialog__header">
-          <h2 class="ts-dialog__title">{gettext("editor.new_file")}</h2>
-        </div>
-        <div class="ts-dialog__body">
-          <.form for={%{}} id="new-file-form" phx-submit="create_file_from_dialog">
-            <label class="ts-field">
-              <span class="ts-field__label">{gettext("editor.file_name")}</span>
-              <input
-                class="ts-input"
-                name="path"
-                autofocus
-                placeholder="main.typ"
-                required
-              />
-            </label>
-            <div class="ts-dialog__footer">
-              <button type="button" phx-click="close_file_dialog" class="ts-btn ts-btn--ghost">
-                {gettext("common.cancel")}
-              </button>
-              <button type="submit" class="ts-btn ts-btn--primary">
-                {gettext("editor.create_file")}
-              </button>
-            </div>
-          </.form>
-        </div>
-      </div>
-    </div>
-  <% end %>
 </Layouts.app>

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -147,6 +147,7 @@
                 nodes={TypsterWeb.FileTree.file_nodes(pinned_files(@file_tree), :flat)}
                 collapsed={@collapsed_dirs}
                 current_id={@current_file && @current_file.id}
+                id_prefix="pinned-"
               />
             </ul>
             <div class="ts-side__head ts-side__head--sub">{gettext("editor.files")}</div>
@@ -186,6 +187,7 @@
                     >
                       {chip_glyph(draft_chip_ext(@new_file_name, @new_file_suggestions))}
                     </span>
+                    <span :if={@create_dir != ""} class="ts-draft__dir">{@create_dir}/</span>
                     <input
                       class="ts-draft__input"
                       name="path"
@@ -231,9 +233,7 @@
                 </.form>
               </li>
               <TypsterWeb.FileTree.tree_rows
-                nodes={
-                  TypsterWeb.FileTree.file_nodes(unpinned_files(@file_tree), @file_view_mode)
-                }
+                nodes={TypsterWeb.FileTree.file_nodes(@file_tree, @file_view_mode)}
                 collapsed={@collapsed_dirs}
                 current_id={@current_file && @current_file.id}
               />

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -305,10 +305,37 @@
 
         <%!-- Source pane: tab bar + formatting toolbar + CodeMirror --%>
         <section class="ts-source">
-          <div class="ts-source__tabs">
-            <div class="ts-tab is-active">
-              <.icon name="hero-document" class="size-3" />
-              {if @current_file, do: @current_file.path, else: gettext("editor.no_file")}
+          <div class="ts-source__tabs" id="editor-tabs">
+            <%= for file <- open_tabs(@file_tree, @open_file_ids) do %>
+              <% {folder, name} = split_path(file.path) %>
+              <% kind = TypsterWeb.FileTree.file_chip_kind(file.path) %>
+              <div
+                class={["ts-tab", @current_file && @current_file.id == file.id && "is-active"]}
+                phx-click="select_file"
+                phx-value-file-id={file.id}
+              >
+                <span :if={file.pinned} class="ts-tab__pin" title={gettext("editor.tree.pinned")}>
+                  <.icon name="hero-map-pin-solid" class="size-3" />
+                </span>
+                <span class={["ts-filechip", "ts-filechip--#{kind}"]}>
+                  {TypsterWeb.FileTree.chip_glyph(kind)}
+                </span>
+                <span class="ts-tab__label">
+                  <span :if={folder} class="ts-tab__folder">{folder}/</span>{name}
+                </span>
+                <span
+                  class="ts-tab__close"
+                  phx-click="close_tab"
+                  phx-value-id={file.id}
+                  onclick="event.stopPropagation()"
+                  aria-label={gettext("editor.tab.close")}
+                >
+                  <.icon name="hero-x-mark" class="size-3" />
+                </span>
+              </div>
+            <% end %>
+            <div :if={@open_file_ids == []} class="ts-tab is-active ts-tab--empty">
+              {gettext("editor.no_file")}
             </div>
           </div>
 

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -629,6 +629,16 @@
             >
               {gettext("editor.drawer.jump_first")}
             </button>
+            <label :if={@drawer_tab == "log"} class="ts-drawer__delay">
+              {gettext("editor.drawer.recompile")}
+              <select id="compile-delay" phx-hook="CompileDelay" phx-update="ignore">
+                <option value="-1">{gettext("editor.drawer.delay_off")}</option>
+                <option value="300">0.3s</option>
+                <option value="700" selected>0.7s</option>
+                <option value="1500">1.5s</option>
+                <option value="3000">3s</option>
+              </select>
+            </label>
             <button
               :if={@drawer_tab == "log"}
               type="button"

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -394,7 +394,6 @@
                   class="ts-tab__close"
                   phx-click="close_tab"
                   phx-value-id={file.id}
-                  onclick="event.stopPropagation()"
                   aria-label={gettext("editor.tab.close")}
                 >
                   <.icon name="hero-x-mark" class="size-3" />

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -203,7 +203,12 @@
             </ul>
           <% end %>
 
-          <div class="ts-side__head">{gettext("editor.outline")}</div>
+          <div class="ts-side__head">
+            <span>{gettext("editor.outline")}</span>
+            <span :if={@outline_count > 0} class="ts-side__count">
+              {ngettext("%{count} section", "%{count} sections", @outline_count)}
+            </span>
+          </div>
           <ul id="outline" phx-update="stream" class="ts-outline">
             <li class="ts-outline__empty only:block hidden" id="outline-empty">
               {gettext("editor.outline_empty")}
@@ -216,6 +221,7 @@
                 JS.dispatch("phx:editor-command", detail: %{cmd: "goto", line: heading.line})
               }
             >
+              <span :if={heading.num != ""} class="ts-outline__num">{heading.num}</span>
               <span class="truncate">{heading.text}</span>
             </li>
           </ul>

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -174,13 +174,9 @@
                   phx-click-away="cancel_new_file"
                 >
                   <div class="ts-draft__row">
-                    <i
-                      :if={@new_kind == :folder}
-                      class="ts-tree__ficon"
-                      data-lucide="folder"
-                      aria-hidden="true"
-                    >
-                    </i>
+                    <span :if={@new_kind == :folder} class="ts-tree__ficon" aria-hidden="true">
+                      <i data-lucide="folder"></i>
+                    </span>
                     <span
                       :if={@new_kind == :file}
                       class={[

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -79,6 +79,14 @@
                 {TypsterWeb.FileTree.view_label(@file_view_mode)}
               </button>
               <button
+                id="create-folder-button"
+                phx-click="new_folder"
+                class="ts-btn ts-btn--ghost ts-btn--icon ts-btn--sm"
+                aria-label={gettext("editor.new_folder")}
+              >
+                <.icon name="hero-folder-plus" class="size-3" />
+              </button>
+              <button
                 id="create-main-file-button"
                 phx-click="new_file"
                 class="ts-btn ts-btn--ghost ts-btn--icon ts-btn--sm"
@@ -144,30 +152,45 @@
                 <.form
                   for={%{}}
                   id="new-file-form"
-                  phx-change="suggest_new_file"
-                  phx-submit="create_file_from_dialog"
+                  phx-change={@new_kind == :file && "suggest_new_file"}
+                  phx-submit={
+                    if(@new_kind == :folder,
+                      do: "create_folder_from_dialog",
+                      else: "create_file_from_dialog"
+                    )
+                  }
                   phx-window-keydown="cancel_new_file"
                   phx-key="Escape"
                   phx-click-away="cancel_new_file"
                 >
                   <div class="ts-draft__row">
-                    <span class={[
-                      "ts-filechip",
-                      "ts-filechip--#{draft_chip_ext(@new_file_name, @new_file_suggestions)}"
-                    ]}>
+                    <span :if={@new_kind == :folder} class="ts-filechip ts-filechip--folder">
+                    </span>
+                    <span
+                      :if={@new_kind == :file}
+                      class={[
+                        "ts-filechip",
+                        "ts-filechip--#{draft_chip_ext(@new_file_name, @new_file_suggestions)}"
+                      ]}
+                    >
                       {chip_glyph(draft_chip_ext(@new_file_name, @new_file_suggestions))}
                     </span>
                     <input
                       class="ts-draft__input"
                       name="path"
                       value={@new_file_name}
-                      placeholder={gettext("editor.newfile.placeholder")}
+                      placeholder={
+                        if(@new_kind == :folder,
+                          do: gettext("editor.newfolder.placeholder"),
+                          else: gettext("editor.newfile.placeholder")
+                        )
+                      }
                       autocomplete="off"
                       spellcheck="false"
                       phx-mounted={JS.focus()}
                     />
                     <button
-                      :if={length(@new_file_suggestions) == 1}
+                      :if={@new_kind == :file and length(@new_file_suggestions) == 1}
                       type="button"
                       class="ts-exthint"
                       phx-click="create_file_from_dialog"
@@ -177,7 +200,10 @@
                       + {draft_hint(@new_file_name, @new_file_suggestions)}
                     </button>
                   </div>
-                  <div :if={length(@new_file_suggestions) > 1} class="ts-suggest">
+                  <div
+                    :if={@new_kind == :file and length(@new_file_suggestions) > 1}
+                    class="ts-suggest"
+                  >
                     <button
                       :for={suggestion <- @new_file_suggestions}
                       type="button"

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -142,13 +142,16 @@
                       spellcheck="false"
                       phx-mounted={JS.focus()}
                     />
-                    <span
-                      :if={draft_hint(@new_file_name, @new_file_suggestions)}
+                    <button
+                      :if={length(@new_file_suggestions) == 1}
+                      type="button"
                       class="ts-exthint"
+                      phx-click="create_file_from_dialog"
+                      phx-value-path={hd(@new_file_suggestions)}
                       title={gettext("editor.newfile.append_hint")}
                     >
                       + {draft_hint(@new_file_name, @new_file_suggestions)}
-                    </span>
+                    </button>
                   </div>
                   <div :if={length(@new_file_suggestions) > 1} class="ts-suggest">
                     <button

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -29,7 +29,9 @@
         <span class="ts-cmdk__icon ts-other" aria-hidden="true">
           <i data-lucide="square-terminal"></i>
         </span>
-        <span class="ts-kbd ts-mac">⌘K</span>
+        <%!-- The ⌘ icon already conveys the modifier, so the Mac key is just "K"
+             (avoids a duplicated ⌘). Non-mac spells out "Ctrl" beside the icon. --%>
+        <span class="ts-kbd ts-mac">K</span>
         <span class="ts-kbd ts-other">Ctrl K</span>
       </button>
       <button

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -2,11 +2,21 @@
   <div class="ts-editor" id="editor-shell" phx-hook="CommandPalette">
     <%!-- Editor top bar: breadcrumb, save status, actions --%>
     <div class="ts-editor__bar">
-      <.link navigate={~p"/projects"} class="ts-btn ts-btn--ghost ts-btn--sm">
-        <.icon name="hero-chevron-left" class="size-3" /> {gettext("nav.projects")}
+      <.link
+        navigate={~p"/projects"}
+        class="ts-btn ts-btn--ghost ts-btn--icon ts-btn--sm"
+        aria-label={gettext("nav.projects")}
+        title={gettext("nav.projects")}
+      >
+        <.icon name="hero-chevron-left" class="size-3" />
       </.link>
-      <span class="ts-crumb-sep">/</span>
-      <span class="ts-crumb-current">{@project.name}</span>
+      <nav class="ts-crumb" aria-label={gettext("editor.breadcrumb")}>
+        <span class="ts-crumb__seg">{@project.name}</span>
+        <span :for={seg <- path_segments(@current_file)}>
+          <span class="ts-crumb__sep">/</span>
+          <span class={["ts-crumb__seg", seg.last && "is-active"]}>{seg.name}</span>
+        </span>
+      </nav>
 
       <div
         id="save-status"

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -158,7 +158,7 @@
               {gettext("editor.no_files")}
             </div>
           <% else %>
-            <ul class="ts-tree">
+            <ul class="ts-tree" id="file-tree-main" phx-hook="FileTreeDnD">
               <li :if={@creating?} class="ts-tree__draft" id="new-file-draft">
                 <.form
                   for={%{}}
@@ -236,6 +236,7 @@
                 nodes={TypsterWeb.FileTree.file_nodes(@file_tree, @file_view_mode)}
                 collapsed={@collapsed_dirs}
                 current_id={@current_file && @current_file.id}
+                dnd={true}
               />
             </ul>
           <% end %>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -52,7 +52,6 @@ msgstr ""
 msgid "auth.sign_up"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
 #: lib/typster_web/live/project_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "common.cancel"
@@ -134,7 +133,7 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:146
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
@@ -144,8 +143,8 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:368
-#: lib/typster_web/live/editor_live/index.html.heex:369
+#: lib/typster_web/live/editor_live/index.html.heex:417
+#: lib/typster_web/live/editor_live/index.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
@@ -155,85 +154,74 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:234
+#: lib/typster_web/live/editor_live/index.ex:251
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:231
+#: lib/typster_web/live/editor_live/index.ex:248
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:153
+#: lib/typster_web/live/editor_live/index.ex:155
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:277
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:191
-#: lib/typster_web/live/editor_live/index.ex:200
+#: lib/typster_web/live/editor_live/index.ex:208
+#: lib/typster_web/live/editor_live/index.ex:217
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:540
-#, elixir-autogen, elixir-format
-msgid "editor.create_file"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:526
-#, elixir-autogen
-msgid "editor.file_name"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:107
-#: lib/typster_web/live/editor_live/index.html.heex:521
+#: lib/typster_web/live/editor_live/index.html.heex:73
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:191
+#: lib/typster_web/live/editor_live/index.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:116
+#: lib/typster_web/live/editor_live/index.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:292
+#: lib/typster_web/live/editor_live/index.ex:337
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:290
+#: lib/typster_web/live/editor_live/index.ex:335
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:291
+#: lib/typster_web/live/editor_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:151
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:200
+#: lib/typster_web/live/editor_live/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -525,17 +513,17 @@ msgstr ""
 msgid "editor.command"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -546,118 +534,118 @@ msgstr ""
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:200
-#: lib/typster_web/live/editor_live/index.html.heex:201
+#: lib/typster_web/live/editor_live/index.html.heex:249
+#: lib/typster_web/live/editor_live/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:219
-#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:268
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:266
-#: lib/typster_web/live/editor_live/index.html.heex:267
+#: lib/typster_web/live/editor_live/index.html.heex:315
+#: lib/typster_web/live/editor_live/index.html.heex:316
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
-#: lib/typster_web/live/editor_live/index.html.heex:210
+#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:247
-#: lib/typster_web/live/editor_live/index.html.heex:248
+#: lib/typster_web/live/editor_live/index.html.heex:296
+#: lib/typster_web/live/editor_live/index.html.heex:297
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:228
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:277
+#: lib/typster_web/live/editor_live/index.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
-#: lib/typster_web/live/editor_live/index.html.heex:239
+#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:305
+#: lib/typster_web/live/editor_live/index.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:128
+#: lib/typster_web/live/editor_live/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:131
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:434
-#: lib/typster_web/live/editor_live/index.html.heex:442
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:483
+#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:482
-#: lib/typster_web/live/editor_live/index.html.heex:490
-#: lib/typster_web/live/editor_live/index.html.heex:499
+#: lib/typster_web/live/editor_live/index.html.heex:531
+#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:548
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:435
-#: lib/typster_web/live/editor_live/index.html.heex:455
-#: lib/typster_web/live/editor_live/index.html.heex:461
+#: lib/typster_web/live/editor_live/index.html.heex:484
+#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:439
+#: lib/typster_web/live/editor_live/index.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:483
-#: lib/typster_web/live/editor_live/index.html.heex:502
-#: lib/typster_web/live/editor_live/index.html.heex:511
+#: lib/typster_web/live/editor_live/index.html.heex:532
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:560
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:360
+#: lib/typster_web/live/editor_live/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -672,17 +660,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:343
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:352
+#: lib/typster_web/live/editor_live/index.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -842,38 +830,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:315
+#: lib/typster_web/live/editor_live/index.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:304
+#: lib/typster_web/live/editor_live/index.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:303
+#: lib/typster_web/live/editor_live/index.html.heex:352
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:276
-#: lib/typster_web/live/editor_live/index.html.heex:277
+#: lib/typster_web/live/editor_live/index.html.heex:325
+#: lib/typster_web/live/editor_live/index.html.heex:326
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -2001,24 +1989,19 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:81
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:81
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:65
+#: lib/typster_web/live/editor_live/index.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:75
-#, elixir-autogen, elixir-format
-msgid "editor.view.menu_title"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:11
@@ -2026,23 +2009,33 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:148
+#, elixir-autogen, elixir-format
+msgid "editor.newfile.append_hint"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:140
+#, elixir-autogen, elixir-format
+msgid "editor.newfile.placeholder"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -155,29 +155,29 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:479
+#: lib/typster_web/live/editor_live/index.ex:513
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:476
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:193
+#: lib/typster_web/live/editor_live/index.ex:227
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:544
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:350
-#: lib/typster_web/live/editor_live/index.ex:374
-#: lib/typster_web/live/editor_live/index.ex:652
+#: lib/typster_web/live/editor_live/index.ex:384
+#: lib/typster_web/live/editor_live/index.ex:408
+#: lib/typster_web/live/editor_live/index.ex:686
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -207,17 +207,17 @@ msgstr ""
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:587
+#: lib/typster_web/live/editor_live/index.ex:621
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:585
+#: lib/typster_web/live/editor_live/index.ex:619
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:586
+#: lib/typster_web/live/editor_live/index.ex:620
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -511,11 +511,6 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:610
-#, elixir-autogen, elixir-format
-msgid "editor.command_hint"
-msgstr ""
-
 #: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
@@ -590,50 +585,50 @@ msgstr ""
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
-#: lib/typster_web/live/editor_live/index.html.heex:649
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:744
+#: lib/typster_web/live/editor_live/index.html.heex:752
+#: lib/typster_web/live/editor_live/index.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:693
-#: lib/typster_web/live/editor_live/index.html.heex:701
-#: lib/typster_web/live/editor_live/index.html.heex:710
+#: lib/typster_web/live/editor_live/index.html.heex:796
+#: lib/typster_web/live/editor_live/index.html.heex:804
+#: lib/typster_web/live/editor_live/index.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:779
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:698
+#: lib/typster_web/live/editor_live/index.html.heex:801
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:633
+#: lib/typster_web/live/editor_live/index.html.heex:736
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:642
-#: lib/typster_web/live/editor_live/index.html.heex:666
-#: lib/typster_web/live/editor_live/index.html.heex:672
+#: lib/typster_web/live/editor_live/index.html.heex:745
+#: lib/typster_web/live/editor_live/index.html.heex:769
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:694
-#: lib/typster_web/live/editor_live/index.html.heex:713
-#: lib/typster_web/live/editor_live/index.html.heex:722
+#: lib/typster_web/live/editor_live/index.html.heex:797
+#: lib/typster_web/live/editor_live/index.html.heex:816
+#: lib/typster_web/live/editor_live/index.html.heex:825
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
@@ -2038,9 +2033,9 @@ msgstr ""
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:315
-#: lib/typster_web/live/editor_live/index.ex:361
-#: lib/typster_web/live/editor_live/index.ex:509
+#: lib/typster_web/live/editor_live/index.ex:349
+#: lib/typster_web/live/editor_live/index.ex:395
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2050,12 +2045,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:446
+#: lib/typster_web/live/editor_live/index.ex:480
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:415
+#: lib/typster_web/live/editor_live/index.ex:449
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2120,7 +2115,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:602
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2146,14 +2141,69 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:653
+#: lib/typster_web/live/editor_live/index.ex:687
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
+#: lib/typster_web/live/editor_live/index.ex:789
 #: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:709
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/typster_web/live/editor_live/index.ex:790
+#, elixir-autogen, elixir-format
+msgid "%{count} warning"
+msgid_plural "%{count} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/typster_web/live/editor_live/index.ex:793
+#, elixir-autogen, elixir-format
+msgid "editor.compile_failed"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:638
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.clear"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.close"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:630
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.jump_first"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.log"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:652
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.log_empty"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:662
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.no_problems"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:614
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.problems"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:702
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.toggle"
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,7 +133,7 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
@@ -143,23 +143,24 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:430
-#: lib/typster_web/live/editor_live/index.html.heex:431
+#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:68
+#: lib/typster_web/live/editor_live/index.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:263
+#: lib/typster_web/live/editor_live/index.ex:326
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:323
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
@@ -169,7 +170,7 @@ msgstr ""
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:293
+#: lib/typster_web/live/editor_live/index.ex:356
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
@@ -185,43 +186,43 @@ msgstr ""
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:125
+#: lib/typster_web/live/editor_live/index.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:446
+#: lib/typster_web/live/editor_live/index.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:367
+#: lib/typster_web/live/editor_live/index.ex:430
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:365
+#: lib/typster_web/live/editor_live/index.ex:428
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:366
+#: lib/typster_web/live/editor_live/index.ex:429
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:213
-#: lib/typster_web/live/editor_live/index.html.heex:242
+#: lib/typster_web/live/editor_live/index.html.heex:225
+#: lib/typster_web/live/editor_live/index.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -508,17 +509,17 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:396
+#: lib/typster_web/live/editor_live/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -529,118 +530,118 @@ msgstr ""
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:262
-#: lib/typster_web/live/editor_live/index.html.heex:263
+#: lib/typster_web/live/editor_live/index.html.heex:274
+#: lib/typster_web/live/editor_live/index.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:281
-#: lib/typster_web/live/editor_live/index.html.heex:282
+#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:328
-#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:271
-#: lib/typster_web/live/editor_live/index.html.heex:272
+#: lib/typster_web/live/editor_live/index.html.heex:283
+#: lib/typster_web/live/editor_live/index.html.heex:284
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:309
-#: lib/typster_web/live/editor_live/index.html.heex:310
+#: lib/typster_web/live/editor_live/index.html.heex:321
+#: lib/typster_web/live/editor_live/index.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:290
-#: lib/typster_web/live/editor_live/index.html.heex:291
+#: lib/typster_web/live/editor_live/index.html.heex:302
+#: lib/typster_web/live/editor_live/index.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:300
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:312
+#: lib/typster_web/live/editor_live/index.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:318
-#: lib/typster_web/live/editor_live/index.html.heex:319
+#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:190
+#: lib/typster_web/live/editor_live/index.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:496
-#: lib/typster_web/live/editor_live/index.html.heex:504
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:508
+#: lib/typster_web/live/editor_live/index.html.heex:516
+#: lib/typster_web/live/editor_live/index.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:544
-#: lib/typster_web/live/editor_live/index.html.heex:552
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:564
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:527
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:497
-#: lib/typster_web/live/editor_live/index.html.heex:517
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:501
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
-#: lib/typster_web/live/editor_live/index.html.heex:564
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:434
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -655,17 +656,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:405
+#: lib/typster_web/live/editor_live/index.html.heex:417
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -825,38 +826,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:371
+#: lib/typster_web/live/editor_live/index.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/live/editor_live/index.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:368
+#: lib/typster_web/live/editor_live/index.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:365
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
-#: lib/typster_web/live/editor_live/index.html.heex:339
+#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -2025,18 +2026,18 @@ msgstr ""
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:161
+#: lib/typster_web/live/editor_live/index.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:150
+#: lib/typster_web/live/editor_live/index.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:217
-#: lib/typster_web/live/editor_live/index.ex:292
+#: lib/typster_web/live/editor_live/index.ex:355
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2044,4 +2045,44 @@ msgstr ""
 #: lib/typster_web/live/editor_live/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:293
+#, elixir-autogen, elixir-format
+msgid "editor.flash.asset_deleted"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:262
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_deleted"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "editor.pinned"
+msgstr ""
+
+#: lib/typster_web/file_tree.ex:187
+#, elixir-autogen, elixir-format
+msgid "editor.tree.delete"
+msgstr ""
+
+#: lib/typster_web/file_tree.ex:185
+#, elixir-autogen, elixir-format
+msgid "editor.tree.delete_confirm"
+msgstr ""
+
+#: lib/typster_web/file_tree.ex:174
+#, elixir-autogen, elixir-format
+msgid "editor.tree.pin"
+msgstr ""
+
+#: lib/typster_web/file_tree.ex:159
+#, elixir-autogen, elixir-format
+msgid "editor.tree.pinned"
+msgstr ""
+
+#: lib/typster_web/file_tree.ex:173
+#, elixir-autogen, elixir-format
+msgid "editor.tree.unpin"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,96 +133,96 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:48
+#: lib/typster_web/live/editor_live/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:442
-#: lib/typster_web/live/editor_live/index.html.heex:443
+#: lib/typster_web/live/editor_live/index.html.heex:452
+#: lib/typster_web/live/editor_live/index.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:68
-#: lib/typster_web/live/editor_live/index.html.heex:132
+#: lib/typster_web/live/editor_live/index.html.heex:70
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:326
+#: lib/typster_web/live/editor_live/index.ex:350
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:323
+#: lib/typster_web/live/editor_live/index.ex:347
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:155
+#: lib/typster_web/live/editor_live/index.ex:179
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:380
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:206
-#: lib/typster_web/live/editor_live/index.ex:229
+#: lib/typster_web/live/editor_live/index.ex:230
+#: lib/typster_web/live/editor_live/index.ex:253
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:83
+#: lib/typster_web/live/editor_live/index.html.heex:85
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:265
+#: lib/typster_web/live/editor_live/index.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:137
+#: lib/typster_web/live/editor_live/index.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:430
+#: lib/typster_web/live/editor_live/index.ex:454
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:428
+#: lib/typster_web/live/editor_live/index.ex:452
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:429
+#: lib/typster_web/live/editor_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:225
-#: lib/typster_web/live/editor_live/index.html.heex:254
+#: lib/typster_web/live/editor_live/index.html.heex:235
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -509,164 +509,164 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:487
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:61
-#: lib/typster_web/live/editor_live/index.html.heex:62
+#: lib/typster_web/live/editor_live/index.html.heex:63
+#: lib/typster_web/live/editor_live/index.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:274
-#: lib/typster_web/live/editor_live/index.html.heex:275
+#: lib/typster_web/live/editor_live/index.html.heex:284
+#: lib/typster_web/live/editor_live/index.html.heex:285
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:303
+#: lib/typster_web/live/editor_live/index.html.heex:304
+#, elixir-autogen, elixir-format
+msgid "editor.format.heading"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
+#, elixir-autogen, elixir-format
+msgid "editor.format.image"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:293
 #: lib/typster_web/live/editor_live/index.html.heex:294
 #, elixir-autogen, elixir-format
-msgid "editor.format.heading"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:340
-#: lib/typster_web/live/editor_live/index.html.heex:341
-#, elixir-autogen, elixir-format
-msgid "editor.format.image"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:283
-#: lib/typster_web/live/editor_live/index.html.heex:284
-#, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:321
-#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:302
-#: lib/typster_web/live/editor_live/index.html.heex:303
-#, elixir-autogen, elixir-format
-msgid "editor.format.list"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:312
 #: lib/typster_web/live/editor_live/index.html.heex:313
 #, elixir-autogen, elixir-format
+msgid "editor.format.list"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:323
+#, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:330
-#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:202
+#: lib/typster_web/live/editor_live/index.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:205
+#: lib/typster_web/live/editor_live/index.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:508
-#: lib/typster_web/live/editor_live/index.html.heex:516
-#: lib/typster_web/live/editor_live/index.html.heex:525
+#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:556
-#: lib/typster_web/live/editor_live/index.html.heex:564
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:574
+#: lib/typster_web/live/editor_live/index.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:500
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:509
-#: lib/typster_web/live/editor_live/index.html.heex:529
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:519
+#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:434
+#: lib/typster_web/live/editor_live/index.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:41
+#: lib/typster_web/live/editor_live/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:39
+#: lib/typster_web/live/editor_live/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:417
+#: lib/typster_web/live/editor_live/index.html.heex:427
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:436
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -826,38 +826,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:391
+#: lib/typster_web/live/editor_live/index.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:380
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:389
+#: lib/typster_web/live/editor_live/index.html.heex:399
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:378
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:360
+#: lib/typster_web/live/editor_live/index.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1985,17 +1985,17 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr ""
@@ -2005,39 +2005,39 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:99
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:98
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:98
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:173
+#: lib/typster_web/live/editor_live/index.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:162
+#: lib/typster_web/live/editor_live/index.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:217
-#: lib/typster_web/live/editor_live/index.ex:355
+#: lib/typster_web/live/editor_live/index.ex:241
+#: lib/typster_web/live/editor_live/index.ex:379
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2047,17 +2047,17 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:293
+#: lib/typster_web/live/editor_live/index.ex:317
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:262
+#: lib/typster_web/live/editor_live/index.ex:286
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:124
+#: lib/typster_web/live/editor_live/index.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr ""
@@ -2086,3 +2086,10 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:209
+#, elixir-autogen, elixir-format
+msgid "%{count} section"
+msgid_plural "%{count} sections"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,7 +133,7 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
@@ -143,8 +143,8 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:417
-#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:420
+#: lib/typster_web/live/editor_live/index.html.heex:421
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
@@ -154,12 +154,12 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:251
+#: lib/typster_web/live/editor_live/index.ex:260
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:248
+#: lib/typster_web/live/editor_live/index.ex:257
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
@@ -169,13 +169,13 @@ msgstr ""
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:277
+#: lib/typster_web/live/editor_live/index.ex:290
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:208
-#: lib/typster_web/live/editor_live/index.ex:217
+#: lib/typster_web/live/editor_live/index.ex:206
+#: lib/typster_web/live/editor_live/index.ex:226
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -185,7 +185,7 @@ msgstr ""
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:240
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
@@ -195,33 +195,33 @@ msgstr ""
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:375
+#: lib/typster_web/live/editor_live/index.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:433
+#: lib/typster_web/live/editor_live/index.html.heex:436
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:337
+#: lib/typster_web/live/editor_live/index.ex:364
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:335
+#: lib/typster_web/live/editor_live/index.ex:362
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:336
+#: lib/typster_web/live/editor_live/index.ex:363
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:200
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:203
+#: lib/typster_web/live/editor_live/index.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -513,17 +513,17 @@ msgstr ""
 msgid "editor.command"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:452
+#: lib/typster_web/live/editor_live/index.html.heex:455
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -534,118 +534,118 @@ msgstr ""
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:249
-#: lib/typster_web/live/editor_live/index.html.heex:250
+#: lib/typster_web/live/editor_live/index.html.heex:252
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:268
-#: lib/typster_web/live/editor_live/index.html.heex:269
+#: lib/typster_web/live/editor_live/index.html.heex:271
+#: lib/typster_web/live/editor_live/index.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:315
-#: lib/typster_web/live/editor_live/index.html.heex:316
+#: lib/typster_web/live/editor_live/index.html.heex:318
+#: lib/typster_web/live/editor_live/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:296
-#: lib/typster_web/live/editor_live/index.html.heex:297
+#: lib/typster_web/live/editor_live/index.html.heex:299
+#: lib/typster_web/live/editor_live/index.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:277
-#: lib/typster_web/live/editor_live/index.html.heex:278
+#: lib/typster_web/live/editor_live/index.html.heex:280
+#: lib/typster_web/live/editor_live/index.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:287
-#: lib/typster_web/live/editor_live/index.html.heex:288
+#: lib/typster_web/live/editor_live/index.html.heex:290
+#: lib/typster_web/live/editor_live/index.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:305
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:309
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:177
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:483
-#: lib/typster_web/live/editor_live/index.html.heex:491
-#: lib/typster_web/live/editor_live/index.html.heex:500
+#: lib/typster_web/live/editor_live/index.html.heex:486
+#: lib/typster_web/live/editor_live/index.html.heex:494
+#: lib/typster_web/live/editor_live/index.html.heex:503
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:531
-#: lib/typster_web/live/editor_live/index.html.heex:539
-#: lib/typster_web/live/editor_live/index.html.heex:548
+#: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:514
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:484
-#: lib/typster_web/live/editor_live/index.html.heex:504
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:532
-#: lib/typster_web/live/editor_live/index.html.heex:551
-#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/live/editor_live/index.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:409
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -660,17 +660,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:401
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:397
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -830,38 +830,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:364
+#: lib/typster_web/live/editor_live/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:353
+#: lib/typster_web/live/editor_live/index.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:352
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:325
-#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:328
+#: lib/typster_web/live/editor_live/index.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -2030,7 +2030,7 @@ msgstr ""
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:148
+#: lib/typster_web/live/editor_live/index.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
@@ -2038,4 +2038,10 @@ msgstr ""
 #: lib/typster_web/live/editor_live/index.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:214
+#: lib/typster_web/live/editor_live/index.ex:289
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_exists"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,24 +133,24 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:50
+#: lib/typster_web/live/editor_live/index.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:142
+#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
@@ -181,27 +181,27 @@ msgstr ""
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:93
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:298
+#: lib/typster_web/live/editor_live/index.html.heex:311
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:147
+#: lib/typster_web/live/editor_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:433
+#: lib/typster_web/live/editor_live/index.html.heex:446
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:504
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
@@ -221,8 +221,8 @@ msgstr ""
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
-#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:271
+#: lib/typster_web/live/editor_live/index.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -303,7 +303,8 @@ msgid "nav.my_projects"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:164
-#: lib/typster_web/live/editor_live/index.html.heex:6
+#: lib/typster_web/live/editor_live/index.html.heex:8
+#: lib/typster_web/live/editor_live/index.html.heex:9
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
@@ -509,164 +510,164 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:445
+#: lib/typster_web/live/editor_live/index.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:63
-#: lib/typster_web/live/editor_live/index.html.heex:64
+#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:307
-#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:320
+#: lib/typster_web/live/editor_live/index.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:326
-#: lib/typster_web/live/editor_live/index.html.heex:327
+#: lib/typster_web/live/editor_live/index.html.heex:339
+#: lib/typster_web/live/editor_live/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:373
-#: lib/typster_web/live/editor_live/index.html.heex:374
+#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:316
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:330
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:335
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:345
-#: lib/typster_web/live/editor_live/index.html.heex:346
+#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:363
-#: lib/typster_web/live/editor_live/index.html.heex:364
+#: lib/typster_web/live/editor_live/index.html.heex:376
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:237
+#: lib/typster_web/live/editor_live/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:541
-#: lib/typster_web/live/editor_live/index.html.heex:549
-#: lib/typster_web/live/editor_live/index.html.heex:558
+#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:589
-#: lib/typster_web/live/editor_live/index.html.heex:597
-#: lib/typster_web/live/editor_live/index.html.heex:606
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:610
+#: lib/typster_web/live/editor_live/index.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:572
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:533
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:568
+#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:559
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:590
-#: lib/typster_web/live/editor_live/index.html.heex:609
-#: lib/typster_web/live/editor_live/index.html.heex:618
+#: lib/typster_web/live/editor_live/index.html.heex:603
+#: lib/typster_web/live/editor_live/index.html.heex:622
+#: lib/typster_web/live/editor_live/index.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:467
+#: lib/typster_web/live/editor_live/index.html.heex:480
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:43
+#: lib/typster_web/live/editor_live/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:41
+#: lib/typster_web/live/editor_live/index.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:472
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:455
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -826,38 +827,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:416
+#: lib/typster_web/live/editor_live/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:396
+#: lib/typster_web/live/editor_live/index.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1985,17 +1986,17 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:111
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:111
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:76
+#: lib/typster_web/live/editor_live/index.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr ""
@@ -2005,33 +2006,33 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:110
+#: lib/typster_web/live/editor_live/index.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:109
+#: lib/typster_web/live/editor_live/index.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
@@ -2043,7 +2044,7 @@ msgstr ""
 msgid "editor.flash.file_exists"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:26
+#: lib/typster_web/live/editor_live/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr ""
@@ -2058,7 +2059,7 @@ msgstr ""
 msgid "editor.flash.file_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr ""
@@ -2088,19 +2089,24 @@ msgstr ""
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:232
+#: lib/typster_web/live/editor_live/index.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:85
+#: lib/typster_web/live/editor_live/index.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:184
+#: lib/typster_web/live/editor_live/index.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "editor.breadcrumb"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -143,8 +143,8 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
-#: lib/typster_web/live/editor_live/index.html.heex:489
+#: lib/typster_web/live/editor_live/index.html.heex:515
+#: lib/typster_web/live/editor_live/index.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
@@ -155,28 +155,28 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:377
+#: lib/typster_web/live/editor_live/index.ex:423
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:374
+#: lib/typster_web/live/editor_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:166
+#: lib/typster_web/live/editor_live/index.ex:168
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:407
+#: lib/typster_web/live/editor_live/index.ex:454
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:257
-#: lib/typster_web/live/editor_live/index.ex:280
+#: lib/typster_web/live/editor_live/index.ex:295
+#: lib/typster_web/live/editor_live/index.ex:318
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -186,7 +186,7 @@ msgstr ""
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:311
+#: lib/typster_web/live/editor_live/index.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
@@ -196,27 +196,27 @@ msgstr ""
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:446
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:531
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:484
+#: lib/typster_web/live/editor_live/index.ex:531
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:529
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:483
+#: lib/typster_web/live/editor_live/index.ex:530
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -510,17 +510,17 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:454
+#: lib/typster_web/live/editor_live/index.html.heex:481
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -531,50 +531,50 @@ msgstr ""
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:320
-#: lib/typster_web/live/editor_live/index.html.heex:321
+#: lib/typster_web/live/editor_live/index.html.heex:347
+#: lib/typster_web/live/editor_live/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:339
-#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:329
-#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:356
+#: lib/typster_web/live/editor_live/index.html.heex:357
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:367
-#: lib/typster_web/live/editor_live/index.html.heex:368
+#: lib/typster_web/live/editor_live/index.html.heex:394
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:348
-#: lib/typster_web/live/editor_live/index.html.heex:349
+#: lib/typster_web/live/editor_live/index.html.heex:375
+#: lib/typster_web/live/editor_live/index.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
-#: lib/typster_web/live/editor_live/index.html.heex:359
+#: lib/typster_web/live/editor_live/index.html.heex:385
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:376
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
@@ -589,60 +589,60 @@ msgstr ""
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:554
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:610
-#: lib/typster_web/live/editor_live/index.html.heex:619
+#: lib/typster_web/live/editor_live/index.html.heex:629
+#: lib/typster_web/live/editor_live/index.html.heex:637
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:607
+#: lib/typster_web/live/editor_live/index.html.heex:634
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
-#: lib/typster_web/live/editor_live/index.html.heex:575
-#: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:582
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:559
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:603
-#: lib/typster_web/live/editor_live/index.html.heex:622
-#: lib/typster_web/live/editor_live/index.html.heex:631
+#: lib/typster_web/live/editor_live/index.html.heex:630
+#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:480
+#: lib/typster_web/live/editor_live/index.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -657,17 +657,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:463
+#: lib/typster_web/live/editor_live/index.html.heex:490
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:472
+#: lib/typster_web/live/editor_live/index.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -827,38 +827,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:429
+#: lib/typster_web/live/editor_live/index.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:435
+#: lib/typster_web/live/editor_live/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:396
-#: lib/typster_web/live/editor_live/index.html.heex:397
+#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -2037,9 +2037,9 @@ msgstr ""
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:227
-#: lib/typster_web/live/editor_live/index.ex:268
-#: lib/typster_web/live/editor_live/index.ex:406
+#: lib/typster_web/live/editor_live/index.ex:265
+#: lib/typster_web/live/editor_live/index.ex:306
+#: lib/typster_web/live/editor_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,12 +2049,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:344
+#: lib/typster_web/live/editor_live/index.ex:390
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:313
+#: lib/typster_web/live/editor_live/index.ex:359
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2080,6 +2080,7 @@ msgid "editor.tree.pin"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:181
+#: lib/typster_web/live/editor_live/index.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
@@ -2109,4 +2110,9 @@ msgstr ""
 #: lib/typster_web/live/editor_live/index.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "editor.breadcrumb"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:331
+#, elixir-autogen, elixir-format
+msgid "editor.tab.close"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,7 +133,7 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:266
+#: lib/typster_web/live/editor_live/index.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
@@ -143,8 +143,8 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:577
-#: lib/typster_web/live/editor_live/index.html.heex:578
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
@@ -155,28 +155,29 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:485
+#: lib/typster_web/live/editor_live/index.ex:466
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:463
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:176
+#: lib/typster_web/live/editor_live/index.ex:187
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:516
+#: lib/typster_web/live/editor_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:356
-#: lib/typster_web/live/editor_live/index.ex:380
+#: lib/typster_web/live/editor_live/index.ex:337
+#: lib/typster_web/live/editor_live/index.ex:361
+#: lib/typster_web/live/editor_live/index.ex:639
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -186,7 +187,7 @@ msgstr ""
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
@@ -196,33 +197,33 @@ msgstr ""
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:528
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:593
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:593
+#: lib/typster_web/live/editor_live/index.ex:574
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:591
+#: lib/typster_web/live/editor_live/index.ex:572
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:592
+#: lib/typster_web/live/editor_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:271
-#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:272
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -510,17 +511,17 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:540
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:543
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -531,118 +532,118 @@ msgstr ""
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:409
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:402
+#: lib/typster_web/live/editor_live/index.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:428
-#: lib/typster_web/live/editor_live/index.html.heex:429
+#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:418
-#: lib/typster_web/live/editor_live/index.html.heex:419
+#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:456
-#: lib/typster_web/live/editor_live/index.html.heex:457
+#: lib/typster_web/live/editor_live/index.html.heex:449
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
-#: lib/typster_web/live/editor_live/index.html.heex:438
+#: lib/typster_web/live/editor_live/index.html.heex:430
+#: lib/typster_web/live/editor_live/index.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:447
-#: lib/typster_web/live/editor_live/index.html.heex:448
+#: lib/typster_web/live/editor_live/index.html.heex:440
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
-#: lib/typster_web/live/editor_live/index.html.heex:466
+#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:459
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:250
+#: lib/typster_web/live/editor_live/index.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:643
-#: lib/typster_web/live/editor_live/index.html.heex:651
-#: lib/typster_web/live/editor_live/index.html.heex:660
+#: lib/typster_web/live/editor_live/index.html.heex:636
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:653
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
-#: lib/typster_web/live/editor_live/index.html.heex:699
-#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:688
+#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:705
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:674
+#: lib/typster_web/live/editor_live/index.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:635
+#: lib/typster_web/live/editor_live/index.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
-#: lib/typster_web/live/editor_live/index.html.heex:664
-#: lib/typster_web/live/editor_live/index.html.heex:670
+#: lib/typster_web/live/editor_live/index.html.heex:637
+#: lib/typster_web/live/editor_live/index.html.heex:661
+#: lib/typster_web/live/editor_live/index.html.heex:667
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:641
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:692
-#: lib/typster_web/live/editor_live/index.html.heex:711
-#: lib/typster_web/live/editor_live/index.html.heex:720
+#: lib/typster_web/live/editor_live/index.html.heex:689
+#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:532
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:569
+#: lib/typster_web/live/editor_live/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -657,17 +658,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -827,38 +828,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:519
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:515
+#: lib/typster_web/live/editor_live/index.html.heex:508
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:524
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:512
+#: lib/typster_web/live/editor_live/index.html.heex:505
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:485
-#: lib/typster_web/live/editor_live/index.html.heex:486
+#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -2027,19 +2028,19 @@ msgstr ""
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:326
-#: lib/typster_web/live/editor_live/index.ex:367
-#: lib/typster_web/live/editor_live/index.ex:515
+#: lib/typster_web/live/editor_live/index.ex:307
+#: lib/typster_web/live/editor_live/index.ex:348
+#: lib/typster_web/live/editor_live/index.ex:496
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,12 +2050,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:452
+#: lib/typster_web/live/editor_live/index.ex:433
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:421
+#: lib/typster_web/live/editor_live/index.ex:402
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2064,35 +2065,35 @@ msgstr ""
 msgid "editor.pinned"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:209
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/file_tree.ex:216
 #: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:207
+#: lib/typster_web/file_tree.ex:215
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:196
+#: lib/typster_web/file_tree.ex:200
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:181
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/file_tree.ex:186
+#: lib/typster_web/live/editor_live/index.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:195
+#: lib/typster_web/file_tree.ex:199
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:245
+#: lib/typster_web/live/editor_live/index.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2104,7 +2105,7 @@ msgstr[1] ""
 msgid "editor.new_folder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:194
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr ""
@@ -2114,34 +2115,24 @@ msgstr ""
 msgid "editor.breadcrumb"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:280
-#, elixir-autogen, elixir-format
-msgid "editor.flash.template_failed"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.ex:285
+#: lib/typster_web/live/editor_live/index.ex:589
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:362
-#, elixir-autogen, elixir-format
-msgid "editor.tpl.save"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:353
@@ -2149,8 +2140,13 @@ msgstr ""
 msgid "editor.tpl.upload"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:322
 #: lib/typster_web/live/editor_live/index.html.heex:323
+#: lib/typster_web/live/editor_live/index.html.heex:324
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:640
+#, elixir-autogen, elixir-format
+msgid "editor.flash.dropped_added"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,7 +133,7 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
@@ -143,86 +143,86 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:452
-#: lib/typster_web/live/editor_live/index.html.heex:453
+#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:350
+#: lib/typster_web/live/editor_live/index.ex:377
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:347
+#: lib/typster_web/live/editor_live/index.ex:374
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:179
+#: lib/typster_web/live/editor_live/index.ex:166
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:380
+#: lib/typster_web/live/editor_live/index.ex:407
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:230
-#: lib/typster_web/live/editor_live/index.ex:253
+#: lib/typster_web/live/editor_live/index.ex:257
+#: lib/typster_web/live/editor_live/index.ex:280
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:85
+#: lib/typster_web/live/editor_live/index.html.heex:93
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:275
+#: lib/typster_web/live/editor_live/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:139
+#: lib/typster_web/live/editor_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:454
+#: lib/typster_web/live/editor_live/index.ex:484
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:452
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:483
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:235
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -509,17 +509,17 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -530,118 +530,118 @@ msgstr ""
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:284
-#: lib/typster_web/live/editor_live/index.html.heex:285
+#: lib/typster_web/live/editor_live/index.html.heex:307
+#: lib/typster_web/live/editor_live/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:303
-#: lib/typster_web/live/editor_live/index.html.heex:304
+#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:373
+#: lib/typster_web/live/editor_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:293
-#: lib/typster_web/live/editor_live/index.html.heex:294
+#: lib/typster_web/live/editor_live/index.html.heex:316
+#: lib/typster_web/live/editor_live/index.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:331
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:312
-#: lib/typster_web/live/editor_live/index.html.heex:313
+#: lib/typster_web/live/editor_live/index.html.heex:335
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:322
-#: lib/typster_web/live/editor_live/index.html.heex:323
+#: lib/typster_web/live/editor_live/index.html.heex:345
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:340
-#: lib/typster_web/live/editor_live/index.html.heex:341
+#: lib/typster_web/live/editor_live/index.html.heex:363
+#: lib/typster_web/live/editor_live/index.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:207
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:214
+#: lib/typster_web/live/editor_live/index.html.heex:237
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
-#: lib/typster_web/live/editor_live/index.html.heex:526
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:541
+#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:566
-#: lib/typster_web/live/editor_live/index.html.heex:574
-#: lib/typster_web/live/editor_live/index.html.heex:583
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:597
+#: lib/typster_web/live/editor_live/index.html.heex:606
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:533
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:519
-#: lib/typster_web/live/editor_live/index.html.heex:539
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:568
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:567
-#: lib/typster_web/live/editor_live/index.html.heex:586
-#: lib/typster_web/live/editor_live/index.html.heex:595
+#: lib/typster_web/live/editor_live/index.html.heex:590
+#: lib/typster_web/live/editor_live/index.html.heex:609
+#: lib/typster_web/live/editor_live/index.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:444
+#: lib/typster_web/live/editor_live/index.html.heex:467
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -656,17 +656,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:427
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:436
+#: lib/typster_web/live/editor_live/index.html.heex:459
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:432
+#: lib/typster_web/live/editor_live/index.html.heex:455
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -826,38 +826,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:416
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:401
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:399
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:360
-#: lib/typster_web/live/editor_live/index.html.heex:361
+#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1985,12 +1985,12 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
@@ -2005,39 +2005,40 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:102
+#: lib/typster_web/live/editor_live/index.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:175
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:164
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:241
-#: lib/typster_web/live/editor_live/index.ex:379
+#: lib/typster_web/live/editor_live/index.ex:227
+#: lib/typster_web/live/editor_live/index.ex:268
+#: lib/typster_web/live/editor_live/index.ex:406
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2047,49 +2048,59 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:317
+#: lib/typster_web/live/editor_live/index.ex:344
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:286
+#: lib/typster_web/live/editor_live/index.ex:313
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:126
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:187
+#: lib/typster_web/file_tree.ex:209
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:185
+#: lib/typster_web/file_tree.ex:207
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:174
+#: lib/typster_web/file_tree.ex:196
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:159
+#: lib/typster_web/file_tree.ex:181
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:173
+#: lib/typster_web/file_tree.ex:195
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "editor.new_folder"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:184
+#, elixir-autogen, elixir-format
+msgid "editor.newfolder.placeholder"
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -143,41 +143,41 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:570
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:576
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:80
-#: lib/typster_web/live/editor_live/index.html.heex:152
+#: lib/typster_web/live/editor_live/index.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:466
+#: lib/typster_web/live/editor_live/index.ex:479
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:463
+#: lib/typster_web/live/editor_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:187
+#: lib/typster_web/live/editor_live/index.ex:193
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:497
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:337
-#: lib/typster_web/live/editor_live/index.ex:361
-#: lib/typster_web/live/editor_live/index.ex:639
+#: lib/typster_web/live/editor_live/index.ex:350
+#: lib/typster_web/live/editor_live/index.ex:374
+#: lib/typster_web/live/editor_live/index.ex:652
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -192,7 +192,7 @@ msgstr ""
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:157
+#: lib/typster_web/live/editor_live/index.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
@@ -202,22 +202,22 @@ msgstr ""
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:574
+#: lib/typster_web/live/editor_live/index.ex:587
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:572
+#: lib/typster_web/live/editor_live/index.ex:585
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:573
+#: lib/typster_web/live/editor_live/index.ex:586
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -511,17 +511,17 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:540
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:541
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -590,60 +590,60 @@ msgstr ""
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:636
-#: lib/typster_web/live/editor_live/index.html.heex:644
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:688
-#: lib/typster_web/live/editor_live/index.html.heex:696
-#: lib/typster_web/live/editor_live/index.html.heex:705
+#: lib/typster_web/live/editor_live/index.html.heex:693
+#: lib/typster_web/live/editor_live/index.html.heex:701
+#: lib/typster_web/live/editor_live/index.html.heex:710
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:671
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:693
+#: lib/typster_web/live/editor_live/index.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:628
+#: lib/typster_web/live/editor_live/index.html.heex:633
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:637
-#: lib/typster_web/live/editor_live/index.html.heex:661
-#: lib/typster_web/live/editor_live/index.html.heex:667
+#: lib/typster_web/live/editor_live/index.html.heex:642
+#: lib/typster_web/live/editor_live/index.html.heex:666
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:689
-#: lib/typster_web/live/editor_live/index.html.heex:708
-#: lib/typster_web/live/editor_live/index.html.heex:717
+#: lib/typster_web/live/editor_live/index.html.heex:694
+#: lib/typster_web/live/editor_live/index.html.heex:713
+#: lib/typster_web/live/editor_live/index.html.heex:722
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:532
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:567
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -658,17 +658,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:559
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -2028,19 +2028,19 @@ msgstr ""
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:307
-#: lib/typster_web/live/editor_live/index.ex:348
-#: lib/typster_web/live/editor_live/index.ex:496
+#: lib/typster_web/live/editor_live/index.ex:315
+#: lib/typster_web/live/editor_live/index.ex:361
+#: lib/typster_web/live/editor_live/index.ex:509
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2050,12 +2050,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:433
+#: lib/typster_web/live/editor_live/index.ex:446
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:402
+#: lib/typster_web/live/editor_live/index.ex:415
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2065,30 +2065,30 @@ msgstr ""
 msgid "editor.pinned"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:216
+#: lib/typster_web/file_tree.ex:218
 #: lib/typster_web/live/editor_live/index.html.heex:334
 #: lib/typster_web/live/editor_live/index.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:215
+#: lib/typster_web/file_tree.ex:217
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:200
+#: lib/typster_web/file_tree.ex:202
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:186
+#: lib/typster_web/file_tree.ex:188
 #: lib/typster_web/live/editor_live/index.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:199
+#: lib/typster_web/file_tree.ex:201
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr ""
@@ -2105,7 +2105,7 @@ msgstr[1] ""
 msgid "editor.new_folder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr ""
@@ -2120,7 +2120,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:589
+#: lib/typster_web/live/editor_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2146,7 +2146,14 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:640
+#: lib/typster_web/live/editor_live/index.ex:653
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:534
+#, elixir-autogen, elixir-format
+msgid "%{count} error"
+msgid_plural "%{count} errors"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,7 +133,7 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:267
+#: lib/typster_web/live/editor_live/index.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
@@ -143,8 +143,8 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:575
 #: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:577
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
@@ -155,12 +155,12 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:513
+#: lib/typster_web/live/editor_live/index.ex:546
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
@@ -170,14 +170,14 @@ msgstr ""
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:544
+#: lib/typster_web/live/editor_live/index.ex:577
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:384
 #: lib/typster_web/live/editor_live/index.ex:408
-#: lib/typster_web/live/editor_live/index.ex:686
+#: lib/typster_web/live/editor_live/index.ex:720
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -187,7 +187,7 @@ msgstr ""
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
@@ -197,33 +197,33 @@ msgstr ""
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:528
+#: lib/typster_web/live/editor_live/index.html.heex:529
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:591
+#: lib/typster_web/live/editor_live/index.html.heex:592
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:621
+#: lib/typster_web/live/editor_live/index.ex:654
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:619
+#: lib/typster_web/live/editor_live/index.ex:652
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:620
+#: lib/typster_web/live/editor_live/index.ex:653
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:272
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:273
+#: lib/typster_web/live/editor_live/index.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -511,12 +511,12 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:541
+#: lib/typster_web/live/editor_live/index.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -527,118 +527,118 @@ msgstr ""
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:402
 #: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:421
 #: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
 #: lib/typster_web/live/editor_live/index.html.heex:469
+#: lib/typster_web/live/editor_live/index.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
 #: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:449
 #: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:430
 #: lib/typster_web/live/editor_live/index.html.heex:431
+#: lib/typster_web/live/editor_live/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:440
 #: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
 #: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:244
+#: lib/typster_web/live/editor_live/index.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:251
+#: lib/typster_web/live/editor_live/index.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:757
-#: lib/typster_web/live/editor_live/index.html.heex:765
-#: lib/typster_web/live/editor_live/index.html.heex:774
+#: lib/typster_web/live/editor_live/index.html.heex:758
+#: lib/typster_web/live/editor_live/index.html.heex:766
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:809
-#: lib/typster_web/live/editor_live/index.html.heex:817
-#: lib/typster_web/live/editor_live/index.html.heex:826
+#: lib/typster_web/live/editor_live/index.html.heex:810
+#: lib/typster_web/live/editor_live/index.html.heex:818
+#: lib/typster_web/live/editor_live/index.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:792
+#: lib/typster_web/live/editor_live/index.html.heex:793
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:814
+#: lib/typster_web/live/editor_live/index.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:758
-#: lib/typster_web/live/editor_live/index.html.heex:782
-#: lib/typster_web/live/editor_live/index.html.heex:788
+#: lib/typster_web/live/editor_live/index.html.heex:759
+#: lib/typster_web/live/editor_live/index.html.heex:783
+#: lib/typster_web/live/editor_live/index.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:762
+#: lib/typster_web/live/editor_live/index.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:810
-#: lib/typster_web/live/editor_live/index.html.heex:829
-#: lib/typster_web/live/editor_live/index.html.heex:838
+#: lib/typster_web/live/editor_live/index.html.heex:811
+#: lib/typster_web/live/editor_live/index.html.heex:830
+#: lib/typster_web/live/editor_live/index.html.heex:839
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:568
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -653,17 +653,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:559
+#: lib/typster_web/live/editor_live/index.html.heex:560
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -823,38 +823,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:511
+#: lib/typster_web/live/editor_live/index.html.heex:512
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:519
+#: lib/typster_web/live/editor_live/index.html.heex:520
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:508
+#: lib/typster_web/live/editor_live/index.html.heex:509
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:506
+#: lib/typster_web/live/editor_live/index.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:505
+#: lib/typster_web/live/editor_live/index.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:478
 #: lib/typster_web/live/editor_live/index.html.heex:479
+#: lib/typster_web/live/editor_live/index.html.heex:480
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -2035,7 +2035,7 @@ msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:349
 #: lib/typster_web/live/editor_live/index.ex:395
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:576
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2045,12 +2045,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:480
+#: lib/typster_web/live/editor_live/index.ex:513
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:449
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2060,35 +2060,35 @@ msgstr ""
 msgid "editor.pinned"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:218
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/file_tree.ex:224
 #: lib/typster_web/live/editor_live/index.html.heex:335
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:217
+#: lib/typster_web/file_tree.ex:223
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:202
+#: lib/typster_web/file_tree.ex:208
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:188
-#: lib/typster_web/live/editor_live/index.html.heex:373
+#: lib/typster_web/file_tree.ex:194
+#: lib/typster_web/live/editor_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
 
-#: lib/typster_web/file_tree.ex:201
+#: lib/typster_web/file_tree.ex:207
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:246
+#: lib/typster_web/live/editor_live/index.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2110,110 +2110,120 @@ msgstr ""
 msgid "editor.breadcrumb"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:670
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:307
+#: lib/typster_web/live/editor_live/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:353
+#: lib/typster_web/live/editor_live/index.html.heex:354
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:323
 #: lib/typster_web/live/editor_live/index.html.heex:324
+#: lib/typster_web/live/editor_live/index.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:687
+#: lib/typster_web/live/editor_live/index.ex:721
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:789
-#: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:722
+#: lib/typster_web/live/editor_live/index.ex:846
+#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:723
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:791
+#: lib/typster_web/live/editor_live/index.ex:848
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:795
+#: lib/typster_web/live/editor_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:654
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:630
+#: lib/typster_web/live/editor_live/index.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:605
-#: lib/typster_web/live/editor_live/index.html.heex:724
+#: lib/typster_web/live/editor_live/index.html.heex:606
+#: lib/typster_web/live/editor_live/index.html.heex:725
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:662
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:614
+#: lib/typster_web/live/editor_live/index.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:715
+#: lib/typster_web/live/editor_live/index.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:635
+#: lib/typster_web/live/editor_live/index.html.heex:636
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:633
+#: lib/typster_web/live/editor_live/index.html.heex:634
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:443
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_moved"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:453
+#, elixir-autogen, elixir-format
+msgid "editor.flash.move_conflict"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -585,50 +585,50 @@ msgstr ""
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:744
-#: lib/typster_web/live/editor_live/index.html.heex:752
-#: lib/typster_web/live/editor_live/index.html.heex:761
+#: lib/typster_web/live/editor_live/index.html.heex:757
+#: lib/typster_web/live/editor_live/index.html.heex:765
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:796
-#: lib/typster_web/live/editor_live/index.html.heex:804
-#: lib/typster_web/live/editor_live/index.html.heex:813
+#: lib/typster_web/live/editor_live/index.html.heex:809
+#: lib/typster_web/live/editor_live/index.html.heex:817
+#: lib/typster_web/live/editor_live/index.html.heex:826
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:779
+#: lib/typster_web/live/editor_live/index.html.heex:792
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:801
+#: lib/typster_web/live/editor_live/index.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:736
+#: lib/typster_web/live/editor_live/index.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:769
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:758
+#: lib/typster_web/live/editor_live/index.html.heex:782
+#: lib/typster_web/live/editor_live/index.html.heex:788
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:762
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:797
-#: lib/typster_web/live/editor_live/index.html.heex:816
-#: lib/typster_web/live/editor_live/index.html.heex:825
+#: lib/typster_web/live/editor_live/index.html.heex:810
+#: lib/typster_web/live/editor_live/index.html.heex:829
+#: lib/typster_web/live/editor_live/index.html.heex:838
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
@@ -2148,31 +2148,31 @@ msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:789
 #: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:709
+#: lib/typster_web/live/editor_live/index.html.heex:722
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:790
+#: lib/typster_web/live/editor_live/index.ex:791
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:793
+#: lib/typster_web/live/editor_live/index.ex:795
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:638
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr ""
@@ -2183,17 +2183,17 @@ msgid "editor.drawer.jump_first"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:605
-#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:662
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:662
+#: lib/typster_web/live/editor_live/index.html.heex:675
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr ""
@@ -2203,7 +2203,17 @@ msgstr ""
 msgid "editor.drawer.problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:702
+#: lib/typster_web/live/editor_live/index.html.heex:715
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:635
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.delay_off"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:633
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.recompile"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -143,8 +143,8 @@ msgstr ""
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:515
-#: lib/typster_web/live/editor_live/index.html.heex:516
+#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
@@ -155,28 +155,28 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:423
+#: lib/typster_web/live/editor_live/index.ex:485
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:420
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:168
+#: lib/typster_web/live/editor_live/index.ex:176
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:454
+#: lib/typster_web/live/editor_live/index.ex:516
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:295
-#: lib/typster_web/live/editor_live/index.ex:318
+#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:380
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -186,7 +186,7 @@ msgstr ""
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
@@ -196,27 +196,27 @@ msgstr ""
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:473
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:531
+#: lib/typster_web/live/editor_live/index.html.heex:593
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:531
+#: lib/typster_web/live/editor_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:529
+#: lib/typster_web/live/editor_live/index.ex:591
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:530
+#: lib/typster_web/live/editor_live/index.ex:592
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -510,17 +510,17 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:485
+#: lib/typster_web/live/editor_live/index.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:481
+#: lib/typster_web/live/editor_live/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
@@ -531,50 +531,50 @@ msgstr ""
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:347
-#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:409
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
-#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:428
+#: lib/typster_web/live/editor_live/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:356
-#: lib/typster_web/live/editor_live/index.html.heex:357
+#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:394
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:456
+#: lib/typster_web/live/editor_live/index.html.heex:457
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:375
-#: lib/typster_web/live/editor_live/index.html.heex:376
+#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:438
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:385
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:447
+#: lib/typster_web/live/editor_live/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:466
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
@@ -589,60 +589,60 @@ msgstr ""
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:581
-#: lib/typster_web/live/editor_live/index.html.heex:589
-#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:643
+#: lib/typster_web/live/editor_live/index.html.heex:651
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:629
-#: lib/typster_web/live/editor_live/index.html.heex:637
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:699
+#: lib/typster_web/live/editor_live/index.html.heex:708
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:674
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:634
+#: lib/typster_web/live/editor_live/index.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:582
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:608
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:670
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:630
-#: lib/typster_web/live/editor_live/index.html.heex:649
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:692
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:720
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:569
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
@@ -657,17 +657,17 @@ msgstr ""
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:490
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:499
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:495
+#: lib/typster_web/live/editor_live/index.html.heex:557
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -827,38 +827,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:456
+#: lib/typster_web/live/editor_live/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:464
+#: lib/typster_web/live/editor_live/index.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:453
+#: lib/typster_web/live/editor_live/index.html.heex:515
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:462
+#: lib/typster_web/live/editor_live/index.html.heex:524
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:512
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:423
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:485
+#: lib/typster_web/live/editor_live/index.html.heex:486
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -2037,9 +2037,9 @@ msgstr ""
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:265
-#: lib/typster_web/live/editor_live/index.ex:306
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:326
+#: lib/typster_web/live/editor_live/index.ex:367
+#: lib/typster_web/live/editor_live/index.ex:515
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,12 +2049,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:390
+#: lib/typster_web/live/editor_live/index.ex:452
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:359
+#: lib/typster_web/live/editor_live/index.ex:421
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2065,6 +2065,8 @@ msgid "editor.pinned"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:209
+#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
@@ -2080,7 +2082,7 @@ msgid "editor.tree.pin"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:181
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
@@ -2112,7 +2114,43 @@ msgstr ""
 msgid "editor.breadcrumb"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:280
+#, elixir-autogen, elixir-format
+msgid "editor.flash.template_failed"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:285
+#, elixir-autogen, elixir-format
+msgid "editor.flash.template_saved"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:306
+#, elixir-autogen, elixir-format
+msgid "editor.templates"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:332
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.delete_confirm"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:362
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.save"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:353
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.upload"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:323
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.use"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,33 +133,33 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:38
+#: lib/typster_web/live/editor_live/index.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:420
-#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:430
+#: lib/typster_web/live/editor_live/index.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:58
+#: lib/typster_web/live/editor_live/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:263
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:257
+#: lib/typster_web/live/editor_live/index.ex:260
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
@@ -169,59 +169,59 @@ msgstr ""
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:290
+#: lib/typster_web/live/editor_live/index.ex:293
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:206
-#: lib/typster_web/live/editor_live/index.ex:226
+#: lib/typster_web/live/editor_live/index.ex:229
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:83
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:115
+#: lib/typster_web/live/editor_live/index.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:378
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:436
+#: lib/typster_web/live/editor_live/index.html.heex:446
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:364
+#: lib/typster_web/live/editor_live/index.ex:367
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:362
+#: lib/typster_web/live/editor_live/index.ex:365
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:363
+#: lib/typster_web/live/editor_live/index.ex:366
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:203
-#: lib/typster_web/live/editor_live/index.html.heex:232
+#: lib/typster_web/live/editor_live/index.html.heex:213
+#: lib/typster_web/live/editor_live/index.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
@@ -508,169 +508,164 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:23
-#, elixir-autogen, elixir-format
-msgid "editor.command"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:455
+#: lib/typster_web/live/editor_live/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:51
-#: lib/typster_web/live/editor_live/index.html.heex:52
+#: lib/typster_web/live/editor_live/index.html.heex:61
+#: lib/typster_web/live/editor_live/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:252
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:262
+#: lib/typster_web/live/editor_live/index.html.heex:263
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:281
+#: lib/typster_web/live/editor_live/index.html.heex:282
+#, elixir-autogen, elixir-format
+msgid "editor.format.heading"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:328
+#: lib/typster_web/live/editor_live/index.html.heex:329
+#, elixir-autogen, elixir-format
+msgid "editor.format.image"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:271
 #: lib/typster_web/live/editor_live/index.html.heex:272
 #, elixir-autogen, elixir-format
-msgid "editor.format.heading"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:318
-#: lib/typster_web/live/editor_live/index.html.heex:319
-#, elixir-autogen, elixir-format
-msgid "editor.format.image"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:261
-#: lib/typster_web/live/editor_live/index.html.heex:262
-#, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:299
-#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:280
-#: lib/typster_web/live/editor_live/index.html.heex:281
-#, elixir-autogen, elixir-format
-msgid "editor.format.list"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:290
 #: lib/typster_web/live/editor_live/index.html.heex:291
 #, elixir-autogen, elixir-format
+msgid "editor.format.list"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:301
+#, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:308
-#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:318
+#: lib/typster_web/live/editor_live/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:183
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:486
-#: lib/typster_web/live/editor_live/index.html.heex:494
-#: lib/typster_web/live/editor_live/index.html.heex:503
+#: lib/typster_web/live/editor_live/index.html.heex:496
+#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:542
-#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:544
+#: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
-#: lib/typster_web/live/editor_live/index.html.heex:507
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:497
+#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:535
-#: lib/typster_web/live/editor_live/index.html.heex:554
-#: lib/typster_web/live/editor_live/index.html.heex:563
+#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:564
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:382
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:31
+#: lib/typster_web/live/editor_live/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:29
+#: lib/typster_web/live/editor_live/index.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:405
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -830,38 +825,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:361
+#: lib/typster_web/live/editor_live/index.html.heex:371
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:369
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:356
+#: lib/typster_web/live/editor_live/index.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:328
-#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:339
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1989,17 +1984,17 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:64
+#: lib/typster_web/live/editor_live/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr ""
@@ -2009,39 +2004,44 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:90
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:89
+#: lib/typster_web/live/editor_live/index.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:151
+#: lib/typster_web/live/editor_live/index.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:140
+#: lib/typster_web/live/editor_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:214
-#: lib/typster_web/live/editor_live/index.ex:289
+#: lib/typster_web/live/editor_live/index.ex:217
+#: lib/typster_web/live/editor_live/index.ex:292
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "editor.command_open"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -143,8 +143,8 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:515
-#: lib/typster_web/live/editor_live/index.html.heex:516
+#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
@@ -155,28 +155,28 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:423
+#: lib/typster_web/live/editor_live/index.ex:485
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:420
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:168
+#: lib/typster_web/live/editor_live/index.ex:176
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:454
+#: lib/typster_web/live/editor_live/index.ex:516
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:295
-#: lib/typster_web/live/editor_live/index.ex:318
+#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:380
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -186,7 +186,7 @@ msgstr "Unsupported file format."
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
@@ -196,27 +196,27 @@ msgstr "No file selected"
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:473
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:531
+#: lib/typster_web/live/editor_live/index.html.heex:593
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:531
+#: lib/typster_web/live/editor_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:529
+#: lib/typster_web/live/editor_live/index.ex:591
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:530
+#: lib/typster_web/live/editor_live/index.ex:592
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -510,17 +510,17 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:485
+#: lib/typster_web/live/editor_live/index.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:481
+#: lib/typster_web/live/editor_live/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -531,50 +531,50 @@ msgstr "Compiling…"
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:347
-#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:409
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
-#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:428
+#: lib/typster_web/live/editor_live/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:356
-#: lib/typster_web/live/editor_live/index.html.heex:357
+#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:394
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:456
+#: lib/typster_web/live/editor_live/index.html.heex:457
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:375
-#: lib/typster_web/live/editor_live/index.html.heex:376
+#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:438
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:385
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:447
+#: lib/typster_web/live/editor_live/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:466
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
@@ -589,60 +589,60 @@ msgstr "Outline"
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:581
-#: lib/typster_web/live/editor_live/index.html.heex:589
-#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:643
+#: lib/typster_web/live/editor_live/index.html.heex:651
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:629
-#: lib/typster_web/live/editor_live/index.html.heex:637
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:699
+#: lib/typster_web/live/editor_live/index.html.heex:708
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:674
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:634
+#: lib/typster_web/live/editor_live/index.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:582
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:608
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:670
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:630
-#: lib/typster_web/live/editor_live/index.html.heex:649
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:692
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:720
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:569
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -657,17 +657,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:490
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:499
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:495
+#: lib/typster_web/live/editor_live/index.html.heex:557
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -827,38 +827,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:456
+#: lib/typster_web/live/editor_live/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:464
+#: lib/typster_web/live/editor_live/index.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:453
+#: lib/typster_web/live/editor_live/index.html.heex:515
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:462
+#: lib/typster_web/live/editor_live/index.html.heex:524
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:512
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:423
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:485
+#: lib/typster_web/live/editor_live/index.html.heex:486
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -2037,9 +2037,9 @@ msgstr "Appended when you press Enter"
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:265
-#: lib/typster_web/live/editor_live/index.ex:306
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:326
+#: lib/typster_web/live/editor_live/index.ex:367
+#: lib/typster_web/live/editor_live/index.ex:515
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,12 +2049,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:390
+#: lib/typster_web/live/editor_live/index.ex:452
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:359
+#: lib/typster_web/live/editor_live/index.ex:421
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2065,6 +2065,8 @@ msgid "editor.pinned"
 msgstr "Pinned"
 
 #: lib/typster_web/file_tree.ex:209
+#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
@@ -2080,7 +2082,7 @@ msgid "editor.tree.pin"
 msgstr "Pin file"
 
 #: lib/typster_web/file_tree.ex:181
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
@@ -2112,7 +2114,43 @@ msgstr "folder name"
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
 
-#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Close tab"
+
+#: lib/typster_web/live/editor_live/index.ex:280
+#, elixir-autogen, elixir-format
+msgid "editor.flash.template_failed"
+msgstr "Could not save the template."
+
+#: lib/typster_web/live/editor_live/index.ex:285
+#, elixir-autogen, elixir-format
+msgid "editor.flash.template_saved"
+msgstr "Template saved."
+
+#: lib/typster_web/live/editor_live/index.html.heex:306
+#, elixir-autogen, elixir-format
+msgid "editor.templates"
+msgstr "Your templates"
+
+#: lib/typster_web/live/editor_live/index.html.heex:332
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.delete_confirm"
+msgstr "Remove this template?"
+
+#: lib/typster_web/live/editor_live/index.html.heex:362
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.save"
+msgstr "Save template"
+
+#: lib/typster_web/live/editor_live/index.html.heex:353
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.upload"
+msgstr "Upload a file to reuse"
+
+#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:323
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.use"
+msgstr "Start a file from this template"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -155,29 +155,29 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:479
+#: lib/typster_web/live/editor_live/index.ex:513
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:476
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:193
+#: lib/typster_web/live/editor_live/index.ex:227
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:544
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:350
-#: lib/typster_web/live/editor_live/index.ex:374
-#: lib/typster_web/live/editor_live/index.ex:652
+#: lib/typster_web/live/editor_live/index.ex:384
+#: lib/typster_web/live/editor_live/index.ex:408
+#: lib/typster_web/live/editor_live/index.ex:686
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -207,17 +207,17 @@ msgstr "Preview"
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:587
+#: lib/typster_web/live/editor_live/index.ex:621
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:585
+#: lib/typster_web/live/editor_live/index.ex:619
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:586
+#: lib/typster_web/live/editor_live/index.ex:620
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -511,11 +511,6 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:610
-#, elixir-autogen, elixir-format
-msgid "editor.command_hint"
-msgstr "⌘K to run command"
-
 #: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
@@ -590,50 +585,50 @@ msgstr "Outline"
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
-#: lib/typster_web/live/editor_live/index.html.heex:649
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:744
+#: lib/typster_web/live/editor_live/index.html.heex:752
+#: lib/typster_web/live/editor_live/index.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:693
-#: lib/typster_web/live/editor_live/index.html.heex:701
-#: lib/typster_web/live/editor_live/index.html.heex:710
+#: lib/typster_web/live/editor_live/index.html.heex:796
+#: lib/typster_web/live/editor_live/index.html.heex:804
+#: lib/typster_web/live/editor_live/index.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:779
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:698
+#: lib/typster_web/live/editor_live/index.html.heex:801
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:633
+#: lib/typster_web/live/editor_live/index.html.heex:736
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:642
-#: lib/typster_web/live/editor_live/index.html.heex:666
-#: lib/typster_web/live/editor_live/index.html.heex:672
+#: lib/typster_web/live/editor_live/index.html.heex:745
+#: lib/typster_web/live/editor_live/index.html.heex:769
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:694
-#: lib/typster_web/live/editor_live/index.html.heex:713
-#: lib/typster_web/live/editor_live/index.html.heex:722
+#: lib/typster_web/live/editor_live/index.html.heex:797
+#: lib/typster_web/live/editor_live/index.html.heex:816
+#: lib/typster_web/live/editor_live/index.html.heex:825
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
@@ -2038,9 +2033,9 @@ msgstr "Appended when you press Enter"
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:315
-#: lib/typster_web/live/editor_live/index.ex:361
-#: lib/typster_web/live/editor_live/index.ex:509
+#: lib/typster_web/live/editor_live/index.ex:349
+#: lib/typster_web/live/editor_live/index.ex:395
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2050,12 +2045,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:446
+#: lib/typster_web/live/editor_live/index.ex:480
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:415
+#: lib/typster_web/live/editor_live/index.ex:449
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2120,7 +2115,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:602
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2146,14 +2141,69 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:653
+#: lib/typster_web/live/editor_live/index.ex:687
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
+#: lib/typster_web/live/editor_live/index.ex:789
 #: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:709
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
+
+#: lib/typster_web/live/editor_live/index.ex:790
+#, elixir-autogen, elixir-format
+msgid "%{count} warning"
+msgid_plural "%{count} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/typster_web/live/editor_live/index.ex:793
+#, elixir-autogen, elixir-format
+msgid "editor.compile_failed"
+msgstr "Compile failed"
+
+#: lib/typster_web/live/editor_live/index.html.heex:638
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.clear"
+msgstr "Clear log"
+
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.close"
+msgstr "Close panel"
+
+#: lib/typster_web/live/editor_live/index.html.heex:630
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.jump_first"
+msgstr "Jump to first"
+
+#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.log"
+msgstr "Compile log"
+
+#: lib/typster_web/live/editor_live/index.html.heex:652
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.log_empty"
+msgstr "No compiles yet"
+
+#: lib/typster_web/live/editor_live/index.html.heex:662
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.no_problems"
+msgstr "No problems"
+
+#: lib/typster_web/live/editor_live/index.html.heex:614
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.problems"
+msgstr "Problems"
+
+#: lib/typster_web/live/editor_live/index.html.heex:702
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.toggle"
+msgstr "Toggle compile panel"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -143,8 +143,8 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
-#: lib/typster_web/live/editor_live/index.html.heex:489
+#: lib/typster_web/live/editor_live/index.html.heex:515
+#: lib/typster_web/live/editor_live/index.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
@@ -155,28 +155,28 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:377
+#: lib/typster_web/live/editor_live/index.ex:423
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:374
+#: lib/typster_web/live/editor_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:166
+#: lib/typster_web/live/editor_live/index.ex:168
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:407
+#: lib/typster_web/live/editor_live/index.ex:454
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:257
-#: lib/typster_web/live/editor_live/index.ex:280
+#: lib/typster_web/live/editor_live/index.ex:295
+#: lib/typster_web/live/editor_live/index.ex:318
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -186,7 +186,7 @@ msgstr "Unsupported file format."
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:311
+#: lib/typster_web/live/editor_live/index.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
@@ -196,27 +196,27 @@ msgstr "No file selected"
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:446
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:531
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:484
+#: lib/typster_web/live/editor_live/index.ex:531
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:529
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:483
+#: lib/typster_web/live/editor_live/index.ex:530
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -510,17 +510,17 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:454
+#: lib/typster_web/live/editor_live/index.html.heex:481
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -531,50 +531,50 @@ msgstr "Compiling…"
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:320
-#: lib/typster_web/live/editor_live/index.html.heex:321
+#: lib/typster_web/live/editor_live/index.html.heex:347
+#: lib/typster_web/live/editor_live/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:339
-#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:329
-#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:356
+#: lib/typster_web/live/editor_live/index.html.heex:357
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:367
-#: lib/typster_web/live/editor_live/index.html.heex:368
+#: lib/typster_web/live/editor_live/index.html.heex:394
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:348
-#: lib/typster_web/live/editor_live/index.html.heex:349
+#: lib/typster_web/live/editor_live/index.html.heex:375
+#: lib/typster_web/live/editor_live/index.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
-#: lib/typster_web/live/editor_live/index.html.heex:359
+#: lib/typster_web/live/editor_live/index.html.heex:385
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:376
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
@@ -589,60 +589,60 @@ msgstr "Outline"
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:554
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:610
-#: lib/typster_web/live/editor_live/index.html.heex:619
+#: lib/typster_web/live/editor_live/index.html.heex:629
+#: lib/typster_web/live/editor_live/index.html.heex:637
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:607
+#: lib/typster_web/live/editor_live/index.html.heex:634
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
-#: lib/typster_web/live/editor_live/index.html.heex:575
-#: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:582
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:559
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:603
-#: lib/typster_web/live/editor_live/index.html.heex:622
-#: lib/typster_web/live/editor_live/index.html.heex:631
+#: lib/typster_web/live/editor_live/index.html.heex:630
+#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:480
+#: lib/typster_web/live/editor_live/index.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -657,17 +657,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:463
+#: lib/typster_web/live/editor_live/index.html.heex:490
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:472
+#: lib/typster_web/live/editor_live/index.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -827,38 +827,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:429
+#: lib/typster_web/live/editor_live/index.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:435
+#: lib/typster_web/live/editor_live/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:396
-#: lib/typster_web/live/editor_live/index.html.heex:397
+#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -2037,9 +2037,9 @@ msgstr "Appended when you press Enter"
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:227
-#: lib/typster_web/live/editor_live/index.ex:268
-#: lib/typster_web/live/editor_live/index.ex:406
+#: lib/typster_web/live/editor_live/index.ex:265
+#: lib/typster_web/live/editor_live/index.ex:306
+#: lib/typster_web/live/editor_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,12 +2049,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:344
+#: lib/typster_web/live/editor_live/index.ex:390
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:313
+#: lib/typster_web/live/editor_live/index.ex:359
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2080,6 +2080,7 @@ msgid "editor.tree.pin"
 msgstr "Pin file"
 
 #: lib/typster_web/file_tree.ex:181
+#: lib/typster_web/live/editor_live/index.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
@@ -2110,3 +2111,8 @@ msgstr "folder name"
 #, elixir-autogen, elixir-format
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
+
+#: lib/typster_web/live/editor_live/index.html.heex:331
+#, elixir-autogen, elixir-format
+msgid "editor.tab.close"
+msgstr "Close tab"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:266
+#: lib/typster_web/live/editor_live/index.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
@@ -143,8 +143,8 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:577
-#: lib/typster_web/live/editor_live/index.html.heex:578
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
@@ -155,28 +155,29 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:485
+#: lib/typster_web/live/editor_live/index.ex:466
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:463
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:176
+#: lib/typster_web/live/editor_live/index.ex:187
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:516
+#: lib/typster_web/live/editor_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:356
-#: lib/typster_web/live/editor_live/index.ex:380
+#: lib/typster_web/live/editor_live/index.ex:337
+#: lib/typster_web/live/editor_live/index.ex:361
+#: lib/typster_web/live/editor_live/index.ex:639
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -186,7 +187,7 @@ msgstr "Unsupported file format."
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
@@ -196,33 +197,33 @@ msgstr "No file selected"
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:528
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:593
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:593
+#: lib/typster_web/live/editor_live/index.ex:574
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:591
+#: lib/typster_web/live/editor_live/index.ex:572
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:592
+#: lib/typster_web/live/editor_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:271
-#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:272
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -510,17 +511,17 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:540
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:543
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -531,118 +532,118 @@ msgstr "Compiling…"
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:409
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:402
+#: lib/typster_web/live/editor_live/index.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:428
-#: lib/typster_web/live/editor_live/index.html.heex:429
+#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:418
-#: lib/typster_web/live/editor_live/index.html.heex:419
+#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:456
-#: lib/typster_web/live/editor_live/index.html.heex:457
+#: lib/typster_web/live/editor_live/index.html.heex:449
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
-#: lib/typster_web/live/editor_live/index.html.heex:438
+#: lib/typster_web/live/editor_live/index.html.heex:430
+#: lib/typster_web/live/editor_live/index.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:447
-#: lib/typster_web/live/editor_live/index.html.heex:448
+#: lib/typster_web/live/editor_live/index.html.heex:440
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
-#: lib/typster_web/live/editor_live/index.html.heex:466
+#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:459
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:250
+#: lib/typster_web/live/editor_live/index.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:643
-#: lib/typster_web/live/editor_live/index.html.heex:651
-#: lib/typster_web/live/editor_live/index.html.heex:660
+#: lib/typster_web/live/editor_live/index.html.heex:636
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:653
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
-#: lib/typster_web/live/editor_live/index.html.heex:699
-#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:688
+#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:705
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:674
+#: lib/typster_web/live/editor_live/index.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:635
+#: lib/typster_web/live/editor_live/index.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
-#: lib/typster_web/live/editor_live/index.html.heex:664
-#: lib/typster_web/live/editor_live/index.html.heex:670
+#: lib/typster_web/live/editor_live/index.html.heex:637
+#: lib/typster_web/live/editor_live/index.html.heex:661
+#: lib/typster_web/live/editor_live/index.html.heex:667
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:641
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:692
-#: lib/typster_web/live/editor_live/index.html.heex:711
-#: lib/typster_web/live/editor_live/index.html.heex:720
+#: lib/typster_web/live/editor_live/index.html.heex:689
+#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:532
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:569
+#: lib/typster_web/live/editor_live/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -657,17 +658,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -827,38 +828,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:519
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:515
+#: lib/typster_web/live/editor_live/index.html.heex:508
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:524
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:512
+#: lib/typster_web/live/editor_live/index.html.heex:505
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:485
-#: lib/typster_web/live/editor_live/index.html.heex:486
+#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -2027,19 +2028,19 @@ msgstr "Tree"
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:326
-#: lib/typster_web/live/editor_live/index.ex:367
-#: lib/typster_web/live/editor_live/index.ex:515
+#: lib/typster_web/live/editor_live/index.ex:307
+#: lib/typster_web/live/editor_live/index.ex:348
+#: lib/typster_web/live/editor_live/index.ex:496
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,12 +2050,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:452
+#: lib/typster_web/live/editor_live/index.ex:433
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:421
+#: lib/typster_web/live/editor_live/index.ex:402
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2064,35 +2065,35 @@ msgstr "File deleted."
 msgid "editor.pinned"
 msgstr "Pinned"
 
-#: lib/typster_web/file_tree.ex:209
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/file_tree.ex:216
 #: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
 
-#: lib/typster_web/file_tree.ex:207
+#: lib/typster_web/file_tree.ex:215
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr "Delete this file? This can't be undone."
 
-#: lib/typster_web/file_tree.ex:196
+#: lib/typster_web/file_tree.ex:200
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr "Pin file"
 
-#: lib/typster_web/file_tree.ex:181
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/file_tree.ex:186
+#: lib/typster_web/live/editor_live/index.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
 
-#: lib/typster_web/file_tree.ex:195
+#: lib/typster_web/file_tree.ex:199
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:245
+#: lib/typster_web/live/editor_live/index.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2104,7 +2105,7 @@ msgstr[1] "%{count} sections"
 msgid "editor.new_folder"
 msgstr "New folder"
 
-#: lib/typster_web/live/editor_live/index.html.heex:194
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "folder name"
@@ -2114,43 +2115,38 @@ msgstr "folder name"
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:280
-#, elixir-autogen, elixir-format
-msgid "editor.flash.template_failed"
-msgstr "Could not save the template."
-
-#: lib/typster_web/live/editor_live/index.ex:285
+#: lib/typster_web/live/editor_live/index.ex:589
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
 
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Your templates"
 
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Remove this template?"
-
-#: lib/typster_web/live/editor_live/index.html.heex:362
-#, elixir-autogen, elixir-format
-msgid "editor.tpl.save"
-msgstr "Save template"
 
 #: lib/typster_web/live/editor_live/index.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Upload a file to reuse"
 
-#: lib/typster_web/live/editor_live/index.html.heex:322
 #: lib/typster_web/live/editor_live/index.html.heex:323
+#: lib/typster_web/live/editor_live/index.html.heex:324
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
+
+#: lib/typster_web/live/editor_live/index.ex:640
+#, elixir-autogen, elixir-format
+msgid "editor.flash.dropped_added"
+msgstr "Added to the project."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,24 +133,24 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
 
-#: lib/typster_web/live/editor_live/index.html.heex:50
+#: lib/typster_web/live/editor_live/index.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:142
+#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
@@ -181,27 +181,27 @@ msgstr "File could not be created."
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:93
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:298
+#: lib/typster_web/live/editor_live/index.html.heex:311
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:147
+#: lib/typster_web/live/editor_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:433
+#: lib/typster_web/live/editor_live/index.html.heex:446
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:504
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
@@ -221,8 +221,8 @@ msgstr "Saved"
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
-#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:271
+#: lib/typster_web/live/editor_live/index.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -303,7 +303,8 @@ msgid "nav.my_projects"
 msgstr "My projects"
 
 #: lib/typster_web/components/layouts.ex:164
-#: lib/typster_web/live/editor_live/index.html.heex:6
+#: lib/typster_web/live/editor_live/index.html.heex:8
+#: lib/typster_web/live/editor_live/index.html.heex:9
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
@@ -509,164 +510,164 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:445
+#: lib/typster_web/live/editor_live/index.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:63
-#: lib/typster_web/live/editor_live/index.html.heex:64
+#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:307
-#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:320
+#: lib/typster_web/live/editor_live/index.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:326
-#: lib/typster_web/live/editor_live/index.html.heex:327
+#: lib/typster_web/live/editor_live/index.html.heex:339
+#: lib/typster_web/live/editor_live/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:373
-#: lib/typster_web/live/editor_live/index.html.heex:374
+#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:316
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:330
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:335
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:345
-#: lib/typster_web/live/editor_live/index.html.heex:346
+#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:363
-#: lib/typster_web/live/editor_live/index.html.heex:364
+#: lib/typster_web/live/editor_live/index.html.heex:376
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:237
+#: lib/typster_web/live/editor_live/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:541
-#: lib/typster_web/live/editor_live/index.html.heex:549
-#: lib/typster_web/live/editor_live/index.html.heex:558
+#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:589
-#: lib/typster_web/live/editor_live/index.html.heex:597
-#: lib/typster_web/live/editor_live/index.html.heex:606
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:610
+#: lib/typster_web/live/editor_live/index.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:572
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:533
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:568
+#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:559
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:590
-#: lib/typster_web/live/editor_live/index.html.heex:609
-#: lib/typster_web/live/editor_live/index.html.heex:618
+#: lib/typster_web/live/editor_live/index.html.heex:603
+#: lib/typster_web/live/editor_live/index.html.heex:622
+#: lib/typster_web/live/editor_live/index.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:467
+#: lib/typster_web/live/editor_live/index.html.heex:480
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:43
+#: lib/typster_web/live/editor_live/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.html.heex:41
+#: lib/typster_web/live/editor_live/index.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:472
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:455
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -826,38 +827,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:416
+#: lib/typster_web/live/editor_live/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:396
+#: lib/typster_web/live/editor_live/index.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1985,17 +1986,17 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:111
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:111
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:76
+#: lib/typster_web/live/editor_live/index.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
@@ -2005,33 +2006,33 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:110
+#: lib/typster_web/live/editor_live/index.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:109
+#: lib/typster_web/live/editor_live/index.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
@@ -2043,7 +2044,7 @@ msgstr "filename"
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
 
-#: lib/typster_web/live/editor_live/index.html.heex:26
+#: lib/typster_web/live/editor_live/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Open command palette"
@@ -2058,7 +2059,7 @@ msgstr "Asset deleted."
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
 
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Pinned"
@@ -2088,19 +2089,24 @@ msgstr "Pinned"
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:232
+#: lib/typster_web/live/editor_live/index.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] "%{count} section"
 msgstr[1] "%{count} sections"
 
-#: lib/typster_web/live/editor_live/index.html.heex:85
+#: lib/typster_web/live/editor_live/index.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "New folder"
 
-#: lib/typster_web/live/editor_live/index.html.heex:184
+#: lib/typster_web/live/editor_live/index.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "folder name"
+
+#: lib/typster_web/live/editor_live/index.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "editor.breadcrumb"
+msgstr "Breadcrumb"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
@@ -143,86 +143,86 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:452
-#: lib/typster_web/live/editor_live/index.html.heex:453
+#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
 #: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:350
+#: lib/typster_web/live/editor_live/index.ex:377
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:347
+#: lib/typster_web/live/editor_live/index.ex:374
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:179
+#: lib/typster_web/live/editor_live/index.ex:166
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:380
+#: lib/typster_web/live/editor_live/index.ex:407
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:230
-#: lib/typster_web/live/editor_live/index.ex:253
+#: lib/typster_web/live/editor_live/index.ex:257
+#: lib/typster_web/live/editor_live/index.ex:280
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:85
+#: lib/typster_web/live/editor_live/index.html.heex:93
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:275
+#: lib/typster_web/live/editor_live/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:139
+#: lib/typster_web/live/editor_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:454
+#: lib/typster_web/live/editor_live/index.ex:484
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:452
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:483
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:235
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -509,17 +509,17 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -530,118 +530,118 @@ msgstr "Compiling…"
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:284
-#: lib/typster_web/live/editor_live/index.html.heex:285
+#: lib/typster_web/live/editor_live/index.html.heex:307
+#: lib/typster_web/live/editor_live/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:303
-#: lib/typster_web/live/editor_live/index.html.heex:304
+#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:373
+#: lib/typster_web/live/editor_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:293
-#: lib/typster_web/live/editor_live/index.html.heex:294
+#: lib/typster_web/live/editor_live/index.html.heex:316
+#: lib/typster_web/live/editor_live/index.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:331
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:312
-#: lib/typster_web/live/editor_live/index.html.heex:313
+#: lib/typster_web/live/editor_live/index.html.heex:335
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:322
-#: lib/typster_web/live/editor_live/index.html.heex:323
+#: lib/typster_web/live/editor_live/index.html.heex:345
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:340
-#: lib/typster_web/live/editor_live/index.html.heex:341
+#: lib/typster_web/live/editor_live/index.html.heex:363
+#: lib/typster_web/live/editor_live/index.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:207
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:214
+#: lib/typster_web/live/editor_live/index.html.heex:237
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
-#: lib/typster_web/live/editor_live/index.html.heex:526
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:541
+#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:566
-#: lib/typster_web/live/editor_live/index.html.heex:574
-#: lib/typster_web/live/editor_live/index.html.heex:583
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:597
+#: lib/typster_web/live/editor_live/index.html.heex:606
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:533
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:519
-#: lib/typster_web/live/editor_live/index.html.heex:539
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:568
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:567
-#: lib/typster_web/live/editor_live/index.html.heex:586
-#: lib/typster_web/live/editor_live/index.html.heex:595
+#: lib/typster_web/live/editor_live/index.html.heex:590
+#: lib/typster_web/live/editor_live/index.html.heex:609
+#: lib/typster_web/live/editor_live/index.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:444
+#: lib/typster_web/live/editor_live/index.html.heex:467
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -656,17 +656,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:427
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:436
+#: lib/typster_web/live/editor_live/index.html.heex:459
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:432
+#: lib/typster_web/live/editor_live/index.html.heex:455
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -826,38 +826,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:416
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:401
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:399
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:360
-#: lib/typster_web/live/editor_live/index.html.heex:361
+#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1985,12 +1985,12 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
@@ -2005,39 +2005,40 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:102
+#: lib/typster_web/live/editor_live/index.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:175
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:164
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:241
-#: lib/typster_web/live/editor_live/index.ex:379
+#: lib/typster_web/live/editor_live/index.ex:227
+#: lib/typster_web/live/editor_live/index.ex:268
+#: lib/typster_web/live/editor_live/index.ex:406
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2047,49 +2048,59 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:317
+#: lib/typster_web/live/editor_live/index.ex:344
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:286
+#: lib/typster_web/live/editor_live/index.ex:313
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
 
-#: lib/typster_web/live/editor_live/index.html.heex:126
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Pinned"
 
-#: lib/typster_web/file_tree.ex:187
+#: lib/typster_web/file_tree.ex:209
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
 
-#: lib/typster_web/file_tree.ex:185
+#: lib/typster_web/file_tree.ex:207
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr "Delete this file? This can't be undone."
 
-#: lib/typster_web/file_tree.ex:174
+#: lib/typster_web/file_tree.ex:196
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr "Pin file"
 
-#: lib/typster_web/file_tree.ex:159
+#: lib/typster_web/file_tree.ex:181
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
 
-#: lib/typster_web/file_tree.ex:173
+#: lib/typster_web/file_tree.ex:195
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] "%{count} section"
 msgstr[1] "%{count} sections"
+
+#: lib/typster_web/live/editor_live/index.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "editor.new_folder"
+msgstr "New folder"
+
+#: lib/typster_web/live/editor_live/index.html.heex:184
+#, elixir-autogen, elixir-format
+msgid "editor.newfolder.placeholder"
+msgstr "folder name"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -52,7 +52,6 @@ msgstr "Logging in…"
 msgid "auth.sign_up"
 msgstr "Sign up"
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
 #: lib/typster_web/live/project_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "common.cancel"
@@ -134,7 +133,7 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:146
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
@@ -144,8 +143,8 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:368
-#: lib/typster_web/live/editor_live/index.html.heex:369
+#: lib/typster_web/live/editor_live/index.html.heex:417
+#: lib/typster_web/live/editor_live/index.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
@@ -155,85 +154,74 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:234
+#: lib/typster_web/live/editor_live/index.ex:251
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:231
+#: lib/typster_web/live/editor_live/index.ex:248
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:153
+#: lib/typster_web/live/editor_live/index.ex:155
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:277
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:191
-#: lib/typster_web/live/editor_live/index.ex:200
+#: lib/typster_web/live/editor_live/index.ex:208
+#: lib/typster_web/live/editor_live/index.ex:217
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:540
-#, elixir-autogen, elixir-format
-msgid "editor.create_file"
-msgstr "Create"
-
-#: lib/typster_web/live/editor_live/index.html.heex:526
-#, elixir-autogen
-msgid "editor.file_name"
-msgstr "File name"
-
-#: lib/typster_web/live/editor_live/index.html.heex:107
-#: lib/typster_web/live/editor_live/index.html.heex:521
+#: lib/typster_web/live/editor_live/index.html.heex:73
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:191
+#: lib/typster_web/live/editor_live/index.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:116
+#: lib/typster_web/live/editor_live/index.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:292
+#: lib/typster_web/live/editor_live/index.ex:337
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:290
+#: lib/typster_web/live/editor_live/index.ex:335
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:291
+#: lib/typster_web/live/editor_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:151
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:200
+#: lib/typster_web/live/editor_live/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -525,17 +513,17 @@ msgstr "Account settings"
 msgid "editor.command"
 msgstr "⌘K"
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -546,118 +534,118 @@ msgstr "Compiling…"
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:200
-#: lib/typster_web/live/editor_live/index.html.heex:201
+#: lib/typster_web/live/editor_live/index.html.heex:249
+#: lib/typster_web/live/editor_live/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:219
-#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:268
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:266
-#: lib/typster_web/live/editor_live/index.html.heex:267
+#: lib/typster_web/live/editor_live/index.html.heex:315
+#: lib/typster_web/live/editor_live/index.html.heex:316
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
-#: lib/typster_web/live/editor_live/index.html.heex:210
+#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:247
-#: lib/typster_web/live/editor_live/index.html.heex:248
+#: lib/typster_web/live/editor_live/index.html.heex:296
+#: lib/typster_web/live/editor_live/index.html.heex:297
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:228
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:277
+#: lib/typster_web/live/editor_live/index.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
-#: lib/typster_web/live/editor_live/index.html.heex:239
+#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:305
+#: lib/typster_web/live/editor_live/index.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:128
+#: lib/typster_web/live/editor_live/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:131
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:434
-#: lib/typster_web/live/editor_live/index.html.heex:442
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:483
+#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:482
-#: lib/typster_web/live/editor_live/index.html.heex:490
-#: lib/typster_web/live/editor_live/index.html.heex:499
+#: lib/typster_web/live/editor_live/index.html.heex:531
+#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:548
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:435
-#: lib/typster_web/live/editor_live/index.html.heex:455
-#: lib/typster_web/live/editor_live/index.html.heex:461
+#: lib/typster_web/live/editor_live/index.html.heex:484
+#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:439
+#: lib/typster_web/live/editor_live/index.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:483
-#: lib/typster_web/live/editor_live/index.html.heex:502
-#: lib/typster_web/live/editor_live/index.html.heex:511
+#: lib/typster_web/live/editor_live/index.html.heex:532
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:560
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:360
+#: lib/typster_web/live/editor_live/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -672,17 +660,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:343
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:352
+#: lib/typster_web/live/editor_live/index.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -842,38 +830,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:315
+#: lib/typster_web/live/editor_live/index.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:304
+#: lib/typster_web/live/editor_live/index.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:303
+#: lib/typster_web/live/editor_live/index.html.heex:352
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:276
-#: lib/typster_web/live/editor_live/index.html.heex:277
+#: lib/typster_web/live/editor_live/index.html.heex:325
+#: lib/typster_web/live/editor_live/index.html.heex:326
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -2001,48 +1989,53 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:81
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:81
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:65
+#: lib/typster_web/live/editor_live/index.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
-
-#: lib/typster_web/live/editor_live/index.html.heex:75
-#, elixir-autogen, elixir-format
-msgid "editor.view.menu_title"
-msgstr "View as"
 
 #: lib/typster_web/file_tree.ex:11
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
+
+#: lib/typster_web/live/editor_live/index.html.heex:148
+#, elixir-autogen, elixir-format
+msgid "editor.newfile.append_hint"
+msgstr "Appended when you press Enter"
+
+#: lib/typster_web/live/editor_live/index.html.heex:140
+#, elixir-autogen, elixir-format
+msgid "editor.newfile.placeholder"
+msgstr "filename"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:267
+#: lib/typster_web/live/editor_live/index.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
@@ -143,8 +143,8 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:575
 #: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:577
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
@@ -155,12 +155,12 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:513
+#: lib/typster_web/live/editor_live/index.ex:546
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
@@ -170,14 +170,14 @@ msgstr "Asset is in."
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:544
+#: lib/typster_web/live/editor_live/index.ex:577
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
 #: lib/typster_web/live/editor_live/index.ex:384
 #: lib/typster_web/live/editor_live/index.ex:408
-#: lib/typster_web/live/editor_live/index.ex:686
+#: lib/typster_web/live/editor_live/index.ex:720
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -187,7 +187,7 @@ msgstr "Unsupported file format."
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
@@ -197,33 +197,33 @@ msgstr "No file selected"
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:528
+#: lib/typster_web/live/editor_live/index.html.heex:529
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:591
+#: lib/typster_web/live/editor_live/index.html.heex:592
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:621
+#: lib/typster_web/live/editor_live/index.ex:654
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:619
+#: lib/typster_web/live/editor_live/index.ex:652
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:620
+#: lib/typster_web/live/editor_live/index.ex:653
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:272
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:273
+#: lib/typster_web/live/editor_live/index.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -511,12 +511,12 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:541
+#: lib/typster_web/live/editor_live/index.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -527,118 +527,118 @@ msgstr "Compiling…"
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:402
 #: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:421
 #: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
 #: lib/typster_web/live/editor_live/index.html.heex:469
+#: lib/typster_web/live/editor_live/index.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
 #: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:449
 #: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:430
 #: lib/typster_web/live/editor_live/index.html.heex:431
+#: lib/typster_web/live/editor_live/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:440
 #: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
 #: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:244
+#: lib/typster_web/live/editor_live/index.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:251
+#: lib/typster_web/live/editor_live/index.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:757
-#: lib/typster_web/live/editor_live/index.html.heex:765
-#: lib/typster_web/live/editor_live/index.html.heex:774
+#: lib/typster_web/live/editor_live/index.html.heex:758
+#: lib/typster_web/live/editor_live/index.html.heex:766
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:809
-#: lib/typster_web/live/editor_live/index.html.heex:817
-#: lib/typster_web/live/editor_live/index.html.heex:826
+#: lib/typster_web/live/editor_live/index.html.heex:810
+#: lib/typster_web/live/editor_live/index.html.heex:818
+#: lib/typster_web/live/editor_live/index.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:792
+#: lib/typster_web/live/editor_live/index.html.heex:793
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:814
+#: lib/typster_web/live/editor_live/index.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:758
-#: lib/typster_web/live/editor_live/index.html.heex:782
-#: lib/typster_web/live/editor_live/index.html.heex:788
+#: lib/typster_web/live/editor_live/index.html.heex:759
+#: lib/typster_web/live/editor_live/index.html.heex:783
+#: lib/typster_web/live/editor_live/index.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:762
+#: lib/typster_web/live/editor_live/index.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:810
-#: lib/typster_web/live/editor_live/index.html.heex:829
-#: lib/typster_web/live/editor_live/index.html.heex:838
+#: lib/typster_web/live/editor_live/index.html.heex:811
+#: lib/typster_web/live/editor_live/index.html.heex:830
+#: lib/typster_web/live/editor_live/index.html.heex:839
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:568
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -653,17 +653,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:559
+#: lib/typster_web/live/editor_live/index.html.heex:560
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -823,38 +823,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:511
+#: lib/typster_web/live/editor_live/index.html.heex:512
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:519
+#: lib/typster_web/live/editor_live/index.html.heex:520
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:508
+#: lib/typster_web/live/editor_live/index.html.heex:509
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:506
+#: lib/typster_web/live/editor_live/index.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:505
+#: lib/typster_web/live/editor_live/index.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:478
 #: lib/typster_web/live/editor_live/index.html.heex:479
+#: lib/typster_web/live/editor_live/index.html.heex:480
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -2035,7 +2035,7 @@ msgstr "filename"
 
 #: lib/typster_web/live/editor_live/index.ex:349
 #: lib/typster_web/live/editor_live/index.ex:395
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:576
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2045,12 +2045,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:480
+#: lib/typster_web/live/editor_live/index.ex:513
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:449
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2060,35 +2060,35 @@ msgstr "File deleted."
 msgid "editor.pinned"
 msgstr "Pinned"
 
-#: lib/typster_web/file_tree.ex:218
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/file_tree.ex:224
 #: lib/typster_web/live/editor_live/index.html.heex:335
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
 
-#: lib/typster_web/file_tree.ex:217
+#: lib/typster_web/file_tree.ex:223
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr "Delete this file? This can't be undone."
 
-#: lib/typster_web/file_tree.ex:202
+#: lib/typster_web/file_tree.ex:208
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr "Pin file"
 
-#: lib/typster_web/file_tree.ex:188
-#: lib/typster_web/live/editor_live/index.html.heex:373
+#: lib/typster_web/file_tree.ex:194
+#: lib/typster_web/live/editor_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
 
-#: lib/typster_web/file_tree.ex:201
+#: lib/typster_web/file_tree.ex:207
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:246
+#: lib/typster_web/live/editor_live/index.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2110,110 +2110,120 @@ msgstr "folder name"
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:670
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
 
-#: lib/typster_web/live/editor_live/index.html.heex:307
+#: lib/typster_web/live/editor_live/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Your templates"
 
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Remove this template?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:353
+#: lib/typster_web/live/editor_live/index.html.heex:354
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Upload a file to reuse"
 
-#: lib/typster_web/live/editor_live/index.html.heex:323
 #: lib/typster_web/live/editor_live/index.html.heex:324
+#: lib/typster_web/live/editor_live/index.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:687
+#: lib/typster_web/live/editor_live/index.ex:721
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:789
-#: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:722
+#: lib/typster_web/live/editor_live/index.ex:846
+#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:723
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:791
+#: lib/typster_web/live/editor_live/index.ex:848
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:795
+#: lib/typster_web/live/editor_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Clear log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:654
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Close panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:630
+#: lib/typster_web/live/editor_live/index.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "Jump to first"
 
-#: lib/typster_web/live/editor_live/index.html.heex:605
-#: lib/typster_web/live/editor_live/index.html.heex:724
+#: lib/typster_web/live/editor_live/index.html.heex:606
+#: lib/typster_web/live/editor_live/index.html.heex:725
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Compile log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:662
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "No compiles yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "No problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:614
+#: lib/typster_web/live/editor_live/index.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:715
+#: lib/typster_web/live/editor_live/index.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Toggle compile panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:635
+#: lib/typster_web/live/editor_live/index.html.heex:636
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Off"
 
-#: lib/typster_web/live/editor_live/index.html.heex:633
+#: lib/typster_web/live/editor_live/index.html.heex:634
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
+
+#: lib/typster_web/live/editor_live/index.ex:443
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_moved"
+msgstr "File moved."
+
+#: lib/typster_web/live/editor_live/index.ex:453
+#, elixir-autogen, elixir-format
+msgid "editor.flash.move_conflict"
+msgstr "A file with that name already lives there."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -585,50 +585,50 @@ msgstr "Outline"
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:744
-#: lib/typster_web/live/editor_live/index.html.heex:752
-#: lib/typster_web/live/editor_live/index.html.heex:761
+#: lib/typster_web/live/editor_live/index.html.heex:757
+#: lib/typster_web/live/editor_live/index.html.heex:765
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:796
-#: lib/typster_web/live/editor_live/index.html.heex:804
-#: lib/typster_web/live/editor_live/index.html.heex:813
+#: lib/typster_web/live/editor_live/index.html.heex:809
+#: lib/typster_web/live/editor_live/index.html.heex:817
+#: lib/typster_web/live/editor_live/index.html.heex:826
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:779
+#: lib/typster_web/live/editor_live/index.html.heex:792
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:801
+#: lib/typster_web/live/editor_live/index.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:736
+#: lib/typster_web/live/editor_live/index.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:769
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:758
+#: lib/typster_web/live/editor_live/index.html.heex:782
+#: lib/typster_web/live/editor_live/index.html.heex:788
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:762
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:797
-#: lib/typster_web/live/editor_live/index.html.heex:816
-#: lib/typster_web/live/editor_live/index.html.heex:825
+#: lib/typster_web/live/editor_live/index.html.heex:810
+#: lib/typster_web/live/editor_live/index.html.heex:829
+#: lib/typster_web/live/editor_live/index.html.heex:838
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
@@ -2148,31 +2148,31 @@ msgstr "Added to the project."
 
 #: lib/typster_web/live/editor_live/index.ex:789
 #: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:709
+#: lib/typster_web/live/editor_live/index.html.heex:722
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:790
+#: lib/typster_web/live/editor_live/index.ex:791
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:793
+#: lib/typster_web/live/editor_live/index.ex:795
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:638
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Clear log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Close panel"
@@ -2183,17 +2183,17 @@ msgid "editor.drawer.jump_first"
 msgstr "Jump to first"
 
 #: lib/typster_web/live/editor_live/index.html.heex:605
-#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Compile log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:662
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "No compiles yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:662
+#: lib/typster_web/live/editor_live/index.html.heex:675
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "No problems"
@@ -2203,7 +2203,17 @@ msgstr "No problems"
 msgid "editor.drawer.problems"
 msgstr "Problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:702
+#: lib/typster_web/live/editor_live/index.html.heex:715
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Toggle compile panel"
+
+#: lib/typster_web/live/editor_live/index.html.heex:635
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.delay_off"
+msgstr "Off"
+
+#: lib/typster_web/live/editor_live/index.html.heex:633
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.recompile"
+msgstr "Recompile after"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,33 +133,33 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
 
-#: lib/typster_web/live/editor_live/index.html.heex:38
+#: lib/typster_web/live/editor_live/index.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:420
-#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:430
+#: lib/typster_web/live/editor_live/index.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
-#: lib/typster_web/live/editor_live/index.html.heex:58
+#: lib/typster_web/live/editor_live/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:263
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:257
+#: lib/typster_web/live/editor_live/index.ex:260
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
@@ -169,59 +169,59 @@ msgstr "Asset is in."
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:290
+#: lib/typster_web/live/editor_live/index.ex:293
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
 #: lib/typster_web/live/editor_live/index.ex:206
-#: lib/typster_web/live/editor_live/index.ex:226
+#: lib/typster_web/live/editor_live/index.ex:229
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:83
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:115
+#: lib/typster_web/live/editor_live/index.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:378
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:436
+#: lib/typster_web/live/editor_live/index.html.heex:446
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:364
+#: lib/typster_web/live/editor_live/index.ex:367
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:362
+#: lib/typster_web/live/editor_live/index.ex:365
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:363
+#: lib/typster_web/live/editor_live/index.ex:366
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:203
-#: lib/typster_web/live/editor_live/index.html.heex:232
+#: lib/typster_web/live/editor_live/index.html.heex:213
+#: lib/typster_web/live/editor_live/index.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -508,169 +508,164 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:23
-#, elixir-autogen, elixir-format
-msgid "editor.command"
-msgstr "⌘K"
-
-#: lib/typster_web/live/editor_live/index.html.heex:455
+#: lib/typster_web/live/editor_live/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:51
-#: lib/typster_web/live/editor_live/index.html.heex:52
+#: lib/typster_web/live/editor_live/index.html.heex:61
+#: lib/typster_web/live/editor_live/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:252
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:262
+#: lib/typster_web/live/editor_live/index.html.heex:263
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:271
-#: lib/typster_web/live/editor_live/index.html.heex:272
+#: lib/typster_web/live/editor_live/index.html.heex:281
+#: lib/typster_web/live/editor_live/index.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:318
-#: lib/typster_web/live/editor_live/index.html.heex:319
+#: lib/typster_web/live/editor_live/index.html.heex:328
+#: lib/typster_web/live/editor_live/index.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
-#: lib/typster_web/live/editor_live/index.html.heex:262
+#: lib/typster_web/live/editor_live/index.html.heex:271
+#: lib/typster_web/live/editor_live/index.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:299
-#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:280
-#: lib/typster_web/live/editor_live/index.html.heex:281
+#: lib/typster_web/live/editor_live/index.html.heex:290
+#: lib/typster_web/live/editor_live/index.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:290
-#: lib/typster_web/live/editor_live/index.html.heex:291
+#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:308
-#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:318
+#: lib/typster_web/live/editor_live/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:183
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:486
-#: lib/typster_web/live/editor_live/index.html.heex:494
-#: lib/typster_web/live/editor_live/index.html.heex:503
+#: lib/typster_web/live/editor_live/index.html.heex:496
+#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:542
-#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:544
+#: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
-#: lib/typster_web/live/editor_live/index.html.heex:507
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:497
+#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:535
-#: lib/typster_web/live/editor_live/index.html.heex:554
-#: lib/typster_web/live/editor_live/index.html.heex:563
+#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:564
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:382
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:31
+#: lib/typster_web/live/editor_live/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.html.heex:29
+#: lib/typster_web/live/editor_live/index.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:405
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -830,38 +825,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:361
+#: lib/typster_web/live/editor_live/index.html.heex:371
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:369
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:356
+#: lib/typster_web/live/editor_live/index.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:328
-#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:339
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1989,17 +1984,17 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:64
+#: lib/typster_web/live/editor_live/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
@@ -2009,39 +2004,44 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:90
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:89
+#: lib/typster_web/live/editor_live/index.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:151
+#: lib/typster_web/live/editor_live/index.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:140
+#: lib/typster_web/live/editor_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:214
-#: lib/typster_web/live/editor_live/index.ex:289
+#: lib/typster_web/live/editor_live/index.ex:217
+#: lib/typster_web/live/editor_live/index.ex:292
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
+
+#: lib/typster_web/live/editor_live/index.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "editor.command_open"
+msgstr "Open command palette"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -143,41 +143,41 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:570
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:576
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
 #: lib/typster_web/live/editor_live/index.html.heex:80
-#: lib/typster_web/live/editor_live/index.html.heex:152
+#: lib/typster_web/live/editor_live/index.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:466
+#: lib/typster_web/live/editor_live/index.ex:479
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:463
+#: lib/typster_web/live/editor_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:187
+#: lib/typster_web/live/editor_live/index.ex:193
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:497
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:337
-#: lib/typster_web/live/editor_live/index.ex:361
-#: lib/typster_web/live/editor_live/index.ex:639
+#: lib/typster_web/live/editor_live/index.ex:350
+#: lib/typster_web/live/editor_live/index.ex:374
+#: lib/typster_web/live/editor_live/index.ex:652
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -192,7 +192,7 @@ msgstr "New file"
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:157
+#: lib/typster_web/live/editor_live/index.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
@@ -202,22 +202,22 @@ msgstr "No files yet"
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:574
+#: lib/typster_web/live/editor_live/index.ex:587
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:572
+#: lib/typster_web/live/editor_live/index.ex:585
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:573
+#: lib/typster_web/live/editor_live/index.ex:586
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -511,17 +511,17 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:540
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:541
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -590,60 +590,60 @@ msgstr "Outline"
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:636
-#: lib/typster_web/live/editor_live/index.html.heex:644
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:688
-#: lib/typster_web/live/editor_live/index.html.heex:696
-#: lib/typster_web/live/editor_live/index.html.heex:705
+#: lib/typster_web/live/editor_live/index.html.heex:693
+#: lib/typster_web/live/editor_live/index.html.heex:701
+#: lib/typster_web/live/editor_live/index.html.heex:710
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:671
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:693
+#: lib/typster_web/live/editor_live/index.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:628
+#: lib/typster_web/live/editor_live/index.html.heex:633
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:637
-#: lib/typster_web/live/editor_live/index.html.heex:661
-#: lib/typster_web/live/editor_live/index.html.heex:667
+#: lib/typster_web/live/editor_live/index.html.heex:642
+#: lib/typster_web/live/editor_live/index.html.heex:666
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:689
-#: lib/typster_web/live/editor_live/index.html.heex:708
-#: lib/typster_web/live/editor_live/index.html.heex:717
+#: lib/typster_web/live/editor_live/index.html.heex:694
+#: lib/typster_web/live/editor_live/index.html.heex:713
+#: lib/typster_web/live/editor_live/index.html.heex:722
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:532
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:567
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -658,17 +658,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:559
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -2028,19 +2028,19 @@ msgstr "Tree"
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:307
-#: lib/typster_web/live/editor_live/index.ex:348
-#: lib/typster_web/live/editor_live/index.ex:496
+#: lib/typster_web/live/editor_live/index.ex:315
+#: lib/typster_web/live/editor_live/index.ex:361
+#: lib/typster_web/live/editor_live/index.ex:509
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2050,12 +2050,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:433
+#: lib/typster_web/live/editor_live/index.ex:446
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:402
+#: lib/typster_web/live/editor_live/index.ex:415
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2065,30 +2065,30 @@ msgstr "File deleted."
 msgid "editor.pinned"
 msgstr "Pinned"
 
-#: lib/typster_web/file_tree.ex:216
+#: lib/typster_web/file_tree.ex:218
 #: lib/typster_web/live/editor_live/index.html.heex:334
 #: lib/typster_web/live/editor_live/index.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
 
-#: lib/typster_web/file_tree.ex:215
+#: lib/typster_web/file_tree.ex:217
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr "Delete this file? This can't be undone."
 
-#: lib/typster_web/file_tree.ex:200
+#: lib/typster_web/file_tree.ex:202
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr "Pin file"
 
-#: lib/typster_web/file_tree.ex:186
+#: lib/typster_web/file_tree.ex:188
 #: lib/typster_web/live/editor_live/index.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
 
-#: lib/typster_web/file_tree.ex:199
+#: lib/typster_web/file_tree.ex:201
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
@@ -2105,7 +2105,7 @@ msgstr[1] "%{count} sections"
 msgid "editor.new_folder"
 msgstr "New folder"
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "folder name"
@@ -2120,7 +2120,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:589
+#: lib/typster_web/live/editor_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2146,7 +2146,14 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:640
+#: lib/typster_web/live/editor_live/index.ex:653
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
+
+#: lib/typster_web/live/editor_live/index.html.heex:534
+#, elixir-autogen, elixir-format
+msgid "%{count} error"
+msgid_plural "%{count} errors"
+msgstr[0] "%{count} error"
+msgstr[1] "%{count} errors"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
@@ -143,8 +143,8 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:417
-#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:420
+#: lib/typster_web/live/editor_live/index.html.heex:421
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
@@ -154,12 +154,12 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:251
+#: lib/typster_web/live/editor_live/index.ex:260
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:248
+#: lib/typster_web/live/editor_live/index.ex:257
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
@@ -169,13 +169,13 @@ msgstr "Asset is in."
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:277
+#: lib/typster_web/live/editor_live/index.ex:290
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:208
-#: lib/typster_web/live/editor_live/index.ex:217
+#: lib/typster_web/live/editor_live/index.ex:206
+#: lib/typster_web/live/editor_live/index.ex:226
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -185,7 +185,7 @@ msgstr "Unsupported file format."
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:240
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
@@ -195,33 +195,33 @@ msgstr "No file selected"
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:375
+#: lib/typster_web/live/editor_live/index.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:433
+#: lib/typster_web/live/editor_live/index.html.heex:436
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:337
+#: lib/typster_web/live/editor_live/index.ex:364
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:335
+#: lib/typster_web/live/editor_live/index.ex:362
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:336
+#: lib/typster_web/live/editor_live/index.ex:363
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:200
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:203
+#: lib/typster_web/live/editor_live/index.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -513,17 +513,17 @@ msgstr "Account settings"
 msgid "editor.command"
 msgstr "⌘K"
 
-#: lib/typster_web/live/editor_live/index.html.heex:452
+#: lib/typster_web/live/editor_live/index.html.heex:455
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -534,118 +534,118 @@ msgstr "Compiling…"
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:249
-#: lib/typster_web/live/editor_live/index.html.heex:250
+#: lib/typster_web/live/editor_live/index.html.heex:252
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:268
-#: lib/typster_web/live/editor_live/index.html.heex:269
+#: lib/typster_web/live/editor_live/index.html.heex:271
+#: lib/typster_web/live/editor_live/index.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:315
-#: lib/typster_web/live/editor_live/index.html.heex:316
+#: lib/typster_web/live/editor_live/index.html.heex:318
+#: lib/typster_web/live/editor_live/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:296
-#: lib/typster_web/live/editor_live/index.html.heex:297
+#: lib/typster_web/live/editor_live/index.html.heex:299
+#: lib/typster_web/live/editor_live/index.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:277
-#: lib/typster_web/live/editor_live/index.html.heex:278
+#: lib/typster_web/live/editor_live/index.html.heex:280
+#: lib/typster_web/live/editor_live/index.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:287
-#: lib/typster_web/live/editor_live/index.html.heex:288
+#: lib/typster_web/live/editor_live/index.html.heex:290
+#: lib/typster_web/live/editor_live/index.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:305
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:309
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:177
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:483
-#: lib/typster_web/live/editor_live/index.html.heex:491
-#: lib/typster_web/live/editor_live/index.html.heex:500
+#: lib/typster_web/live/editor_live/index.html.heex:486
+#: lib/typster_web/live/editor_live/index.html.heex:494
+#: lib/typster_web/live/editor_live/index.html.heex:503
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:531
-#: lib/typster_web/live/editor_live/index.html.heex:539
-#: lib/typster_web/live/editor_live/index.html.heex:548
+#: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:514
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:484
-#: lib/typster_web/live/editor_live/index.html.heex:504
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:532
-#: lib/typster_web/live/editor_live/index.html.heex:551
-#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/live/editor_live/index.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:409
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -660,17 +660,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:401
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:397
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -830,38 +830,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:364
+#: lib/typster_web/live/editor_live/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:353
+#: lib/typster_web/live/editor_live/index.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:352
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:325
-#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:328
+#: lib/typster_web/live/editor_live/index.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -2030,7 +2030,7 @@ msgstr "Tree"
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:148
+#: lib/typster_web/live/editor_live/index.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
@@ -2039,3 +2039,9 @@ msgstr "Appended when you press Enter"
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
+
+#: lib/typster_web/live/editor_live/index.ex:214
+#: lib/typster_web/live/editor_live/index.ex:289
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_exists"
+msgstr "A file with that path already exists — pick another name."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
@@ -143,23 +143,24 @@ msgstr "Assets"
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:430
-#: lib/typster_web/live/editor_live/index.html.heex:431
+#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
 #: lib/typster_web/live/editor_live/index.html.heex:68
+#: lib/typster_web/live/editor_live/index.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:263
+#: lib/typster_web/live/editor_live/index.ex:326
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:323
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
@@ -169,7 +170,7 @@ msgstr "Asset is in."
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:293
+#: lib/typster_web/live/editor_live/index.ex:356
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
@@ -185,43 +186,43 @@ msgstr "Unsupported file format."
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:125
+#: lib/typster_web/live/editor_live/index.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:446
+#: lib/typster_web/live/editor_live/index.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:367
+#: lib/typster_web/live/editor_live/index.ex:430
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:365
+#: lib/typster_web/live/editor_live/index.ex:428
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:366
+#: lib/typster_web/live/editor_live/index.ex:429
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:213
-#: lib/typster_web/live/editor_live/index.html.heex:242
+#: lib/typster_web/live/editor_live/index.html.heex:225
+#: lib/typster_web/live/editor_live/index.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -508,17 +509,17 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:396
+#: lib/typster_web/live/editor_live/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
@@ -529,118 +530,118 @@ msgstr "Compiling…"
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:262
-#: lib/typster_web/live/editor_live/index.html.heex:263
+#: lib/typster_web/live/editor_live/index.html.heex:274
+#: lib/typster_web/live/editor_live/index.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:281
-#: lib/typster_web/live/editor_live/index.html.heex:282
+#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:328
-#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:271
-#: lib/typster_web/live/editor_live/index.html.heex:272
+#: lib/typster_web/live/editor_live/index.html.heex:283
+#: lib/typster_web/live/editor_live/index.html.heex:284
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:309
-#: lib/typster_web/live/editor_live/index.html.heex:310
+#: lib/typster_web/live/editor_live/index.html.heex:321
+#: lib/typster_web/live/editor_live/index.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:290
-#: lib/typster_web/live/editor_live/index.html.heex:291
+#: lib/typster_web/live/editor_live/index.html.heex:302
+#: lib/typster_web/live/editor_live/index.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:300
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:312
+#: lib/typster_web/live/editor_live/index.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:318
-#: lib/typster_web/live/editor_live/index.html.heex:319
+#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:190
+#: lib/typster_web/live/editor_live/index.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:496
-#: lib/typster_web/live/editor_live/index.html.heex:504
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:508
+#: lib/typster_web/live/editor_live/index.html.heex:516
+#: lib/typster_web/live/editor_live/index.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:544
-#: lib/typster_web/live/editor_live/index.html.heex:552
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:564
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:527
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:497
-#: lib/typster_web/live/editor_live/index.html.heex:517
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:501
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
-#: lib/typster_web/live/editor_live/index.html.heex:564
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:434
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
@@ -655,17 +656,17 @@ msgstr "Share"
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:405
+#: lib/typster_web/live/editor_live/index.html.heex:417
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -825,38 +826,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:371
+#: lib/typster_web/live/editor_live/index.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/live/editor_live/index.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:368
+#: lib/typster_web/live/editor_live/index.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:365
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
-#: lib/typster_web/live/editor_live/index.html.heex:339
+#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -2025,18 +2026,18 @@ msgstr "Tree"
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:161
+#: lib/typster_web/live/editor_live/index.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:150
+#: lib/typster_web/live/editor_live/index.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
 #: lib/typster_web/live/editor_live/index.ex:217
-#: lib/typster_web/live/editor_live/index.ex:292
+#: lib/typster_web/live/editor_live/index.ex:355
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2045,3 +2046,43 @@ msgstr "A file with that path already exists — pick another name."
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Open command palette"
+
+#: lib/typster_web/live/editor_live/index.ex:293
+#, elixir-autogen, elixir-format
+msgid "editor.flash.asset_deleted"
+msgstr "Asset deleted."
+
+#: lib/typster_web/live/editor_live/index.ex:262
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_deleted"
+msgstr "File deleted."
+
+#: lib/typster_web/live/editor_live/index.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "editor.pinned"
+msgstr "Pinned"
+
+#: lib/typster_web/file_tree.ex:187
+#, elixir-autogen, elixir-format
+msgid "editor.tree.delete"
+msgstr "Delete file"
+
+#: lib/typster_web/file_tree.ex:185
+#, elixir-autogen, elixir-format
+msgid "editor.tree.delete_confirm"
+msgstr "Delete this file? This can't be undone."
+
+#: lib/typster_web/file_tree.ex:174
+#, elixir-autogen, elixir-format
+msgid "editor.tree.pin"
+msgstr "Pin file"
+
+#: lib/typster_web/file_tree.ex:159
+#, elixir-autogen, elixir-format
+msgid "editor.tree.pinned"
+msgstr "Pinned"
+
+#: lib/typster_web/file_tree.ex:173
+#, elixir-autogen, elixir-format
+msgid "editor.tree.unpin"
+msgstr "Unpin file"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,96 +133,96 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
 
-#: lib/typster_web/live/editor_live/index.html.heex:48
+#: lib/typster_web/live/editor_live/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:442
-#: lib/typster_web/live/editor_live/index.html.heex:443
+#: lib/typster_web/live/editor_live/index.html.heex:452
+#: lib/typster_web/live/editor_live/index.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
-#: lib/typster_web/live/editor_live/index.html.heex:68
-#: lib/typster_web/live/editor_live/index.html.heex:132
+#: lib/typster_web/live/editor_live/index.html.heex:70
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:326
+#: lib/typster_web/live/editor_live/index.ex:350
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:323
+#: lib/typster_web/live/editor_live/index.ex:347
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:155
+#: lib/typster_web/live/editor_live/index.ex:179
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:380
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:206
-#: lib/typster_web/live/editor_live/index.ex:229
+#: lib/typster_web/live/editor_live/index.ex:230
+#: lib/typster_web/live/editor_live/index.ex:253
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:83
+#: lib/typster_web/live/editor_live/index.html.heex:85
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:265
+#: lib/typster_web/live/editor_live/index.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:137
+#: lib/typster_web/live/editor_live/index.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:430
+#: lib/typster_web/live/editor_live/index.ex:454
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:428
+#: lib/typster_web/live/editor_live/index.ex:452
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:429
+#: lib/typster_web/live/editor_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:225
-#: lib/typster_web/live/editor_live/index.html.heex:254
+#: lib/typster_web/live/editor_live/index.html.heex:235
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
@@ -509,164 +509,164 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:487
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K to run command"
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:61
-#: lib/typster_web/live/editor_live/index.html.heex:62
+#: lib/typster_web/live/editor_live/index.html.heex:63
+#: lib/typster_web/live/editor_live/index.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:274
-#: lib/typster_web/live/editor_live/index.html.heex:275
+#: lib/typster_web/live/editor_live/index.html.heex:284
+#: lib/typster_web/live/editor_live/index.html.heex:285
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:293
-#: lib/typster_web/live/editor_live/index.html.heex:294
+#: lib/typster_web/live/editor_live/index.html.heex:303
+#: lib/typster_web/live/editor_live/index.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:340
-#: lib/typster_web/live/editor_live/index.html.heex:341
+#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:283
-#: lib/typster_web/live/editor_live/index.html.heex:284
+#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:321
-#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:302
-#: lib/typster_web/live/editor_live/index.html.heex:303
+#: lib/typster_web/live/editor_live/index.html.heex:312
+#: lib/typster_web/live/editor_live/index.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:312
-#: lib/typster_web/live/editor_live/index.html.heex:313
+#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:323
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:330
-#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:202
+#: lib/typster_web/live/editor_live/index.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:205
+#: lib/typster_web/live/editor_live/index.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:508
-#: lib/typster_web/live/editor_live/index.html.heex:516
-#: lib/typster_web/live/editor_live/index.html.heex:525
+#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:556
-#: lib/typster_web/live/editor_live/index.html.heex:564
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:574
+#: lib/typster_web/live/editor_live/index.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:500
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:509
-#: lib/typster_web/live/editor_live/index.html.heex:529
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:519
+#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:434
+#: lib/typster_web/live/editor_live/index.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:41
+#: lib/typster_web/live/editor_live/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.html.heex:39
+#: lib/typster_web/live/editor_live/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:417
+#: lib/typster_web/live/editor_live/index.html.heex:427
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:436
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -826,38 +826,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:391
+#: lib/typster_web/live/editor_live/index.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:380
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:389
+#: lib/typster_web/live/editor_live/index.html.heex:399
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:378
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:360
+#: lib/typster_web/live/editor_live/index.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1985,17 +1985,17 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
@@ -2005,39 +2005,39 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:99
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:98
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:98
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:173
+#: lib/typster_web/live/editor_live/index.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:162
+#: lib/typster_web/live/editor_live/index.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:217
-#: lib/typster_web/live/editor_live/index.ex:355
+#: lib/typster_web/live/editor_live/index.ex:241
+#: lib/typster_web/live/editor_live/index.ex:379
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2047,17 +2047,17 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:293
+#: lib/typster_web/live/editor_live/index.ex:317
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:262
+#: lib/typster_web/live/editor_live/index.ex:286
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
 
-#: lib/typster_web/live/editor_live/index.html.heex:124
+#: lib/typster_web/live/editor_live/index.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Pinned"
@@ -2086,3 +2086,10 @@ msgstr "Pinned"
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
+
+#: lib/typster_web/live/editor_live/index.html.heex:209
+#, elixir-autogen, elixir-format
+msgid "%{count} section"
+msgid_plural "%{count} sections"
+msgstr[0] "%{count} section"
+msgstr[1] "%{count} sections"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -143,8 +143,8 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:515
-#: lib/typster_web/live/editor_live/index.html.heex:516
+#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
@@ -155,28 +155,28 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:423
+#: lib/typster_web/live/editor_live/index.ex:485
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:420
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:168
+#: lib/typster_web/live/editor_live/index.ex:176
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:454
+#: lib/typster_web/live/editor_live/index.ex:516
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:295
-#: lib/typster_web/live/editor_live/index.ex:318
+#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:380
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -186,7 +186,7 @@ msgstr "Неподдерживаемый формат файла."
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
@@ -196,27 +196,27 @@ msgstr "Файла нет"
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:473
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:531
+#: lib/typster_web/live/editor_live/index.html.heex:593
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:531
+#: lib/typster_web/live/editor_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:529
+#: lib/typster_web/live/editor_live/index.ex:591
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:530
+#: lib/typster_web/live/editor_live/index.ex:592
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -512,17 +512,17 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:485
+#: lib/typster_web/live/editor_live/index.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:481
+#: lib/typster_web/live/editor_live/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -533,50 +533,50 @@ msgstr "Компиляция…"
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:347
-#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:409
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
-#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:428
+#: lib/typster_web/live/editor_live/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:356
-#: lib/typster_web/live/editor_live/index.html.heex:357
+#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:394
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:456
+#: lib/typster_web/live/editor_live/index.html.heex:457
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:375
-#: lib/typster_web/live/editor_live/index.html.heex:376
+#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:438
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:385
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:447
+#: lib/typster_web/live/editor_live/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:466
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
@@ -591,60 +591,60 @@ msgstr "Структура"
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:581
-#: lib/typster_web/live/editor_live/index.html.heex:589
-#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:643
+#: lib/typster_web/live/editor_live/index.html.heex:651
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:629
-#: lib/typster_web/live/editor_live/index.html.heex:637
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:699
+#: lib/typster_web/live/editor_live/index.html.heex:708
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:674
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:634
+#: lib/typster_web/live/editor_live/index.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:582
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:608
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:670
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:630
-#: lib/typster_web/live/editor_live/index.html.heex:649
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:692
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:720
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:569
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -659,17 +659,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:490
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:499
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:495
+#: lib/typster_web/live/editor_live/index.html.heex:557
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -833,38 +833,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:456
+#: lib/typster_web/live/editor_live/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:464
+#: lib/typster_web/live/editor_live/index.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:453
+#: lib/typster_web/live/editor_live/index.html.heex:515
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:462
+#: lib/typster_web/live/editor_live/index.html.heex:524
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:512
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:423
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:485
+#: lib/typster_web/live/editor_live/index.html.heex:486
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -2043,9 +2043,9 @@ msgstr "Добавится по нажатию Enter"
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:265
-#: lib/typster_web/live/editor_live/index.ex:306
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:326
+#: lib/typster_web/live/editor_live/index.ex:367
+#: lib/typster_web/live/editor_live/index.ex:515
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,12 +2055,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:390
+#: lib/typster_web/live/editor_live/index.ex:452
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:359
+#: lib/typster_web/live/editor_live/index.ex:421
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2071,6 +2071,8 @@ msgid "editor.pinned"
 msgstr "Закреплённые"
 
 #: lib/typster_web/file_tree.ex:209
+#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
@@ -2086,7 +2088,7 @@ msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
 #: lib/typster_web/file_tree.ex:181
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
@@ -2119,7 +2121,43 @@ msgstr "имя папки"
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
+
+#: lib/typster_web/live/editor_live/index.ex:280
+#, elixir-autogen, elixir-format
+msgid "editor.flash.template_failed"
+msgstr "Не удалось сохранить шаблон."
+
+#: lib/typster_web/live/editor_live/index.ex:285
+#, elixir-autogen, elixir-format
+msgid "editor.flash.template_saved"
+msgstr "Шаблон сохранён."
+
+#: lib/typster_web/live/editor_live/index.html.heex:306
+#, elixir-autogen, elixir-format
+msgid "editor.templates"
+msgstr "Ваши шаблоны"
+
+#: lib/typster_web/live/editor_live/index.html.heex:332
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.delete_confirm"
+msgstr "Удалить этот шаблон?"
+
+#: lib/typster_web/live/editor_live/index.html.heex:362
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.save"
+msgstr "Сохранить шаблон"
+
+#: lib/typster_web/live/editor_live/index.html.heex:353
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.upload"
+msgstr "Загрузите файл для повторного использования"
+
+#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:323
+#, elixir-autogen, elixir-format
+msgid "editor.tpl.use"
+msgstr "Создать файл из этого шаблона"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -52,7 +52,6 @@ msgstr "Вход…"
 msgid "auth.sign_up"
 msgstr "Создать аккаунт"
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
 #: lib/typster_web/live/project_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "common.cancel"
@@ -134,7 +133,7 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:146
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
@@ -144,8 +143,8 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:368
-#: lib/typster_web/live/editor_live/index.html.heex:369
+#: lib/typster_web/live/editor_live/index.html.heex:417
+#: lib/typster_web/live/editor_live/index.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
@@ -155,85 +154,74 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:234
+#: lib/typster_web/live/editor_live/index.ex:251
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:231
+#: lib/typster_web/live/editor_live/index.ex:248
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:153
+#: lib/typster_web/live/editor_live/index.ex:155
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:277
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:191
-#: lib/typster_web/live/editor_live/index.ex:200
+#: lib/typster_web/live/editor_live/index.ex:208
+#: lib/typster_web/live/editor_live/index.ex:217
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:540
-#, elixir-autogen, elixir-format
-msgid "editor.create_file"
-msgstr "Создать"
-
-#: lib/typster_web/live/editor_live/index.html.heex:526
-#, elixir-autogen
-msgid "editor.file_name"
-msgstr "Имя файла"
-
-#: lib/typster_web/live/editor_live/index.html.heex:107
-#: lib/typster_web/live/editor_live/index.html.heex:521
+#: lib/typster_web/live/editor_live/index.html.heex:73
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:191
+#: lib/typster_web/live/editor_live/index.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:116
+#: lib/typster_web/live/editor_live/index.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:292
+#: lib/typster_web/live/editor_live/index.ex:337
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:290
+#: lib/typster_web/live/editor_live/index.ex:335
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:291
+#: lib/typster_web/live/editor_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:151
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:200
+#: lib/typster_web/live/editor_live/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -527,17 +515,17 @@ msgstr "Настройки аккаунта"
 msgid "editor.command"
 msgstr "⌘K"
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -548,118 +536,118 @@ msgstr "Компиляция…"
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:200
-#: lib/typster_web/live/editor_live/index.html.heex:201
+#: lib/typster_web/live/editor_live/index.html.heex:249
+#: lib/typster_web/live/editor_live/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:219
-#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:268
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:266
-#: lib/typster_web/live/editor_live/index.html.heex:267
+#: lib/typster_web/live/editor_live/index.html.heex:315
+#: lib/typster_web/live/editor_live/index.html.heex:316
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
-#: lib/typster_web/live/editor_live/index.html.heex:210
+#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:247
-#: lib/typster_web/live/editor_live/index.html.heex:248
+#: lib/typster_web/live/editor_live/index.html.heex:296
+#: lib/typster_web/live/editor_live/index.html.heex:297
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:228
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:277
+#: lib/typster_web/live/editor_live/index.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
-#: lib/typster_web/live/editor_live/index.html.heex:239
+#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:305
+#: lib/typster_web/live/editor_live/index.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:128
+#: lib/typster_web/live/editor_live/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:131
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:434
-#: lib/typster_web/live/editor_live/index.html.heex:442
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:483
+#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:482
-#: lib/typster_web/live/editor_live/index.html.heex:490
-#: lib/typster_web/live/editor_live/index.html.heex:499
+#: lib/typster_web/live/editor_live/index.html.heex:531
+#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:548
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:435
-#: lib/typster_web/live/editor_live/index.html.heex:455
-#: lib/typster_web/live/editor_live/index.html.heex:461
+#: lib/typster_web/live/editor_live/index.html.heex:484
+#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:439
+#: lib/typster_web/live/editor_live/index.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:483
-#: lib/typster_web/live/editor_live/index.html.heex:502
-#: lib/typster_web/live/editor_live/index.html.heex:511
+#: lib/typster_web/live/editor_live/index.html.heex:532
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:560
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:360
+#: lib/typster_web/live/editor_live/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -674,17 +662,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:343
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:352
+#: lib/typster_web/live/editor_live/index.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -848,38 +836,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:315
+#: lib/typster_web/live/editor_live/index.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:304
+#: lib/typster_web/live/editor_live/index.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:303
+#: lib/typster_web/live/editor_live/index.html.heex:352
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:276
-#: lib/typster_web/live/editor_live/index.html.heex:277
+#: lib/typster_web/live/editor_live/index.html.heex:325
+#: lib/typster_web/live/editor_live/index.html.heex:326
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -2007,48 +1995,53 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:81
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:81
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:65
+#: lib/typster_web/live/editor_live/index.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
-
-#: lib/typster_web/live/editor_live/index.html.heex:75
-#, elixir-autogen, elixir-format
-msgid "editor.view.menu_title"
-msgstr "Показывать как"
 
 #: lib/typster_web/file_tree.ex:11
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
+
+#: lib/typster_web/live/editor_live/index.html.heex:148
+#, elixir-autogen, elixir-format
+msgid "editor.newfile.append_hint"
+msgstr "Добавится по нажатию Enter"
+
+#: lib/typster_web/live/editor_live/index.html.heex:140
+#, elixir-autogen, elixir-format
+msgid "editor.newfile.placeholder"
+msgstr "имя файла"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -143,8 +143,8 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
-#: lib/typster_web/live/editor_live/index.html.heex:489
+#: lib/typster_web/live/editor_live/index.html.heex:515
+#: lib/typster_web/live/editor_live/index.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
@@ -155,28 +155,28 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:377
+#: lib/typster_web/live/editor_live/index.ex:423
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:374
+#: lib/typster_web/live/editor_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:166
+#: lib/typster_web/live/editor_live/index.ex:168
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:407
+#: lib/typster_web/live/editor_live/index.ex:454
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:257
-#: lib/typster_web/live/editor_live/index.ex:280
+#: lib/typster_web/live/editor_live/index.ex:295
+#: lib/typster_web/live/editor_live/index.ex:318
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -186,7 +186,7 @@ msgstr "Неподдерживаемый формат файла."
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:311
+#: lib/typster_web/live/editor_live/index.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
@@ -196,27 +196,27 @@ msgstr "Файла нет"
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:446
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:531
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:484
+#: lib/typster_web/live/editor_live/index.ex:531
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:529
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:483
+#: lib/typster_web/live/editor_live/index.ex:530
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -512,17 +512,17 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:454
+#: lib/typster_web/live/editor_live/index.html.heex:481
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -533,50 +533,50 @@ msgstr "Компиляция…"
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:320
-#: lib/typster_web/live/editor_live/index.html.heex:321
+#: lib/typster_web/live/editor_live/index.html.heex:347
+#: lib/typster_web/live/editor_live/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:339
-#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:329
-#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:356
+#: lib/typster_web/live/editor_live/index.html.heex:357
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:367
-#: lib/typster_web/live/editor_live/index.html.heex:368
+#: lib/typster_web/live/editor_live/index.html.heex:394
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:348
-#: lib/typster_web/live/editor_live/index.html.heex:349
+#: lib/typster_web/live/editor_live/index.html.heex:375
+#: lib/typster_web/live/editor_live/index.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
-#: lib/typster_web/live/editor_live/index.html.heex:359
+#: lib/typster_web/live/editor_live/index.html.heex:385
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:376
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
@@ -591,60 +591,60 @@ msgstr "Структура"
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:554
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:610
-#: lib/typster_web/live/editor_live/index.html.heex:619
+#: lib/typster_web/live/editor_live/index.html.heex:629
+#: lib/typster_web/live/editor_live/index.html.heex:637
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:607
+#: lib/typster_web/live/editor_live/index.html.heex:634
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
-#: lib/typster_web/live/editor_live/index.html.heex:575
-#: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:582
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:559
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:603
-#: lib/typster_web/live/editor_live/index.html.heex:622
-#: lib/typster_web/live/editor_live/index.html.heex:631
+#: lib/typster_web/live/editor_live/index.html.heex:630
+#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:480
+#: lib/typster_web/live/editor_live/index.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -659,17 +659,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:463
+#: lib/typster_web/live/editor_live/index.html.heex:490
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:472
+#: lib/typster_web/live/editor_live/index.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -833,38 +833,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:429
+#: lib/typster_web/live/editor_live/index.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:435
+#: lib/typster_web/live/editor_live/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:396
-#: lib/typster_web/live/editor_live/index.html.heex:397
+#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -2043,9 +2043,9 @@ msgstr "Добавится по нажатию Enter"
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:227
-#: lib/typster_web/live/editor_live/index.ex:268
-#: lib/typster_web/live/editor_live/index.ex:406
+#: lib/typster_web/live/editor_live/index.ex:265
+#: lib/typster_web/live/editor_live/index.ex:306
+#: lib/typster_web/live/editor_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,12 +2055,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:344
+#: lib/typster_web/live/editor_live/index.ex:390
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:313
+#: lib/typster_web/live/editor_live/index.ex:359
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2086,6 +2086,7 @@ msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
 #: lib/typster_web/file_tree.ex:181
+#: lib/typster_web/live/editor_live/index.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
@@ -2117,3 +2118,8 @@ msgstr "имя папки"
 #, elixir-autogen, elixir-format
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
+
+#: lib/typster_web/live/editor_live/index.html.heex:331
+#, elixir-autogen, elixir-format
+msgid "editor.tab.close"
+msgstr "Закрыть вкладку"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:267
+#: lib/typster_web/live/editor_live/index.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
@@ -143,8 +143,8 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:575
 #: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:577
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
@@ -155,12 +155,12 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:513
+#: lib/typster_web/live/editor_live/index.ex:546
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
@@ -170,14 +170,14 @@ msgstr "Ассет на месте."
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:544
+#: lib/typster_web/live/editor_live/index.ex:577
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
 #: lib/typster_web/live/editor_live/index.ex:384
 #: lib/typster_web/live/editor_live/index.ex:408
-#: lib/typster_web/live/editor_live/index.ex:686
+#: lib/typster_web/live/editor_live/index.ex:720
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -187,7 +187,7 @@ msgstr "Неподдерживаемый формат файла."
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
@@ -197,33 +197,33 @@ msgstr "Файла нет"
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:528
+#: lib/typster_web/live/editor_live/index.html.heex:529
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:591
+#: lib/typster_web/live/editor_live/index.html.heex:592
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:621
+#: lib/typster_web/live/editor_live/index.ex:654
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:619
+#: lib/typster_web/live/editor_live/index.ex:652
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:620
+#: lib/typster_web/live/editor_live/index.ex:653
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:272
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:273
+#: lib/typster_web/live/editor_live/index.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -513,12 +513,12 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:541
+#: lib/typster_web/live/editor_live/index.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -529,118 +529,118 @@ msgstr "Компиляция…"
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:402
 #: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:421
 #: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
 #: lib/typster_web/live/editor_live/index.html.heex:469
+#: lib/typster_web/live/editor_live/index.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
 #: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:449
 #: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:430
 #: lib/typster_web/live/editor_live/index.html.heex:431
+#: lib/typster_web/live/editor_live/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:440
 #: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
 #: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:244
+#: lib/typster_web/live/editor_live/index.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:251
+#: lib/typster_web/live/editor_live/index.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:757
-#: lib/typster_web/live/editor_live/index.html.heex:765
-#: lib/typster_web/live/editor_live/index.html.heex:774
+#: lib/typster_web/live/editor_live/index.html.heex:758
+#: lib/typster_web/live/editor_live/index.html.heex:766
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:809
-#: lib/typster_web/live/editor_live/index.html.heex:817
-#: lib/typster_web/live/editor_live/index.html.heex:826
+#: lib/typster_web/live/editor_live/index.html.heex:810
+#: lib/typster_web/live/editor_live/index.html.heex:818
+#: lib/typster_web/live/editor_live/index.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:792
+#: lib/typster_web/live/editor_live/index.html.heex:793
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:814
+#: lib/typster_web/live/editor_live/index.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:758
-#: lib/typster_web/live/editor_live/index.html.heex:782
-#: lib/typster_web/live/editor_live/index.html.heex:788
+#: lib/typster_web/live/editor_live/index.html.heex:759
+#: lib/typster_web/live/editor_live/index.html.heex:783
+#: lib/typster_web/live/editor_live/index.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:762
+#: lib/typster_web/live/editor_live/index.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:810
-#: lib/typster_web/live/editor_live/index.html.heex:829
-#: lib/typster_web/live/editor_live/index.html.heex:838
+#: lib/typster_web/live/editor_live/index.html.heex:811
+#: lib/typster_web/live/editor_live/index.html.heex:830
+#: lib/typster_web/live/editor_live/index.html.heex:839
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:568
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -655,17 +655,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:559
+#: lib/typster_web/live/editor_live/index.html.heex:560
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -829,38 +829,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:511
+#: lib/typster_web/live/editor_live/index.html.heex:512
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:519
+#: lib/typster_web/live/editor_live/index.html.heex:520
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:508
+#: lib/typster_web/live/editor_live/index.html.heex:509
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:506
+#: lib/typster_web/live/editor_live/index.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:505
+#: lib/typster_web/live/editor_live/index.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:478
 #: lib/typster_web/live/editor_live/index.html.heex:479
+#: lib/typster_web/live/editor_live/index.html.heex:480
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -2041,7 +2041,7 @@ msgstr "имя файла"
 
 #: lib/typster_web/live/editor_live/index.ex:349
 #: lib/typster_web/live/editor_live/index.ex:395
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:576
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2051,12 +2051,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:480
+#: lib/typster_web/live/editor_live/index.ex:513
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:449
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2066,35 +2066,35 @@ msgstr "Файл удалён."
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
-#: lib/typster_web/file_tree.ex:218
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/file_tree.ex:224
 #: lib/typster_web/live/editor_live/index.html.heex:335
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
 
-#: lib/typster_web/file_tree.ex:217
+#: lib/typster_web/file_tree.ex:223
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr "Удалить этот файл? Это нельзя отменить."
 
-#: lib/typster_web/file_tree.ex:202
+#: lib/typster_web/file_tree.ex:208
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
-#: lib/typster_web/file_tree.ex:188
-#: lib/typster_web/live/editor_live/index.html.heex:373
+#: lib/typster_web/file_tree.ex:194
+#: lib/typster_web/live/editor_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
 
-#: lib/typster_web/file_tree.ex:201
+#: lib/typster_web/file_tree.ex:207
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:246
+#: lib/typster_web/live/editor_live/index.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2117,45 +2117,45 @@ msgstr "имя папки"
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:670
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:307
+#: lib/typster_web/live/editor_live/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Ваши шаблоны"
 
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Удалить этот шаблон?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:353
+#: lib/typster_web/live/editor_live/index.html.heex:354
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Загрузите файл для повторного использования"
 
-#: lib/typster_web/live/editor_live/index.html.heex:323
 #: lib/typster_web/live/editor_live/index.html.heex:324
+#: lib/typster_web/live/editor_live/index.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:687
+#: lib/typster_web/live/editor_live/index.ex:721
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:789
-#: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:722
+#: lib/typster_web/live/editor_live/index.ex:846
+#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:723
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2163,7 +2163,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:791
+#: lib/typster_web/live/editor_live/index.ex:848
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2171,58 +2171,68 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:795
+#: lib/typster_web/live/editor_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Очистить лог"
 
-#: lib/typster_web/live/editor_live/index.html.heex:654
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Закрыть панель"
 
-#: lib/typster_web/live/editor_live/index.html.heex:630
+#: lib/typster_web/live/editor_live/index.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "К первой"
 
-#: lib/typster_web/live/editor_live/index.html.heex:605
-#: lib/typster_web/live/editor_live/index.html.heex:724
+#: lib/typster_web/live/editor_live/index.html.heex:606
+#: lib/typster_web/live/editor_live/index.html.heex:725
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Лог компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:662
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "Пока нет компиляций"
 
-#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "Нет проблем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:614
+#: lib/typster_web/live/editor_live/index.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Проблемы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:715
+#: lib/typster_web/live/editor_live/index.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Показать панель компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:635
+#: lib/typster_web/live/editor_live/index.html.heex:636
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Выкл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:633
+#: lib/typster_web/live/editor_live/index.html.heex:634
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
+
+#: lib/typster_web/live/editor_live/index.ex:443
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_moved"
+msgstr "Файл перемещён."
+
+#: lib/typster_web/live/editor_live/index.ex:453
+#, elixir-autogen, elixir-format
+msgid "editor.flash.move_conflict"
+msgstr "Там уже лежит файл с таким именем."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -133,96 +133,96 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:48
+#: lib/typster_web/live/editor_live/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:442
-#: lib/typster_web/live/editor_live/index.html.heex:443
+#: lib/typster_web/live/editor_live/index.html.heex:452
+#: lib/typster_web/live/editor_live/index.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:68
-#: lib/typster_web/live/editor_live/index.html.heex:132
+#: lib/typster_web/live/editor_live/index.html.heex:70
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:326
+#: lib/typster_web/live/editor_live/index.ex:350
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:323
+#: lib/typster_web/live/editor_live/index.ex:347
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:155
+#: lib/typster_web/live/editor_live/index.ex:179
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:380
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:206
-#: lib/typster_web/live/editor_live/index.ex:229
+#: lib/typster_web/live/editor_live/index.ex:230
+#: lib/typster_web/live/editor_live/index.ex:253
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:83
+#: lib/typster_web/live/editor_live/index.html.heex:85
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:265
+#: lib/typster_web/live/editor_live/index.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:137
+#: lib/typster_web/live/editor_live/index.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:430
+#: lib/typster_web/live/editor_live/index.ex:454
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:428
+#: lib/typster_web/live/editor_live/index.ex:452
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:429
+#: lib/typster_web/live/editor_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:225
-#: lib/typster_web/live/editor_live/index.html.heex:254
+#: lib/typster_web/live/editor_live/index.html.heex:235
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -511,164 +511,164 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:487
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:61
-#: lib/typster_web/live/editor_live/index.html.heex:62
+#: lib/typster_web/live/editor_live/index.html.heex:63
+#: lib/typster_web/live/editor_live/index.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:274
-#: lib/typster_web/live/editor_live/index.html.heex:275
+#: lib/typster_web/live/editor_live/index.html.heex:284
+#: lib/typster_web/live/editor_live/index.html.heex:285
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:293
-#: lib/typster_web/live/editor_live/index.html.heex:294
+#: lib/typster_web/live/editor_live/index.html.heex:303
+#: lib/typster_web/live/editor_live/index.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:340
-#: lib/typster_web/live/editor_live/index.html.heex:341
+#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:283
-#: lib/typster_web/live/editor_live/index.html.heex:284
+#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:321
-#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:302
-#: lib/typster_web/live/editor_live/index.html.heex:303
+#: lib/typster_web/live/editor_live/index.html.heex:312
+#: lib/typster_web/live/editor_live/index.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:312
-#: lib/typster_web/live/editor_live/index.html.heex:313
+#: lib/typster_web/live/editor_live/index.html.heex:322
+#: lib/typster_web/live/editor_live/index.html.heex:323
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:330
-#: lib/typster_web/live/editor_live/index.html.heex:331
+#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:202
+#: lib/typster_web/live/editor_live/index.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:205
+#: lib/typster_web/live/editor_live/index.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:508
-#: lib/typster_web/live/editor_live/index.html.heex:516
-#: lib/typster_web/live/editor_live/index.html.heex:525
+#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:556
-#: lib/typster_web/live/editor_live/index.html.heex:564
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:574
+#: lib/typster_web/live/editor_live/index.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:500
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:509
-#: lib/typster_web/live/editor_live/index.html.heex:529
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:519
+#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:434
+#: lib/typster_web/live/editor_live/index.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:41
+#: lib/typster_web/live/editor_live/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.html.heex:39
+#: lib/typster_web/live/editor_live/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:417
+#: lib/typster_web/live/editor_live/index.html.heex:427
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:426
+#: lib/typster_web/live/editor_live/index.html.heex:436
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -832,38 +832,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:391
+#: lib/typster_web/live/editor_live/index.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:380
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:389
+#: lib/typster_web/live/editor_live/index.html.heex:399
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:378
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:360
+#: lib/typster_web/live/editor_live/index.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1991,17 +1991,17 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
@@ -2011,39 +2011,39 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:99
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:98
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:98
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:173
+#: lib/typster_web/live/editor_live/index.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:162
+#: lib/typster_web/live/editor_live/index.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:217
-#: lib/typster_web/live/editor_live/index.ex:355
+#: lib/typster_web/live/editor_live/index.ex:241
+#: lib/typster_web/live/editor_live/index.ex:379
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2053,17 +2053,17 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:293
+#: lib/typster_web/live/editor_live/index.ex:317
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:262
+#: lib/typster_web/live/editor_live/index.ex:286
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:124
+#: lib/typster_web/live/editor_live/index.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Закреплённые"
@@ -2092,3 +2092,11 @@ msgstr "Закреплён"
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
+
+#: lib/typster_web/live/editor_live/index.html.heex:209
+#, elixir-autogen, elixir-format
+msgid "%{count} section"
+msgid_plural "%{count} sections"
+msgstr[0] "%{count} раздел"
+msgstr[1] "%{count} раздела"
+msgstr[2] "%{count} разделов"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
@@ -143,8 +143,8 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:417
-#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:420
+#: lib/typster_web/live/editor_live/index.html.heex:421
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
@@ -154,12 +154,12 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:251
+#: lib/typster_web/live/editor_live/index.ex:260
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:248
+#: lib/typster_web/live/editor_live/index.ex:257
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
@@ -169,13 +169,13 @@ msgstr "Ассет на месте."
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:277
+#: lib/typster_web/live/editor_live/index.ex:290
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:208
-#: lib/typster_web/live/editor_live/index.ex:217
+#: lib/typster_web/live/editor_live/index.ex:206
+#: lib/typster_web/live/editor_live/index.ex:226
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -185,7 +185,7 @@ msgstr "Неподдерживаемый формат файла."
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:240
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
@@ -195,33 +195,33 @@ msgstr "Файла нет"
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:375
+#: lib/typster_web/live/editor_live/index.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:433
+#: lib/typster_web/live/editor_live/index.html.heex:436
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:337
+#: lib/typster_web/live/editor_live/index.ex:364
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:335
+#: lib/typster_web/live/editor_live/index.ex:362
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:336
+#: lib/typster_web/live/editor_live/index.ex:363
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:200
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:203
+#: lib/typster_web/live/editor_live/index.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -515,17 +515,17 @@ msgstr "Настройки аккаунта"
 msgid "editor.command"
 msgstr "⌘K"
 
-#: lib/typster_web/live/editor_live/index.html.heex:452
+#: lib/typster_web/live/editor_live/index.html.heex:455
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -536,118 +536,118 @@ msgstr "Компиляция…"
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:249
-#: lib/typster_web/live/editor_live/index.html.heex:250
+#: lib/typster_web/live/editor_live/index.html.heex:252
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:268
-#: lib/typster_web/live/editor_live/index.html.heex:269
+#: lib/typster_web/live/editor_live/index.html.heex:271
+#: lib/typster_web/live/editor_live/index.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:315
-#: lib/typster_web/live/editor_live/index.html.heex:316
+#: lib/typster_web/live/editor_live/index.html.heex:318
+#: lib/typster_web/live/editor_live/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:296
-#: lib/typster_web/live/editor_live/index.html.heex:297
+#: lib/typster_web/live/editor_live/index.html.heex:299
+#: lib/typster_web/live/editor_live/index.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:277
-#: lib/typster_web/live/editor_live/index.html.heex:278
+#: lib/typster_web/live/editor_live/index.html.heex:280
+#: lib/typster_web/live/editor_live/index.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:287
-#: lib/typster_web/live/editor_live/index.html.heex:288
+#: lib/typster_web/live/editor_live/index.html.heex:290
+#: lib/typster_web/live/editor_live/index.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:305
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:309
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:177
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:483
-#: lib/typster_web/live/editor_live/index.html.heex:491
-#: lib/typster_web/live/editor_live/index.html.heex:500
+#: lib/typster_web/live/editor_live/index.html.heex:486
+#: lib/typster_web/live/editor_live/index.html.heex:494
+#: lib/typster_web/live/editor_live/index.html.heex:503
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:531
-#: lib/typster_web/live/editor_live/index.html.heex:539
-#: lib/typster_web/live/editor_live/index.html.heex:548
+#: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:514
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:484
-#: lib/typster_web/live/editor_live/index.html.heex:504
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:532
-#: lib/typster_web/live/editor_live/index.html.heex:551
-#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/live/editor_live/index.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:409
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -662,17 +662,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:401
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:397
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -836,38 +836,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:364
+#: lib/typster_web/live/editor_live/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:353
+#: lib/typster_web/live/editor_live/index.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:352
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:325
-#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:328
+#: lib/typster_web/live/editor_live/index.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -2036,7 +2036,7 @@ msgstr "Дерево"
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:148
+#: lib/typster_web/live/editor_live/index.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
@@ -2045,3 +2045,9 @@ msgstr "Добавится по нажатию Enter"
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
+
+#: lib/typster_web/live/editor_live/index.ex:214
+#: lib/typster_web/live/editor_live/index.ex:289
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_exists"
+msgstr "Файл с таким путём уже существует — выбери другое имя."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -143,41 +143,41 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:570
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:576
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
 #: lib/typster_web/live/editor_live/index.html.heex:80
-#: lib/typster_web/live/editor_live/index.html.heex:152
+#: lib/typster_web/live/editor_live/index.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:466
+#: lib/typster_web/live/editor_live/index.ex:479
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:463
+#: lib/typster_web/live/editor_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:187
+#: lib/typster_web/live/editor_live/index.ex:193
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:497
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:337
-#: lib/typster_web/live/editor_live/index.ex:361
-#: lib/typster_web/live/editor_live/index.ex:639
+#: lib/typster_web/live/editor_live/index.ex:350
+#: lib/typster_web/live/editor_live/index.ex:374
+#: lib/typster_web/live/editor_live/index.ex:652
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -192,7 +192,7 @@ msgstr "Новый файл"
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:157
+#: lib/typster_web/live/editor_live/index.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
@@ -202,22 +202,22 @@ msgstr "Файлов пока нет"
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:574
+#: lib/typster_web/live/editor_live/index.ex:587
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:572
+#: lib/typster_web/live/editor_live/index.ex:585
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:573
+#: lib/typster_web/live/editor_live/index.ex:586
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -513,17 +513,17 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:540
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:536
+#: lib/typster_web/live/editor_live/index.html.heex:541
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -592,60 +592,60 @@ msgstr "Структура"
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:636
-#: lib/typster_web/live/editor_live/index.html.heex:644
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:688
-#: lib/typster_web/live/editor_live/index.html.heex:696
-#: lib/typster_web/live/editor_live/index.html.heex:705
+#: lib/typster_web/live/editor_live/index.html.heex:693
+#: lib/typster_web/live/editor_live/index.html.heex:701
+#: lib/typster_web/live/editor_live/index.html.heex:710
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:671
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:693
+#: lib/typster_web/live/editor_live/index.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:628
+#: lib/typster_web/live/editor_live/index.html.heex:633
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:637
-#: lib/typster_web/live/editor_live/index.html.heex:661
-#: lib/typster_web/live/editor_live/index.html.heex:667
+#: lib/typster_web/live/editor_live/index.html.heex:642
+#: lib/typster_web/live/editor_live/index.html.heex:666
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:689
-#: lib/typster_web/live/editor_live/index.html.heex:708
-#: lib/typster_web/live/editor_live/index.html.heex:717
+#: lib/typster_web/live/editor_live/index.html.heex:694
+#: lib/typster_web/live/editor_live/index.html.heex:713
+#: lib/typster_web/live/editor_live/index.html.heex:722
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:532
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:567
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -660,17 +660,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:559
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:550
+#: lib/typster_web/live/editor_live/index.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -2034,19 +2034,19 @@ msgstr "Дерево"
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:307
-#: lib/typster_web/live/editor_live/index.ex:348
-#: lib/typster_web/live/editor_live/index.ex:496
+#: lib/typster_web/live/editor_live/index.ex:315
+#: lib/typster_web/live/editor_live/index.ex:361
+#: lib/typster_web/live/editor_live/index.ex:509
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2056,12 +2056,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:433
+#: lib/typster_web/live/editor_live/index.ex:446
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:402
+#: lib/typster_web/live/editor_live/index.ex:415
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2071,30 +2071,30 @@ msgstr "Файл удалён."
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
-#: lib/typster_web/file_tree.ex:216
+#: lib/typster_web/file_tree.ex:218
 #: lib/typster_web/live/editor_live/index.html.heex:334
 #: lib/typster_web/live/editor_live/index.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
 
-#: lib/typster_web/file_tree.ex:215
+#: lib/typster_web/file_tree.ex:217
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr "Удалить этот файл? Это нельзя отменить."
 
-#: lib/typster_web/file_tree.ex:200
+#: lib/typster_web/file_tree.ex:202
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
-#: lib/typster_web/file_tree.ex:186
+#: lib/typster_web/file_tree.ex:188
 #: lib/typster_web/live/editor_live/index.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
 
-#: lib/typster_web/file_tree.ex:199
+#: lib/typster_web/file_tree.ex:201
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
@@ -2112,7 +2112,7 @@ msgstr[2] "%{count} разделов"
 msgid "editor.new_folder"
 msgstr "Новая папка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "имя папки"
@@ -2127,7 +2127,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:589
+#: lib/typster_web/live/editor_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2153,7 +2153,15 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:640
+#: lib/typster_web/live/editor_live/index.ex:653
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
+
+#: lib/typster_web/live/editor_live/index.html.heex:534
+#, elixir-autogen, elixir-format
+msgid "%{count} error"
+msgid_plural "%{count} errors"
+msgstr[0] "%{count} ошибка"
+msgstr[1] "%{count} ошибки"
+msgstr[2] "%{count} ошибок"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -133,33 +133,33 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:38
+#: lib/typster_web/live/editor_live/index.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:420
-#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:430
+#: lib/typster_web/live/editor_live/index.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:58
+#: lib/typster_web/live/editor_live/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:263
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:257
+#: lib/typster_web/live/editor_live/index.ex:260
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
@@ -169,59 +169,59 @@ msgstr "Ассет на месте."
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:290
+#: lib/typster_web/live/editor_live/index.ex:293
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
 #: lib/typster_web/live/editor_live/index.ex:206
-#: lib/typster_web/live/editor_live/index.ex:226
+#: lib/typster_web/live/editor_live/index.ex:229
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:83
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:115
+#: lib/typster_web/live/editor_live/index.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:378
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:436
+#: lib/typster_web/live/editor_live/index.html.heex:446
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:364
+#: lib/typster_web/live/editor_live/index.ex:367
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:362
+#: lib/typster_web/live/editor_live/index.ex:365
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:363
+#: lib/typster_web/live/editor_live/index.ex:366
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:203
-#: lib/typster_web/live/editor_live/index.html.heex:232
+#: lib/typster_web/live/editor_live/index.html.heex:213
+#: lib/typster_web/live/editor_live/index.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -510,169 +510,164 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:23
-#, elixir-autogen, elixir-format
-msgid "editor.command"
-msgstr "⌘K"
-
-#: lib/typster_web/live/editor_live/index.html.heex:455
+#: lib/typster_web/live/editor_live/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:51
-#: lib/typster_web/live/editor_live/index.html.heex:52
+#: lib/typster_web/live/editor_live/index.html.heex:61
+#: lib/typster_web/live/editor_live/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:252
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:262
+#: lib/typster_web/live/editor_live/index.html.heex:263
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:271
-#: lib/typster_web/live/editor_live/index.html.heex:272
+#: lib/typster_web/live/editor_live/index.html.heex:281
+#: lib/typster_web/live/editor_live/index.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:318
-#: lib/typster_web/live/editor_live/index.html.heex:319
+#: lib/typster_web/live/editor_live/index.html.heex:328
+#: lib/typster_web/live/editor_live/index.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
-#: lib/typster_web/live/editor_live/index.html.heex:262
+#: lib/typster_web/live/editor_live/index.html.heex:271
+#: lib/typster_web/live/editor_live/index.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:299
-#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:280
-#: lib/typster_web/live/editor_live/index.html.heex:281
+#: lib/typster_web/live/editor_live/index.html.heex:290
+#: lib/typster_web/live/editor_live/index.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:290
-#: lib/typster_web/live/editor_live/index.html.heex:291
+#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:308
-#: lib/typster_web/live/editor_live/index.html.heex:309
+#: lib/typster_web/live/editor_live/index.html.heex:318
+#: lib/typster_web/live/editor_live/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:183
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:486
-#: lib/typster_web/live/editor_live/index.html.heex:494
-#: lib/typster_web/live/editor_live/index.html.heex:503
+#: lib/typster_web/live/editor_live/index.html.heex:496
+#: lib/typster_web/live/editor_live/index.html.heex:504
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:542
-#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:544
+#: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
-#: lib/typster_web/live/editor_live/index.html.heex:507
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:497
+#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:535
-#: lib/typster_web/live/editor_live/index.html.heex:554
-#: lib/typster_web/live/editor_live/index.html.heex:563
+#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:564
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:382
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:31
+#: lib/typster_web/live/editor_live/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.html.heex:29
+#: lib/typster_web/live/editor_live/index.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:405
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -836,38 +831,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:361
+#: lib/typster_web/live/editor_live/index.html.heex:371
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:369
+#: lib/typster_web/live/editor_live/index.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:356
+#: lib/typster_web/live/editor_live/index.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:328
-#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:339
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1995,17 +1990,17 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:64
+#: lib/typster_web/live/editor_live/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
@@ -2015,39 +2010,44 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:90
+#: lib/typster_web/live/editor_live/index.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:89
+#: lib/typster_web/live/editor_live/index.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:151
+#: lib/typster_web/live/editor_live/index.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:140
+#: lib/typster_web/live/editor_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:214
-#: lib/typster_web/live/editor_live/index.ex:289
+#: lib/typster_web/live/editor_live/index.ex:217
+#: lib/typster_web/live/editor_live/index.ex:292
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
+
+#: lib/typster_web/live/editor_live/index.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "editor.command_open"
+msgstr "Открыть палитру команд"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -587,50 +587,50 @@ msgstr "Структура"
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:744
-#: lib/typster_web/live/editor_live/index.html.heex:752
-#: lib/typster_web/live/editor_live/index.html.heex:761
+#: lib/typster_web/live/editor_live/index.html.heex:757
+#: lib/typster_web/live/editor_live/index.html.heex:765
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:796
-#: lib/typster_web/live/editor_live/index.html.heex:804
-#: lib/typster_web/live/editor_live/index.html.heex:813
+#: lib/typster_web/live/editor_live/index.html.heex:809
+#: lib/typster_web/live/editor_live/index.html.heex:817
+#: lib/typster_web/live/editor_live/index.html.heex:826
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:779
+#: lib/typster_web/live/editor_live/index.html.heex:792
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:801
+#: lib/typster_web/live/editor_live/index.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:736
+#: lib/typster_web/live/editor_live/index.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:769
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:758
+#: lib/typster_web/live/editor_live/index.html.heex:782
+#: lib/typster_web/live/editor_live/index.html.heex:788
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:762
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:797
-#: lib/typster_web/live/editor_live/index.html.heex:816
-#: lib/typster_web/live/editor_live/index.html.heex:825
+#: lib/typster_web/live/editor_live/index.html.heex:810
+#: lib/typster_web/live/editor_live/index.html.heex:829
+#: lib/typster_web/live/editor_live/index.html.heex:838
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
@@ -2155,7 +2155,7 @@ msgstr "Добавлено в проект."
 
 #: lib/typster_web/live/editor_live/index.ex:789
 #: lib/typster_web/live/editor_live/index.html.heex:534
-#: lib/typster_web/live/editor_live/index.html.heex:709
+#: lib/typster_web/live/editor_live/index.html.heex:722
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2163,7 +2163,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:790
+#: lib/typster_web/live/editor_live/index.ex:791
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2171,17 +2171,17 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:793
+#: lib/typster_web/live/editor_live/index.ex:795
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:638
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Очистить лог"
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Закрыть панель"
@@ -2192,17 +2192,17 @@ msgid "editor.drawer.jump_first"
 msgstr "К первой"
 
 #: lib/typster_web/live/editor_live/index.html.heex:605
-#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Лог компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:662
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "Пока нет компиляций"
 
-#: lib/typster_web/live/editor_live/index.html.heex:662
+#: lib/typster_web/live/editor_live/index.html.heex:675
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "Нет проблем"
@@ -2212,7 +2212,17 @@ msgstr "Нет проблем"
 msgid "editor.drawer.problems"
 msgstr "Проблемы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:702
+#: lib/typster_web/live/editor_live/index.html.heex:715
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Показать панель компиляции"
+
+#: lib/typster_web/live/editor_live/index.html.heex:635
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.delay_off"
+msgstr "Выкл"
+
+#: lib/typster_web/live/editor_live/index.html.heex:633
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.recompile"
+msgstr "Перекомпиляция через"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
@@ -143,86 +143,86 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:452
-#: lib/typster_web/live/editor_live/index.html.heex:453
+#: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
 #: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:350
+#: lib/typster_web/live/editor_live/index.ex:377
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:347
+#: lib/typster_web/live/editor_live/index.ex:374
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:179
+#: lib/typster_web/live/editor_live/index.ex:166
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:380
+#: lib/typster_web/live/editor_live/index.ex:407
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:230
-#: lib/typster_web/live/editor_live/index.ex:253
+#: lib/typster_web/live/editor_live/index.ex:257
+#: lib/typster_web/live/editor_live/index.ex:280
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:85
+#: lib/typster_web/live/editor_live/index.html.heex:93
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:275
+#: lib/typster_web/live/editor_live/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:139
+#: lib/typster_web/live/editor_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:454
+#: lib/typster_web/live/editor_live/index.ex:484
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:452
+#: lib/typster_web/live/editor_live/index.ex:482
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:483
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:235
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -511,17 +511,17 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:487
+#: lib/typster_web/live/editor_live/index.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:418
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -532,118 +532,118 @@ msgstr "Компиляция…"
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:284
-#: lib/typster_web/live/editor_live/index.html.heex:285
+#: lib/typster_web/live/editor_live/index.html.heex:307
+#: lib/typster_web/live/editor_live/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:303
-#: lib/typster_web/live/editor_live/index.html.heex:304
+#: lib/typster_web/live/editor_live/index.html.heex:326
+#: lib/typster_web/live/editor_live/index.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:373
+#: lib/typster_web/live/editor_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:293
-#: lib/typster_web/live/editor_live/index.html.heex:294
+#: lib/typster_web/live/editor_live/index.html.heex:316
+#: lib/typster_web/live/editor_live/index.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:331
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:312
-#: lib/typster_web/live/editor_live/index.html.heex:313
+#: lib/typster_web/live/editor_live/index.html.heex:335
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:322
-#: lib/typster_web/live/editor_live/index.html.heex:323
+#: lib/typster_web/live/editor_live/index.html.heex:345
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:340
-#: lib/typster_web/live/editor_live/index.html.heex:341
+#: lib/typster_web/live/editor_live/index.html.heex:363
+#: lib/typster_web/live/editor_live/index.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:207
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:214
+#: lib/typster_web/live/editor_live/index.html.heex:237
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
-#: lib/typster_web/live/editor_live/index.html.heex:526
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:541
+#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:566
-#: lib/typster_web/live/editor_live/index.html.heex:574
-#: lib/typster_web/live/editor_live/index.html.heex:583
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:597
+#: lib/typster_web/live/editor_live/index.html.heex:606
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:533
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:519
-#: lib/typster_web/live/editor_live/index.html.heex:539
-#: lib/typster_web/live/editor_live/index.html.heex:545
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:568
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:567
-#: lib/typster_web/live/editor_live/index.html.heex:586
-#: lib/typster_web/live/editor_live/index.html.heex:595
+#: lib/typster_web/live/editor_live/index.html.heex:590
+#: lib/typster_web/live/editor_live/index.html.heex:609
+#: lib/typster_web/live/editor_live/index.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:444
+#: lib/typster_web/live/editor_live/index.html.heex:467
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -658,17 +658,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:427
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:436
+#: lib/typster_web/live/editor_live/index.html.heex:459
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:432
+#: lib/typster_web/live/editor_live/index.html.heex:455
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -832,38 +832,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:416
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:401
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:399
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:360
-#: lib/typster_web/live/editor_live/index.html.heex:361
+#: lib/typster_web/live/editor_live/index.html.heex:383
+#: lib/typster_web/live/editor_live/index.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1991,12 +1991,12 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
@@ -2011,39 +2011,40 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:102
+#: lib/typster_web/live/editor_live/index.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:101
+#: lib/typster_web/live/editor_live/index.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:175
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:164
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:241
-#: lib/typster_web/live/editor_live/index.ex:379
+#: lib/typster_web/live/editor_live/index.ex:227
+#: lib/typster_web/live/editor_live/index.ex:268
+#: lib/typster_web/live/editor_live/index.ex:406
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2053,50 +2054,60 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:317
+#: lib/typster_web/live/editor_live/index.ex:344
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:286
+#: lib/typster_web/live/editor_live/index.ex:313
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:126
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
-#: lib/typster_web/file_tree.ex:187
+#: lib/typster_web/file_tree.ex:209
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
 
-#: lib/typster_web/file_tree.ex:185
+#: lib/typster_web/file_tree.ex:207
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr "Удалить этот файл? Это нельзя отменить."
 
-#: lib/typster_web/file_tree.ex:174
+#: lib/typster_web/file_tree.ex:196
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
-#: lib/typster_web/file_tree.ex:159
+#: lib/typster_web/file_tree.ex:181
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
 
-#: lib/typster_web/file_tree.ex:173
+#: lib/typster_web/file_tree.ex:195
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] "%{count} раздел"
 msgstr[1] "%{count} раздела"
 msgstr[2] "%{count} разделов"
+
+#: lib/typster_web/live/editor_live/index.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "editor.new_folder"
+msgstr "Новая папка"
+
+#: lib/typster_web/live/editor_live/index.html.heex:184
+#, elixir-autogen, elixir-format
+msgid "editor.newfolder.placeholder"
+msgstr "имя папки"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:266
+#: lib/typster_web/live/editor_live/index.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
@@ -143,8 +143,8 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:577
-#: lib/typster_web/live/editor_live/index.html.heex:578
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
@@ -155,28 +155,29 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:485
+#: lib/typster_web/live/editor_live/index.ex:466
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:463
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:176
+#: lib/typster_web/live/editor_live/index.ex:187
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:516
+#: lib/typster_web/live/editor_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:356
-#: lib/typster_web/live/editor_live/index.ex:380
+#: lib/typster_web/live/editor_live/index.ex:337
+#: lib/typster_web/live/editor_live/index.ex:361
+#: lib/typster_web/live/editor_live/index.ex:639
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -186,7 +187,7 @@ msgstr "Неподдерживаемый формат файла."
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
@@ -196,33 +197,33 @@ msgstr "Файла нет"
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:535
+#: lib/typster_web/live/editor_live/index.html.heex:528
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:593
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:593
+#: lib/typster_web/live/editor_live/index.ex:574
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:591
+#: lib/typster_web/live/editor_live/index.ex:572
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:592
+#: lib/typster_web/live/editor_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:271
-#: lib/typster_web/live/editor_live/index.html.heex:300
+#: lib/typster_web/live/editor_live/index.html.heex:272
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -512,17 +513,17 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:540
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:543
+#: lib/typster_web/live/editor_live/index.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -533,118 +534,118 @@ msgstr "Компиляция…"
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:409
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:402
+#: lib/typster_web/live/editor_live/index.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:428
-#: lib/typster_web/live/editor_live/index.html.heex:429
+#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:418
-#: lib/typster_web/live/editor_live/index.html.heex:419
+#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:456
-#: lib/typster_web/live/editor_live/index.html.heex:457
+#: lib/typster_web/live/editor_live/index.html.heex:449
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
-#: lib/typster_web/live/editor_live/index.html.heex:438
+#: lib/typster_web/live/editor_live/index.html.heex:430
+#: lib/typster_web/live/editor_live/index.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:447
-#: lib/typster_web/live/editor_live/index.html.heex:448
+#: lib/typster_web/live/editor_live/index.html.heex:440
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
-#: lib/typster_web/live/editor_live/index.html.heex:466
+#: lib/typster_web/live/editor_live/index.html.heex:458
+#: lib/typster_web/live/editor_live/index.html.heex:459
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:250
+#: lib/typster_web/live/editor_live/index.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:643
-#: lib/typster_web/live/editor_live/index.html.heex:651
-#: lib/typster_web/live/editor_live/index.html.heex:660
+#: lib/typster_web/live/editor_live/index.html.heex:636
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:653
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
-#: lib/typster_web/live/editor_live/index.html.heex:699
-#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:688
+#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:705
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:674
+#: lib/typster_web/live/editor_live/index.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:635
+#: lib/typster_web/live/editor_live/index.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
-#: lib/typster_web/live/editor_live/index.html.heex:664
-#: lib/typster_web/live/editor_live/index.html.heex:670
+#: lib/typster_web/live/editor_live/index.html.heex:637
+#: lib/typster_web/live/editor_live/index.html.heex:661
+#: lib/typster_web/live/editor_live/index.html.heex:667
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:641
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:692
-#: lib/typster_web/live/editor_live/index.html.heex:711
-#: lib/typster_web/live/editor_live/index.html.heex:720
+#: lib/typster_web/live/editor_live/index.html.heex:689
+#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:532
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:569
+#: lib/typster_web/live/editor_live/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -659,17 +660,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -833,38 +834,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:519
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:515
+#: lib/typster_web/live/editor_live/index.html.heex:508
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:524
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:512
+#: lib/typster_web/live/editor_live/index.html.heex:505
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:485
-#: lib/typster_web/live/editor_live/index.html.heex:486
+#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -2033,19 +2034,19 @@ msgstr "Дерево"
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:195
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:326
-#: lib/typster_web/live/editor_live/index.ex:367
-#: lib/typster_web/live/editor_live/index.ex:515
+#: lib/typster_web/live/editor_live/index.ex:307
+#: lib/typster_web/live/editor_live/index.ex:348
+#: lib/typster_web/live/editor_live/index.ex:496
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,12 +2056,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:452
+#: lib/typster_web/live/editor_live/index.ex:433
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:421
+#: lib/typster_web/live/editor_live/index.ex:402
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2070,35 +2071,35 @@ msgstr "Файл удалён."
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
-#: lib/typster_web/file_tree.ex:209
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/file_tree.ex:216
 #: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
 
-#: lib/typster_web/file_tree.ex:207
+#: lib/typster_web/file_tree.ex:215
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete_confirm"
 msgstr "Удалить этот файл? Это нельзя отменить."
 
-#: lib/typster_web/file_tree.ex:196
+#: lib/typster_web/file_tree.ex:200
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
-#: lib/typster_web/file_tree.ex:181
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/file_tree.ex:186
+#: lib/typster_web/live/editor_live/index.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
 
-#: lib/typster_web/file_tree.ex:195
+#: lib/typster_web/file_tree.ex:199
 #, elixir-autogen, elixir-format
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:245
+#: lib/typster_web/live/editor_live/index.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2111,7 +2112,7 @@ msgstr[2] "%{count} разделов"
 msgid "editor.new_folder"
 msgstr "Новая папка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:194
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "имя папки"
@@ -2121,43 +2122,38 @@ msgstr "имя папки"
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:393
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:280
-#, elixir-autogen, elixir-format
-msgid "editor.flash.template_failed"
-msgstr "Не удалось сохранить шаблон."
-
-#: lib/typster_web/live/editor_live/index.ex:285
+#: lib/typster_web/live/editor_live/index.ex:589
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:306
+#: lib/typster_web/live/editor_live/index.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Ваши шаблоны"
 
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Удалить этот шаблон?"
-
-#: lib/typster_web/live/editor_live/index.html.heex:362
-#, elixir-autogen, elixir-format
-msgid "editor.tpl.save"
-msgstr "Сохранить шаблон"
 
 #: lib/typster_web/live/editor_live/index.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Загрузите файл для повторного использования"
 
-#: lib/typster_web/live/editor_live/index.html.heex:322
 #: lib/typster_web/live/editor_live/index.html.heex:323
+#: lib/typster_web/live/editor_live/index.html.heex:324
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
+
+#: lib/typster_web/live/editor_live/index.ex:640
+#, elixir-autogen, elixir-format
+msgid "editor.flash.dropped_added"
+msgstr "Добавлено в проект."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
@@ -143,23 +143,24 @@ msgstr "Ассеты"
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:430
-#: lib/typster_web/live/editor_live/index.html.heex:431
+#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
 #: lib/typster_web/live/editor_live/index.html.heex:68
+#: lib/typster_web/live/editor_live/index.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:263
+#: lib/typster_web/live/editor_live/index.ex:326
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:260
+#: lib/typster_web/live/editor_live/index.ex:323
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
@@ -169,7 +170,7 @@ msgstr "Ассет на месте."
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:293
+#: lib/typster_web/live/editor_live/index.ex:356
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
@@ -185,43 +186,43 @@ msgstr "Неподдерживаемый формат файла."
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:125
+#: lib/typster_web/live/editor_live/index.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:446
+#: lib/typster_web/live/editor_live/index.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:367
+#: lib/typster_web/live/editor_live/index.ex:430
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:365
+#: lib/typster_web/live/editor_live/index.ex:428
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:366
+#: lib/typster_web/live/editor_live/index.ex:429
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:213
-#: lib/typster_web/live/editor_live/index.html.heex:242
+#: lib/typster_web/live/editor_live/index.html.heex:225
+#: lib/typster_web/live/editor_live/index.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -510,17 +511,17 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:400
+#: lib/typster_web/live/editor_live/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:396
+#: lib/typster_web/live/editor_live/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
@@ -531,118 +532,118 @@ msgstr "Компиляция…"
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:262
-#: lib/typster_web/live/editor_live/index.html.heex:263
+#: lib/typster_web/live/editor_live/index.html.heex:274
+#: lib/typster_web/live/editor_live/index.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:281
-#: lib/typster_web/live/editor_live/index.html.heex:282
+#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:328
-#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:271
-#: lib/typster_web/live/editor_live/index.html.heex:272
+#: lib/typster_web/live/editor_live/index.html.heex:283
+#: lib/typster_web/live/editor_live/index.html.heex:284
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:309
-#: lib/typster_web/live/editor_live/index.html.heex:310
+#: lib/typster_web/live/editor_live/index.html.heex:321
+#: lib/typster_web/live/editor_live/index.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:290
-#: lib/typster_web/live/editor_live/index.html.heex:291
+#: lib/typster_web/live/editor_live/index.html.heex:302
+#: lib/typster_web/live/editor_live/index.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:300
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:312
+#: lib/typster_web/live/editor_live/index.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:318
-#: lib/typster_web/live/editor_live/index.html.heex:319
+#: lib/typster_web/live/editor_live/index.html.heex:330
+#: lib/typster_web/live/editor_live/index.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:190
+#: lib/typster_web/live/editor_live/index.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:496
-#: lib/typster_web/live/editor_live/index.html.heex:504
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:508
+#: lib/typster_web/live/editor_live/index.html.heex:516
+#: lib/typster_web/live/editor_live/index.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:544
-#: lib/typster_web/live/editor_live/index.html.heex:552
-#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:564
+#: lib/typster_web/live/editor_live/index.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:527
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:549
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:497
-#: lib/typster_web/live/editor_live/index.html.heex:517
-#: lib/typster_web/live/editor_live/index.html.heex:523
+#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:501
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:545
-#: lib/typster_web/live/editor_live/index.html.heex:564
-#: lib/typster_web/live/editor_live/index.html.heex:573
+#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:434
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
@@ -657,17 +658,17 @@ msgstr "Поделиться"
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:405
+#: lib/typster_web/live/editor_live/index.html.heex:417
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:414
+#: lib/typster_web/live/editor_live/index.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -831,38 +832,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:371
+#: lib/typster_web/live/editor_live/index.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:379
+#: lib/typster_web/live/editor_live/index.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:368
+#: lib/typster_web/live/editor_live/index.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:377
+#: lib/typster_web/live/editor_live/index.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:366
+#: lib/typster_web/live/editor_live/index.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:365
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
-#: lib/typster_web/live/editor_live/index.html.heex:339
+#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -2031,18 +2032,18 @@ msgstr "Дерево"
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:161
+#: lib/typster_web/live/editor_live/index.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:150
+#: lib/typster_web/live/editor_live/index.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
 #: lib/typster_web/live/editor_live/index.ex:217
-#: lib/typster_web/live/editor_live/index.ex:292
+#: lib/typster_web/live/editor_live/index.ex:355
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2051,3 +2052,43 @@ msgstr "Файл с таким путём уже существует — выб
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
+
+#: lib/typster_web/live/editor_live/index.ex:293
+#, elixir-autogen, elixir-format
+msgid "editor.flash.asset_deleted"
+msgstr "Ассет удалён."
+
+#: lib/typster_web/live/editor_live/index.ex:262
+#, elixir-autogen, elixir-format
+msgid "editor.flash.file_deleted"
+msgstr "Файл удалён."
+
+#: lib/typster_web/live/editor_live/index.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "editor.pinned"
+msgstr "Закреплённые"
+
+#: lib/typster_web/file_tree.ex:187
+#, elixir-autogen, elixir-format
+msgid "editor.tree.delete"
+msgstr "Удалить файл"
+
+#: lib/typster_web/file_tree.ex:185
+#, elixir-autogen, elixir-format
+msgid "editor.tree.delete_confirm"
+msgstr "Удалить этот файл? Это нельзя отменить."
+
+#: lib/typster_web/file_tree.ex:174
+#, elixir-autogen, elixir-format
+msgid "editor.tree.pin"
+msgstr "Закрепить файл"
+
+#: lib/typster_web/file_tree.ex:159
+#, elixir-autogen, elixir-format
+msgid "editor.tree.pinned"
+msgstr "Закреплён"
+
+#: lib/typster_web/file_tree.ex:173
+#, elixir-autogen, elixir-format
+msgid "editor.tree.unpin"
+msgstr "Открепить файл"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -155,29 +155,29 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:479
+#: lib/typster_web/live/editor_live/index.ex:513
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:476
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:193
+#: lib/typster_web/live/editor_live/index.ex:227
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:544
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:350
-#: lib/typster_web/live/editor_live/index.ex:374
-#: lib/typster_web/live/editor_live/index.ex:652
+#: lib/typster_web/live/editor_live/index.ex:384
+#: lib/typster_web/live/editor_live/index.ex:408
+#: lib/typster_web/live/editor_live/index.ex:686
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -207,17 +207,17 @@ msgstr "Превью"
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:587
+#: lib/typster_web/live/editor_live/index.ex:621
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:585
+#: lib/typster_web/live/editor_live/index.ex:619
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:586
+#: lib/typster_web/live/editor_live/index.ex:620
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -513,11 +513,6 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:610
-#, elixir-autogen, elixir-format
-msgid "editor.command_hint"
-msgstr "⌘K — команды"
-
 #: lib/typster_web/live/editor_live/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
@@ -592,50 +587,50 @@ msgstr "Структура"
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
-#: lib/typster_web/live/editor_live/index.html.heex:649
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:744
+#: lib/typster_web/live/editor_live/index.html.heex:752
+#: lib/typster_web/live/editor_live/index.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:693
-#: lib/typster_web/live/editor_live/index.html.heex:701
-#: lib/typster_web/live/editor_live/index.html.heex:710
+#: lib/typster_web/live/editor_live/index.html.heex:796
+#: lib/typster_web/live/editor_live/index.html.heex:804
+#: lib/typster_web/live/editor_live/index.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:779
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:698
+#: lib/typster_web/live/editor_live/index.html.heex:801
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:633
+#: lib/typster_web/live/editor_live/index.html.heex:736
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:642
-#: lib/typster_web/live/editor_live/index.html.heex:666
-#: lib/typster_web/live/editor_live/index.html.heex:672
+#: lib/typster_web/live/editor_live/index.html.heex:745
+#: lib/typster_web/live/editor_live/index.html.heex:769
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:694
-#: lib/typster_web/live/editor_live/index.html.heex:713
-#: lib/typster_web/live/editor_live/index.html.heex:722
+#: lib/typster_web/live/editor_live/index.html.heex:797
+#: lib/typster_web/live/editor_live/index.html.heex:816
+#: lib/typster_web/live/editor_live/index.html.heex:825
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
@@ -2044,9 +2039,9 @@ msgstr "Добавится по нажатию Enter"
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:315
-#: lib/typster_web/live/editor_live/index.ex:361
-#: lib/typster_web/live/editor_live/index.ex:509
+#: lib/typster_web/live/editor_live/index.ex:349
+#: lib/typster_web/live/editor_live/index.ex:395
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2056,12 +2051,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:446
+#: lib/typster_web/live/editor_live/index.ex:480
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:415
+#: lib/typster_web/live/editor_live/index.ex:449
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2127,7 +2122,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:602
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2153,15 +2148,71 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:653
+#: lib/typster_web/live/editor_live/index.ex:687
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
+#: lib/typster_web/live/editor_live/index.ex:789
 #: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:709
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
+
+#: lib/typster_web/live/editor_live/index.ex:790
+#, elixir-autogen, elixir-format
+msgid "%{count} warning"
+msgid_plural "%{count} warnings"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: lib/typster_web/live/editor_live/index.ex:793
+#, elixir-autogen, elixir-format
+msgid "editor.compile_failed"
+msgstr "Ошибка компиляции"
+
+#: lib/typster_web/live/editor_live/index.html.heex:638
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.clear"
+msgstr "Очистить лог"
+
+#: lib/typster_web/live/editor_live/index.html.heex:644
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.close"
+msgstr "Закрыть панель"
+
+#: lib/typster_web/live/editor_live/index.html.heex:630
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.jump_first"
+msgstr "К первой"
+
+#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.log"
+msgstr "Лог компиляции"
+
+#: lib/typster_web/live/editor_live/index.html.heex:652
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.log_empty"
+msgstr "Пока нет компиляций"
+
+#: lib/typster_web/live/editor_live/index.html.heex:662
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.no_problems"
+msgstr "Нет проблем"
+
+#: lib/typster_web/live/editor_live/index.html.heex:614
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.problems"
+msgstr "Проблемы"
+
+#: lib/typster_web/live/editor_live/index.html.heex:702
+#, elixir-autogen, elixir-format
+msgid "editor.drawer.toggle"
+msgstr "Показать панель компиляции"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -133,24 +133,24 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:50
+#: lib/typster_web/live/editor_live/index.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:488
+#: lib/typster_web/live/editor_live/index.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:142
+#: lib/typster_web/live/editor_live/index.html.heex:80
+#: lib/typster_web/live/editor_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
@@ -181,27 +181,27 @@ msgstr "Файл не удалось создать."
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:93
+#: lib/typster_web/live/editor_live/index.html.heex:103
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:298
+#: lib/typster_web/live/editor_live/index.html.heex:311
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:147
+#: lib/typster_web/live/editor_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:433
+#: lib/typster_web/live/editor_live/index.html.heex:446
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:491
+#: lib/typster_web/live/editor_live/index.html.heex:504
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
@@ -221,8 +221,8 @@ msgstr "Сохранено"
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
-#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:271
+#: lib/typster_web/live/editor_live/index.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
@@ -303,7 +303,8 @@ msgid "nav.my_projects"
 msgstr "Мои проекты"
 
 #: lib/typster_web/components/layouts.ex:164
-#: lib/typster_web/live/editor_live/index.html.heex:6
+#: lib/typster_web/live/editor_live/index.html.heex:8
+#: lib/typster_web/live/editor_live/index.html.heex:9
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
@@ -511,164 +512,164 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:510
+#: lib/typster_web/live/editor_live/index.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "editor.command_hint"
 msgstr "⌘K — команды"
 
-#: lib/typster_web/live/editor_live/index.html.heex:445
+#: lib/typster_web/live/editor_live/index.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:63
-#: lib/typster_web/live/editor_live/index.html.heex:64
+#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:307
-#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:320
+#: lib/typster_web/live/editor_live/index.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:326
-#: lib/typster_web/live/editor_live/index.html.heex:327
+#: lib/typster_web/live/editor_live/index.html.heex:339
+#: lib/typster_web/live/editor_live/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:373
-#: lib/typster_web/live/editor_live/index.html.heex:374
+#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:316
-#: lib/typster_web/live/editor_live/index.html.heex:317
+#: lib/typster_web/live/editor_live/index.html.heex:329
+#: lib/typster_web/live/editor_live/index.html.heex:330
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
-#: lib/typster_web/live/editor_live/index.html.heex:355
+#: lib/typster_web/live/editor_live/index.html.heex:367
+#: lib/typster_web/live/editor_live/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:335
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:348
+#: lib/typster_web/live/editor_live/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:345
-#: lib/typster_web/live/editor_live/index.html.heex:346
+#: lib/typster_web/live/editor_live/index.html.heex:358
+#: lib/typster_web/live/editor_live/index.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:363
-#: lib/typster_web/live/editor_live/index.html.heex:364
+#: lib/typster_web/live/editor_live/index.html.heex:376
+#: lib/typster_web/live/editor_live/index.html.heex:377
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:237
+#: lib/typster_web/live/editor_live/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:541
-#: lib/typster_web/live/editor_live/index.html.heex:549
-#: lib/typster_web/live/editor_live/index.html.heex:558
+#: lib/typster_web/live/editor_live/index.html.heex:554
+#: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:589
-#: lib/typster_web/live/editor_live/index.html.heex:597
-#: lib/typster_web/live/editor_live/index.html.heex:606
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:610
+#: lib/typster_web/live/editor_live/index.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:572
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:533
+#: lib/typster_web/live/editor_live/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:568
+#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:559
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:590
-#: lib/typster_web/live/editor_live/index.html.heex:609
-#: lib/typster_web/live/editor_live/index.html.heex:618
+#: lib/typster_web/live/editor_live/index.html.heex:603
+#: lib/typster_web/live/editor_live/index.html.heex:622
+#: lib/typster_web/live/editor_live/index.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:467
+#: lib/typster_web/live/editor_live/index.html.heex:480
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:43
+#: lib/typster_web/live/editor_live/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.html.heex:41
+#: lib/typster_web/live/editor_live/index.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
+#: lib/typster_web/live/editor_live/index.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:472
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:455
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -832,38 +833,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:416
+#: lib/typster_web/live/editor_live/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:424
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
+#: lib/typster_web/live/editor_live/index.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:424
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:410
+#: lib/typster_web/live/editor_live/index.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:383
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:396
+#: lib/typster_web/live/editor_live/index.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1991,17 +1992,17 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:111
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:111
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:76
+#: lib/typster_web/live/editor_live/index.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
@@ -2011,33 +2012,33 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:110
+#: lib/typster_web/live/editor_live/index.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:109
+#: lib/typster_web/live/editor_live/index.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
@@ -2049,7 +2050,7 @@ msgstr "имя файла"
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
 
-#: lib/typster_web/live/editor_live/index.html.heex:26
+#: lib/typster_web/live/editor_live/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
@@ -2064,7 +2065,7 @@ msgstr "Ассет удалён."
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Закреплённые"
@@ -2094,7 +2095,7 @@ msgstr "Закреплён"
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:232
+#: lib/typster_web/live/editor_live/index.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2102,12 +2103,17 @@ msgstr[0] "%{count} раздел"
 msgstr[1] "%{count} раздела"
 msgstr[2] "%{count} разделов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:85
+#: lib/typster_web/live/editor_live/index.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "Новая папка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:184
+#: lib/typster_web/live/editor_live/index.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "имя папки"
+
+#: lib/typster_web/live/editor_live/index.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "editor.breadcrumb"
+msgstr "Хлебные крошки"

--- a/priv/repo/migrations/20260525220503_unique_file_path_per_project.exs
+++ b/priv/repo/migrations/20260525220503_unique_file_path_per_project.exs
@@ -1,0 +1,7 @@
+defmodule Typster.Repo.Migrations.UniqueFilePathPerProject do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:files, [:project_id, :path])
+  end
+end

--- a/priv/repo/migrations/20260525220503_unique_file_path_per_project.exs
+++ b/priv/repo/migrations/20260525220503_unique_file_path_per_project.exs
@@ -1,7 +1,24 @@
 defmodule Typster.Repo.Migrations.UniqueFilePathPerProject do
   use Ecto.Migration
 
-  def change do
+  def up do
+    # Pre-existing data may already contain duplicate (project_id, path) rows
+    # from before this constraint. Collapse each group to the most recently
+    # updated row (ties broken by id) so the unique index can be created.
+    execute("""
+    DELETE FROM files a
+    USING files b
+    WHERE a.project_id = b.project_id
+      AND a.path = b.path
+      AND a.id <> b.id
+      AND (a.updated_at < b.updated_at
+           OR (a.updated_at = b.updated_at AND a.id < b.id))
+    """)
+
     create unique_index(:files, [:project_id, :path])
+  end
+
+  def down do
+    drop unique_index(:files, [:project_id, :path])
   end
 end

--- a/priv/repo/migrations/20260525224204_add_pinned_to_files.exs
+++ b/priv/repo/migrations/20260525224204_add_pinned_to_files.exs
@@ -1,0 +1,9 @@
+defmodule Typster.Repo.Migrations.AddPinnedToFiles do
+  use Ecto.Migration
+
+  def change do
+    alter table(:files) do
+      add :pinned, :boolean, null: false, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260525232233_create_templates.exs
+++ b/priv/repo/migrations/20260525232233_create_templates.exs
@@ -1,0 +1,17 @@
+defmodule Typster.Repo.Migrations.CreateTemplates do
+  use Ecto.Migration
+
+  def change do
+    create table(:templates, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :name, :text, null: false
+      add :content, :text
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:templates, [:user_id])
+  end
+end

--- a/test/typster/files_test.exs
+++ b/test/typster/files_test.exs
@@ -133,4 +133,23 @@ defmodule Typster.FilesTest do
       assert {:ok, _} = Files.create_file(scope, other.id, %{path: "main.typ"})
     end
   end
+
+  describe "set_pinned/3" do
+    setup do
+      user = Typster.AccountsFixtures.user_fixture()
+      %{scope: Typster.Accounts.Scope.for_user(user), project: project_fixture(user)}
+    end
+
+    test "toggles the pinned flag and persists it", %{scope: scope, project: project} do
+      {:ok, file} = Files.create_file(scope, project.id, %{path: "main.typ"})
+      refute file.pinned
+
+      assert {:ok, pinned} = Files.set_pinned(scope, file, true)
+      assert pinned.pinned
+      assert Files.get_file!(scope, file.id).pinned
+
+      assert {:ok, unpinned} = Files.set_pinned(scope, file, false)
+      refute unpinned.pinned
+    end
+  end
 end

--- a/test/typster/files_test.exs
+++ b/test/typster/files_test.exs
@@ -23,4 +23,90 @@ defmodule Typster.FilesTest do
       refute Files.editable_file?("archive.bin")
     end
   end
+
+  describe "majority_source_extension/1" do
+    test "defaults to .typ for an empty or Typst-heavy project" do
+      assert Files.majority_source_extension([]) == ".typ"
+      assert Files.majority_source_extension(["main.typ", "intro.typ", "notes.md"]) == ".typ"
+    end
+
+    test "suggests .tex when LaTeX sources dominate" do
+      assert Files.majority_source_extension(["main.tex", "appendix.tex", "intro.typ"]) == ".tex"
+      assert Files.majority_source_extension(["doc.tex", "macros.sty", "thesis.cls"]) == ".tex"
+    end
+
+    test "ties favor Typst" do
+      assert Files.majority_source_extension(["a.tex", "b.typ"]) == ".typ"
+    end
+
+    test "accepts File structs and maps, ignoring assets" do
+      files = [%Typster.Projects.File{path: "main.tex"}, %{path: "logo.png"}]
+      assert Files.majority_source_extension(files) == ".tex"
+    end
+  end
+
+  describe "new_file_suggestions/2" do
+    test "returns [] for empty input or an explicitly typed extension" do
+      assert Files.new_file_suggestions(["main.typ"], "") == []
+      assert Files.new_file_suggestions(["main.typ"], "  ") == []
+      assert Files.new_file_suggestions(["main.typ"], "notes.md") == []
+    end
+
+    test "suggests the project's majority source type for a plain name" do
+      assert Files.new_file_suggestions(["main.typ"], "conclusion") == ["conclusion.typ"]
+      assert Files.new_file_suggestions(["main.tex", "a.tex"], "conclusion") == ["conclusion.tex"]
+    end
+
+    test "a bib-like name with no existing .bib offers .bib first, then majority type" do
+      assert Files.new_file_suggestions(["main.typ"], "refs") == ["refs.bib", "refs.typ"]
+
+      assert Files.new_file_suggestions(["main.typ"], "references") == [
+               "references.bib",
+               "references.typ"
+             ]
+
+      assert Files.new_file_suggestions(["main.tex", "a.tex"], "biblio") == [
+               "biblio.bib",
+               "biblio.tex"
+             ]
+    end
+
+    test "a bib-like name only suggests the majority type once a .bib already exists" do
+      assert Files.new_file_suggestions(["main.typ", "refs.bib"], "library") == ["library.typ"]
+    end
+
+    test "short fragments below the match threshold are not treated as bib names" do
+      assert Files.new_file_suggestions(["main.typ"], "re") == ["re.typ"]
+    end
+
+    test "matches a bib name nested under a folder by its basename" do
+      assert Files.new_file_suggestions(["main.typ"], "src/bibliography") ==
+               ["src/bibliography.bib", "src/bibliography.typ"]
+    end
+  end
+
+  describe "resolve_new_file_path/2" do
+    test "keeps an explicitly typed extension" do
+      assert Files.resolve_new_file_path(["main.typ"], "notes.md") == "notes.md"
+      assert Files.resolve_new_file_path(["main.typ"], "refs.bib") == "refs.bib"
+    end
+
+    test "applies the first smart suggestion when no extension is typed" do
+      assert Files.resolve_new_file_path(["main.typ"], "conclusion") == "conclusion.typ"
+      assert Files.resolve_new_file_path(["main.tex", "a.tex"], "conclusion") == "conclusion.tex"
+      assert Files.resolve_new_file_path(["main.typ"], "refs") == "refs.bib"
+    end
+
+    test "trims whitespace and handles empty input" do
+      assert Files.resolve_new_file_path(["main.typ"], "  draft  ") == "draft.typ"
+      assert Files.resolve_new_file_path(["main.typ"], "") == ""
+    end
+  end
+
+  describe "has_bibliography?/1" do
+    test "detects an existing .bib file" do
+      refute Files.has_bibliography?(["main.typ", "notes.md"])
+      assert Files.has_bibliography?(["main.typ", "refs.bib"])
+    end
+  end
 end

--- a/test/typster/files_test.exs
+++ b/test/typster/files_test.exs
@@ -1,6 +1,8 @@
 defmodule Typster.FilesTest do
   use Typster.DataCase, async: true
 
+  import Typster.ProjectsFixtures
+
   alias Typster.Files
 
   describe "file classification" do
@@ -107,6 +109,28 @@ defmodule Typster.FilesTest do
     test "detects an existing .bib file" do
       refute Files.has_bibliography?(["main.typ", "notes.md"])
       assert Files.has_bibliography?(["main.typ", "refs.bib"])
+    end
+  end
+
+  describe "create_file/3 path uniqueness" do
+    setup do
+      user = Typster.AccountsFixtures.user_fixture()
+      %{scope: Typster.Accounts.Scope.for_user(user), project: project_fixture(user)}
+    end
+
+    test "rejects a second file with the same path in the same project", %{
+      scope: scope,
+      project: project
+    } do
+      assert {:ok, _} = Files.create_file(scope, project.id, %{path: "main.typ", content: ""})
+      assert {:error, changeset} = Files.create_file(scope, project.id, %{path: "main.typ"})
+      assert %{path: ["already exists in this project"]} = errors_on(changeset)
+    end
+
+    test "allows the same path in a different project", %{scope: scope, project: project} do
+      other = project_fixture(scope)
+      assert {:ok, _} = Files.create_file(scope, project.id, %{path: "main.typ"})
+      assert {:ok, _} = Files.create_file(scope, other.id, %{path: "main.typ"})
     end
   end
 end

--- a/test/typster/templates_test.exs
+++ b/test/typster/templates_test.exs
@@ -1,0 +1,30 @@
+defmodule Typster.TemplatesTest do
+  use Typster.DataCase, async: true
+
+  alias Typster.Templates
+
+  setup do
+    user = Typster.AccountsFixtures.user_fixture()
+    %{scope: Typster.Accounts.Scope.for_user(user)}
+  end
+
+  test "create, list and delete templates scoped to the user", %{scope: scope} do
+    assert Templates.list_templates(scope) == []
+
+    {:ok, tpl} = Templates.create_template(scope, %{name: "ieee.typ", content: "= Paper"})
+    assert [listed] = Templates.list_templates(scope)
+    assert listed.id == tpl.id
+    assert listed.content == "= Paper"
+
+    other = Typster.Accounts.Scope.for_user(Typster.AccountsFixtures.user_fixture())
+    assert Templates.list_templates(other) == []
+
+    assert {:ok, _} = Templates.delete_template(scope, tpl)
+    assert Templates.list_templates(scope) == []
+  end
+
+  test "requires a name", %{scope: scope} do
+    assert {:error, changeset} = Templates.create_template(scope, %{content: "x"})
+    assert %{name: ["can't be blank"]} = errors_on(changeset)
+  end
+end

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -215,6 +215,26 @@ defmodule TypsterWeb.EditorLiveTest do
     assert path_exists?(user, project, "chapters/untitled.typ")
   end
 
+  test "dropping a source file onto the editor creates it from the dropped content",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    input =
+      file_input(view, "#dropped-upload-form", :dropped, [
+        %{name: "dropped.typ", content: "= Dropped in", type: "text/plain"}
+      ])
+
+    render_upload(input, "dropped.typ")
+
+    scope = Typster.Accounts.Scope.for_user(user)
+
+    created =
+      Enum.find(Typster.Files.get_file_tree(scope, project.id), &(&1.path == "dropped.typ"))
+
+    assert created.content == "= Dropped in"
+  end
+
   test "using a template stages its content into the file you create",
        %{conn: conn, user: user, project: project} do
     scope = Typster.Accounts.Scope.for_user(user)

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -103,6 +103,42 @@ defmodule TypsterWeb.EditorLiveTest do
     assert Enum.count(tree, &(&1.path == "main.typ")) == 1
   end
 
+  test "pinning a file moves it into the Pinned section", %{
+    conn: conn,
+    user: user,
+    project: project
+  } do
+    file = file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    refute has_element?(view, ".ts-side__head--sub")
+
+    view
+    |> element("button[phx-click='toggle_pin'][phx-value-id='#{file.id}']")
+    |> render_click()
+
+    assert has_element?(view, ".ts-side__head--sub", "Pinned")
+    assert has_element?(view, ".ts-tree__pin-ind")
+
+    scope = Typster.Accounts.Scope.for_user(user)
+    assert Typster.Files.get_file!(scope, file.id).pinned
+  end
+
+  test "deleting a file removes it from the tree", %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    other = file_fixture(project, user, %{path: "notes.md"})
+    view = open_editor(conn, project)
+
+    assert has_element?(view, "[phx-value-file-id='#{other.id}']")
+
+    view
+    |> element("button[phx-click='delete_file'][phx-value-id='#{other.id}']")
+    |> render_click()
+
+    refute path_exists?(user, project, "notes.md")
+    assert path_exists?(user, project, "main.typ")
+  end
+
   defp path_exists?(user, project, path) do
     scope = Typster.Accounts.Scope.for_user(user)
     Enum.any?(Typster.Files.get_file_tree(scope, project.id), &(&1.path == path))

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -158,6 +158,18 @@ defmodule TypsterWeb.EditorLiveTest do
     assert has_element?(view, ".ts-side__count", "4 sections")
   end
 
+  test "the new-folder button creates a folder seeded with a starter file",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    view |> element("#create-folder-button") |> render_click()
+    assert has_element?(view, "#new-file-draft #new-file-form")
+    view |> form("#new-file-form", %{path: "chapters"}) |> render_submit()
+
+    assert path_exists?(user, project, "chapters/untitled.typ")
+  end
+
   test "file rows render colored type chips by extension",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "main.typ"})

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -139,6 +139,25 @@ defmodule TypsterWeb.EditorLiveTest do
     assert path_exists?(user, project, "main.typ")
   end
 
+  test "outline numbers headings and shows a section count",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "outline_parsed", %{
+      "items" => [
+        %{"level" => 1, "text" => "Quarterly Report", "line" => 1},
+        %{"level" => 2, "text" => "Summary", "line" => 3},
+        %{"level" => 2, "text" => "Key results", "line" => 7},
+        %{"level" => 3, "text" => "Uptime", "line" => 9}
+      ]
+    })
+
+    # level-1 title stays unnumbered; level 2 -> 1, 2; level 3 -> 2.1
+    assert has_element?(view, ".ts-outline__num", "2.1")
+    assert has_element?(view, ".ts-side__count", "4 sections")
+  end
+
   defp path_exists?(user, project, path) do
     scope = Typster.Accounts.Scope.for_user(user)
     Enum.any?(Typster.Files.get_file_tree(scope, project.id), &(&1.path == path))

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -168,10 +168,9 @@ defmodule TypsterWeb.EditorLiveTest do
     # sections/intro.typ is the initial file, so its folder is active.
     view |> element("#create-main-file-button") |> render_click()
 
-    assert view |> element("#new-file-form input[name='path']") |> render() =~
-             ~s(value="sections/")
-
-    view |> form("#new-file-form", %{path: "sections/results"}) |> render_submit()
+    # The folder is shown as a static prefix; you type only the filename.
+    assert has_element?(view, ".ts-draft__dir", "sections/")
+    view |> form("#new-file-form", %{path: "results"}) |> render_submit()
     assert path_exists?(user, project, "sections/results.typ")
   end
 

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -139,6 +139,15 @@ defmodule TypsterWeb.EditorLiveTest do
     assert path_exists?(user, project, "main.typ")
   end
 
+  test "the header breadcrumb shows the active file's path segments",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "sections/intro.typ"})
+    view = open_editor(conn, project)
+
+    assert has_element?(view, ".ts-crumb .ts-crumb__seg", "sections")
+    assert has_element?(view, ".ts-crumb .ts-crumb__seg.is-active", "intro.typ")
+  end
+
   test "outline numbers headings and shows a section count",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "main.typ"})

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -160,6 +160,21 @@ defmodule TypsterWeb.EditorLiveTest do
     assert view |> element(".ts-tab.is-active .ts-tab__label") |> render() =~ "main.typ"
   end
 
+  test "new file is seeded into the folder of the active file",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "sections/intro.typ"})
+    view = open_editor(conn, project)
+
+    # sections/intro.typ is the initial file, so its folder is active.
+    view |> element("#create-main-file-button") |> render_click()
+
+    assert view |> element("#new-file-form input[name='path']") |> render() =~
+             ~s(value="sections/")
+
+    view |> form("#new-file-form", %{path: "sections/results"}) |> render_submit()
+    assert path_exists?(user, project, "sections/results.typ")
+  end
+
   test "the header breadcrumb shows the active file's path segments",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "sections/intro.typ"})

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -200,6 +200,27 @@ defmodule TypsterWeb.EditorLiveTest do
     assert path_exists?(user, project, "chapters/untitled.typ")
   end
 
+  test "using a template stages its content into the file you create",
+       %{conn: conn, user: user, project: project} do
+    scope = Typster.Accounts.Scope.for_user(user)
+
+    {:ok, tpl} =
+      Typster.Templates.create_template(scope, %{name: "ieee.typ", content: "= From tpl"})
+
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    view
+    |> element("button[phx-click='use_template'][phx-value-id='#{tpl.id}']")
+    |> render_click()
+
+    assert has_element?(view, "#new-file-draft")
+    view |> form("#new-file-form", %{path: "paper.typ"}) |> render_submit()
+
+    created = Enum.find(Typster.Files.get_file_tree(scope, project.id), &(&1.path == "paper.typ"))
+    assert created.content == "= From tpl"
+  end
+
   test "file rows render colored type chips by extension",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "main.typ"})

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -1,0 +1,64 @@
+defmodule TypsterWeb.EditorLiveTest do
+  use TypsterWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Typster.ProjectsFixtures
+
+  setup %{conn: conn} do
+    user = Typster.AccountsFixtures.user_fixture()
+    conn = log_in_user(conn, user)
+    project = project_fixture(user, %{name: "Quarterly Report"})
+    %{conn: conn, user: user, project: project}
+  end
+
+  defp open_editor(conn, project) do
+    {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/edit")
+    view
+  end
+
+  test "the new-file button reveals an inline draft row", %{conn: conn, project: project} do
+    view = open_editor(conn, project)
+
+    refute has_element?(view, "#new-file-draft")
+    view |> element("#create-main-file-button") |> render_click()
+    assert has_element?(view, "#new-file-draft #new-file-form")
+  end
+
+  test "typing a plain name suggests the project's majority source extension",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    view |> element("#create-main-file-button") |> render_click()
+    html = view |> form("#new-file-form", %{path: "conclusion"}) |> render_change()
+
+    # The "+ .typ" hint pill is shown, no explicit extension chips for a single suggestion.
+    assert html =~ "+ .typ"
+    refute has_element?(view, ".ts-suggest")
+  end
+
+  test "a bib-like name with no existing .bib offers a .bib chip plus the majority type",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    view |> element("#create-main-file-button") |> render_click()
+    view |> form("#new-file-form", %{path: "refs"}) |> render_change()
+
+    assert has_element?(view, ".ts-suggest__chip", "refs.bib")
+    assert has_element?(view, ".ts-suggest__chip", "refs.typ")
+  end
+
+  test "creating from the typed name resolves the smart extension and opens the file",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    view |> element("#create-main-file-button") |> render_click()
+    view |> form("#new-file-form", %{path: "appendix"}) |> render_submit()
+
+    scope = Typster.Accounts.Scope.for_user(user)
+    tree = Typster.Files.get_file_tree(scope, project.id)
+    assert Enum.any?(tree, &(&1.path == "appendix.typ"))
+  end
+end

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -174,6 +174,20 @@ defmodule TypsterWeb.EditorLiveTest do
     assert path_exists?(user, project, "sections/results.typ")
   end
 
+  test "a failed compile shows the error count in the preview status pill",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "preview_error", %{
+      "message" => "error: unknown variable: x",
+      "errors" => 2,
+      "warnings" => 1
+    })
+
+    assert has_element?(view, ".ts-pill--error", "2 errors")
+  end
+
   test "the header breadcrumb shows the active file's path segments",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "sections/intro.typ"})

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -139,6 +139,27 @@ defmodule TypsterWeb.EditorLiveTest do
     assert path_exists?(user, project, "main.typ")
   end
 
+  test "opening files adds tabs and closing a tab activates a neighbor",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    other = file_fixture(project, user, %{path: "sections/intro.typ"})
+    view = open_editor(conn, project)
+
+    # main.typ opens as the initial tab; open the second file.
+    view
+    |> element("[phx-click='select_file'][phx-value-file-id='#{other.id}']")
+    |> render_click()
+
+    assert view |> element(".ts-tab.is-active .ts-tab__label") |> render() =~ "intro.typ"
+
+    # Two tabs now open.
+    assert view |> render() |> then(&(Regex.scan(~r/ts-tab__label/, &1) |> length())) == 2
+
+    # Close the active tab → falls back to the remaining one.
+    view |> element(".ts-tab.is-active .ts-tab__close") |> render_click()
+    assert view |> element(".ts-tab.is-active .ts-tab__label") |> render() =~ "main.typ"
+  end
+
   test "the header breadcrumb shows the active file's path segments",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "sections/intro.typ"})

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -320,6 +320,50 @@ defmodule TypsterWeb.EditorLiveTest do
     assert has_element?(view, ".ts-filechip--bib")
   end
 
+  test "file rows are draggable and folder rows are drop targets",
+       %{conn: conn, user: user, project: project} do
+    file = file_fixture(project, user, %{path: "chapters/intro.typ"})
+    view = open_editor(conn, project)
+
+    assert has_element?(view, "li[draggable='true'][data-dnd-file='#{file.id}']")
+    assert has_element?(view, "li[data-dnd-dir='chapters']")
+  end
+
+  test "dragging a file onto a folder moves it under that folder",
+       %{conn: conn, user: user, project: project} do
+    file = file_fixture(project, user, %{path: "main.typ"})
+    file_fixture(project, user, %{path: "chapters/intro.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "move_file", %{"id" => file.id, "dir" => "chapters"})
+
+    assert path_exists?(user, project, "chapters/main.typ")
+    refute path_exists?(user, project, "main.typ")
+  end
+
+  test "dropping a nested file onto the empty tree moves it to the project root",
+       %{conn: conn, user: user, project: project} do
+    file = file_fixture(project, user, %{path: "chapters/intro.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "move_file", %{"id" => file.id, "dir" => ""})
+
+    assert path_exists?(user, project, "intro.typ")
+    refute path_exists?(user, project, "chapters/intro.typ")
+  end
+
+  test "moving onto a folder that already holds the same name is rejected",
+       %{conn: conn, user: user, project: project} do
+    file = file_fixture(project, user, %{path: "main.typ"})
+    file_fixture(project, user, %{path: "chapters/main.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "move_file", %{"id" => file.id, "dir" => "chapters"})
+
+    assert path_exists?(user, project, "main.typ")
+    assert path_exists?(user, project, "chapters/main.typ")
+  end
+
   defp path_exists?(user, project, path) do
     scope = Typster.Accounts.Scope.for_user(user)
     Enum.any?(Typster.Files.get_file_tree(scope, project.id), &(&1.path == path))

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -57,8 +57,54 @@ defmodule TypsterWeb.EditorLiveTest do
     view |> element("#create-main-file-button") |> render_click()
     view |> form("#new-file-form", %{path: "appendix"}) |> render_submit()
 
+    assert path_exists?(user, project, "appendix.typ")
+  end
+
+  test "the default extension suggestion is a clickable button that creates the file",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    view |> element("#create-main-file-button") |> render_click()
+    view |> form("#new-file-form", %{path: "conclusion"}) |> render_change()
+
+    # The hint pill is a real button wired to create the resolved file.
+    assert view |> element("button.ts-exthint[phx-value-path='conclusion.typ']") |> has_element?()
+    view |> element("button.ts-exthint") |> render_click()
+
+    assert path_exists?(user, project, "conclusion.typ")
+  end
+
+  test "clicking a bib suggestion chip creates that file",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    view |> element("#create-main-file-button") |> render_click()
+    view |> form("#new-file-form", %{path: "refs"}) |> render_change()
+    view |> element(".ts-suggest__chip[phx-value-path='refs.bib']") |> render_click()
+
+    assert path_exists?(user, project, "refs.bib")
+  end
+
+  test "creating a duplicate path is rejected and keeps the draft open",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    view |> element("#create-main-file-button") |> render_click()
+    html = view |> form("#new-file-form", %{path: "main.typ"}) |> render_submit()
+
+    assert html =~ "already exists"
+    assert has_element?(view, "#new-file-draft")
+    # No duplicate row was inserted.
     scope = Typster.Accounts.Scope.for_user(user)
     tree = Typster.Files.get_file_tree(scope, project.id)
-    assert Enum.any?(tree, &(&1.path == "appendix.typ"))
+    assert Enum.count(tree, &(&1.path == "main.typ")) == 1
+  end
+
+  defp path_exists?(user, project, path) do
+    scope = Typster.Accounts.Scope.for_user(user)
+    Enum.any?(Typster.Files.get_file_tree(scope, project.id), &(&1.path == path))
   end
 end

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -188,6 +188,47 @@ defmodule TypsterWeb.EditorLiveTest do
     assert has_element?(view, ".ts-pill--error", "2 errors")
   end
 
+  test "the compile drawer lists diagnostics and toggles from the status bar",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    refute has_element?(view, ".ts-drawer")
+
+    render_hook(view, "preview_error", %{
+      "message" => "expected comma",
+      "errors" => 1,
+      "warnings" => 0,
+      "diagnostics" => [
+        %{
+          "severity" => "error",
+          "message" => "expected comma",
+          "location" => %{"file" => "main.typ", "line" => 15, "col" => 23}
+        }
+      ]
+    })
+
+    assert has_element?(view, ".ts-statusbar__btn.is-error", "1 error")
+
+    view |> element(".ts-statusbar__btn") |> render_click()
+    assert has_element?(view, ".ts-drawer")
+
+    view |> element(".ts-drawer__tab", "Problems") |> render_click()
+    assert has_element?(view, ".ts-problem__loc", "15 : 23")
+    assert has_element?(view, ".ts-problem__msg", "expected comma")
+  end
+
+  test "a successful compile records a log entry in the drawer",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "update_preview", %{"ms" => 47, "pages" => 3})
+    view |> element(".ts-statusbar__btn") |> render_click()
+
+    assert has_element?(view, ".ts-log__row--ok", "compiled")
+  end
+
   test "the header breadcrumb shows the active file's path segments",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "sections/intro.typ"})

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -158,6 +158,16 @@ defmodule TypsterWeb.EditorLiveTest do
     assert has_element?(view, ".ts-side__count", "4 sections")
   end
 
+  test "file rows render colored type chips by extension",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    file_fixture(project, user, %{path: "refs.bib"})
+    view = open_editor(conn, project)
+
+    assert has_element?(view, ".ts-filechip--typ")
+    assert has_element?(view, ".ts-filechip--bib")
+  end
+
   defp path_exists?(user, project, path) do
     scope = Typster.Accounts.Scope.for_user(user)
     Enum.any?(Typster.Files.get_file_tree(scope, project.id), &(&1.path == path))

--- a/test/typster_web/live/project_live_test.exs
+++ b/test/typster_web/live/project_live_test.exs
@@ -72,7 +72,7 @@ defmodule TypsterWeb.ProjectLiveTest do
     assert has_element?(view, ".ts-preview__bar .ts-pill")
     refute has_element?(view, "#command-palette")
 
-    view |> element("button", "⌘K") |> render_click()
+    view |> element("button.ts-cmdk") |> render_click()
 
     assert has_element?(view, "#command-palette")
     assert has_element?(view, "#command-palette #palette-input")


### PR DESCRIPTION
Implements the remaining v2 "Improvements" from the Claude Design handoff, plus the file-handling and shortcut polish requested along the way.

## Highlights
- **Smart new-file creation** — inline draft row with project-aware extension suggestions (`.tex` vs `.typ` by composition; `.bib` first for bibliography-like names), clickable suggestion, duplicate-path guard.
- **Unique file paths** — DB unique index `(project_id, path)` + changeset constraint; migration dedupes any pre-existing duplicates.
- **Colored file-type chips** in the tree (T/B/≡/▢/M/L + folder chips) for readability.
- **Pin / delete** files and assets from the tree, with a Pinned section.
- **Outline numbering** (1, 2, 2.1…) + "N sections" count.
- **Breadcrumb header** with project / folder / file path segments.
- **Multi-file tabs** — open, switch, close, with pin indicator.
- **New folder** action (seeds a starter file, since folders are path-derived).
- **Upload-your-own templates** — save a file as a reusable starting point, then start new files from it.
- **OS-aware ⌘/Ctrl command-palette button** (lucide `command` / `square-terminal`), de-duplicated glyph; docs in `docs/os-aware-shortcuts.md`.

## Tests
Full suite green (168). New ExUnit + LiveView coverage for suggestions, uniqueness, pin/delete, tabs, folders, outline numbering, breadcrumb, and templates; E2E specs updated for the inline new-file flow and the relabeled command button.

Closes #85
Closes #86
Closes #87
Closes #88
Closes #89
Closes #90
Closes #92
Closes #93
Closes #94
Closes #95
Closes #98
Closes #99
Closes #101
Closes #96
Closes #102
