### PR TITLE
feat(editor): open-core foundation + merged top bar v3.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pro"]
+	path = pro
+	url = git@github.com:typster-io/typster-pro.git

--- a/assets/css/_editor_topbar.css
+++ b/assets/css/_editor_topbar.css
@@ -22,6 +22,13 @@
 }
 .ts-tb--dense { height: 36px; padding: 0 6px 0 8px; font-size: 12.5px; }
 
+/* Icon weight + size — the design uses thin 1.6 strokes (lucide defaults to 2)
+   and small, even glyphs. Small decorative chevrons sit a touch tighter. */
+.ts-tb svg { width: 14px; height: 14px; stroke-width: 1.6; }
+.ts-tb .ts-tb__proj svg,
+.ts-tb .ts-tb__avatar svg,
+.ts-tb .ts-tb__branch-glyph { width: 12px; height: 12px; }
+
 /* ── Project switcher ─────────────────────────────────────────────────────── */
 .ts-tb__proj {
   display: inline-flex;
@@ -145,7 +152,7 @@
   white-space: nowrap;
   flex-shrink: 0;
 }
-.ts-tb__branch-glyph { color: var(--mk-fg3); font-weight: 700; }
+.ts-tb__branch-glyph { color: var(--mk-fg3); }
 .ts-tb__branch-ahead { color: var(--mk-success); font-weight: 600; }
 
 /* ── Omnibox (center search / command field) ──────────────────────────────── */

--- a/assets/css/_editor_topbar.css
+++ b/assets/css/_editor_topbar.css
@@ -1,24 +1,26 @@
 /* ── Editor top bar v3.1 — ts-tb-* class system ──────────────────────────────
-   Merged compact bar: project switcher · breadcrumb · omnibox · compile ·
-   collaborators · utilities · account. Token-driven via --mk-* so light and
-   dark themes flip for free (no per-theme overrides needed here).
-   Mono = 'JetBrains Mono', ui-monospace, monospace · Sans = inherited Inter.
+   Faithful port of the v3.1 design (project switcher · breadcrumb · branch ·
+   omnibox · compile · collaborators · utilities · account). Token-driven via
+   --mk-* so light/dark flip for free. Mono = JetBrains Mono · Sans = Inter.
    ─────────────────────────────────────────────────────────────────────────── */
 
-/* ── The bar ──────────────────────────────────────────────────────────────── */
 .ts-tb {
+  --tb-mono: "JetBrains Mono", ui-monospace, monospace;
+  --tb-bd-strong: color-mix(in oklab, var(--mk-bd) 45%, var(--mk-fg4));
+
   position: relative;
+  z-index: 5;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   height: 44px;
-  padding: 0 10px;
+  padding: 0 8px 0 10px;
   border-bottom: 1px solid var(--mk-bd);
   background: var(--mk-bg);
   font-size: 13px;
   flex-shrink: 0;
 }
-.ts-tb--dense { height: 36px; }
+.ts-tb--dense { height: 36px; padding: 0 6px 0 8px; font-size: 12.5px; }
 
 /* ── Project switcher ─────────────────────────────────────────────────────── */
 .ts-tb__proj {
@@ -28,32 +30,36 @@
   height: 28px;
   padding: 0 8px 0 5px;
   border: 1px solid transparent;
-  border-radius: var(--mk-r-sm);
+  border-radius: 7px;
   background: transparent;
   color: var(--mk-fg);
-  font: 600 12.5px 'JetBrains Mono', ui-monospace, monospace;
+  font: 600 12.5px var(--tb-mono);
+  text-decoration: none;
   cursor: pointer;
   flex-shrink: 0;
-  transition: background 200ms var(--mk-ease), border-color 200ms var(--mk-ease);
+  transition: background 0.18s var(--mk-ease), border-color 0.18s var(--mk-ease);
 }
-.ts-tb__proj:hover { background: var(--mk-bg2); }
+.ts-tb__proj:hover { background: var(--mk-bg2); border-color: var(--mk-bd); }
 .ts-tb__proj-glyph {
   width: 20px;
   height: 20px;
   display: grid;
   place-items: center;
-  border-radius: 6px;
-  background: var(--mk-pri);
+  border-radius: 5px;
+  background: linear-gradient(180deg, var(--mk-pri) 0%, var(--mk-pri-h) 100%);
   color: #fff;
-  font-size: 12px;
+  font: 700 11px "Inter", system-ui, sans-serif;
   line-height: 1;
   flex-shrink: 0;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.15) inset, 0 1px 2px rgba(0, 0, 0, 0.18);
 }
+.ts-tb__proj svg { color: var(--mk-fg3); }
 
 /* ── Vertical divider ─────────────────────────────────────────────────────── */
 .ts-tb__div {
   width: 1px;
   height: 18px;
+  margin: 0 2px;
   background: var(--mk-bd);
   flex-shrink: 0;
 }
@@ -64,13 +70,13 @@
   place-items: center;
   width: 26px;
   height: 26px;
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
-  color: var(--mk-fg3);
+  color: var(--mk-fg2);
   cursor: pointer;
   flex-shrink: 0;
-  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease);
+  transition: background 0.18s var(--mk-ease), color 0.18s var(--mk-ease);
 }
 .ts-tb__navbtn:hover { background: var(--mk-bg2); color: var(--mk-fg); }
 
@@ -81,129 +87,165 @@
   gap: 4px;
   min-width: 0;
   flex-shrink: 1;
-  font-size: 12.5px;
 }
 .ts-tb__seg {
   padding: 3px 6px;
   border-radius: 5px;
-  color: var(--mk-fg3);
+  color: var(--mk-fg2);
   text-decoration: none;
   white-space: nowrap;
   cursor: pointer;
-  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease);
+  transition: background 0.18s var(--mk-ease), color 0.18s var(--mk-ease);
 }
 .ts-tb__seg:hover { background: var(--mk-bg2); color: var(--mk-fg); }
-.ts-tb__seg.is-active { color: var(--mk-fg); font-weight: 600; }
-.ts-tb__sep { color: var(--mk-fg4); }
+.ts-tb__seg.is-active { color: var(--mk-fg); font: 600 12.5px var(--tb-mono); }
+.ts-tb__sep { color: var(--mk-fg3); }
+
+/* ── Save dot (reuses the SaveStatus hook element) ────────────────────────── */
+.ts-tb .ts-savestat {
+  display: inline-flex;
+  align-items: center;
+  margin: 0 4px 0 2px;
+  padding: 0;
+  background: none;
+  border: 0;
+  flex-shrink: 0;
+}
+.ts-tb .ts-savestat__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: transparent;
+  border: 1.5px solid var(--mk-fg3);
+  transition: all 0.18s var(--mk-ease);
+}
+.ts-tb .ts-savestat--saving .ts-savestat__dot {
+  border-color: var(--mk-fg3);
+  border-top-color: var(--mk-pri);
+  animation: ts-tb-spin 0.7s linear infinite;
+}
+.ts-tb .ts-savestat--error .ts-savestat__dot {
+  background: var(--mk-error);
+  border-color: var(--mk-error);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--mk-error) 18%, transparent);
+}
+
+/* ── Branch chip ──────────────────────────────────────────────────────────── */
+.ts-tb__branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 22px;
+  padding: 0 7px;
+  border: 1px solid var(--mk-bd);
+  border-radius: 5px;
+  background: var(--mk-bg2);
+  color: var(--mk-fg2);
+  font: 500 11px var(--tb-mono);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.ts-tb__branch-glyph { color: var(--mk-fg3); font-weight: 700; }
+.ts-tb__branch-ahead { color: var(--mk-success); font-weight: 600; }
 
 /* ── Omnibox (center search / command field) ──────────────────────────────── */
 .ts-tb__omni {
-  flex: 1;
-  min-width: 120px;
+  flex: 1 1 auto;
+  min-width: 160px;
   max-width: 460px;
-  margin: 0 auto;
-  height: 30px;
+  height: 28px;
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 0 10px;
   border: 1px solid var(--mk-bd);
-  border-radius: 8px;
+  border-radius: 7px;
   background: var(--mk-bg2);
   color: var(--mk-fg3);
+  font: 13px "Inter", system-ui, sans-serif;
   cursor: text;
-  transition: border-color 200ms var(--mk-ease);
+  transition: background 0.18s var(--mk-ease), border-color 0.18s var(--mk-ease);
 }
-.ts-tb__omni:hover { border-color: var(--mk-pri); }
+.ts-tb__omni:hover { background: var(--mk-bg); border-color: var(--tb-bd-strong); }
+.ts-tb__omni svg { color: var(--mk-fg3); flex-shrink: 0; }
 .ts-tb__omni-ph {
   flex: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: left;
 }
 .ts-tb__omni-key {
   flex-shrink: 0;
   padding: 1px 5px;
   border: 1px solid var(--mk-bd);
   border-radius: 4px;
-  color: var(--mk-fg4);
-  font: 10px 'JetBrains Mono', ui-monospace, monospace;
+  background: var(--mk-bg);
+  color: var(--mk-fg3);
+  font: 500 10.5px var(--tb-mono);
 }
+
+/* ── Share button — pin the action cluster to the right edge ──────────────── */
+.ts-tb__share { margin-left: auto; flex-shrink: 0; }
 
 /* ── Compile button (single element + state modifiers) ────────────────────── */
 .ts-tb__compile {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 30px;
-  padding: 0 12px;
-  border: 1px solid transparent;
-  border-radius: 8px;
+  height: 28px;
+  padding: 0 11px;
+  border: 0;
+  border-radius: 7px;
   background: var(--mk-pri);
   color: #fff;
-  font: 600 12.5px 'Inter', system-ui, sans-serif;
+  font: 600 12.5px "Inter", system-ui, sans-serif;
   white-space: nowrap;
   cursor: pointer;
   flex-shrink: 0;
-  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease),
-    border-color 200ms var(--mk-ease), filter 200ms var(--mk-ease);
+  transition: filter 0.18s var(--mk-ease), background 0.18s var(--mk-ease);
 }
 .ts-tb__compile:hover { filter: brightness(1.08); }
+.ts-tb__compile svg { display: block; }
 
 .ts-tb__compile.is-compiling {
-  background: var(--mk-bg3);
-  color: var(--mk-fg2);
+  background: color-mix(in oklab, var(--mk-pri) 78%, var(--mk-fg3));
   cursor: progress;
 }
 .ts-tb__compile.is-compiling:hover { filter: none; }
-.ts-tb__compile.is-success {
-  background: var(--mk-success-50);
-  color: var(--mk-success);
-  border-color: var(--mk-success-bd);
-}
-.ts-tb__compile.is-warn {
-  background: var(--mk-warning-50);
-  color: var(--mk-warning);
-  border-color: var(--mk-warning-bd);
-}
-.ts-tb__compile.is-error {
-  background: var(--mk-error-50);
-  color: var(--mk-error);
-  border-color: var(--mk-error-bd);
-}
+.ts-tb__compile.is-success { background: var(--mk-success); }
+.ts-tb__compile.is-warn { background: var(--mk-warning); }
+.ts-tb__compile.is-error { background: var(--mk-error); }
 
 .ts-tb__compile-spin {
   width: 12px;
   height: 12px;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #fff;
   border-radius: 50%;
-  animation: spin 0.6s linear infinite;
+  animation: ts-tb-spin 0.6s linear infinite;
   flex-shrink: 0;
 }
-.ts-tb__compile-ms,
-.ts-tb__compile-count {
-  font-size: 11px;
-  opacity: 0.85;
-  font-variant-numeric: tabular-nums;
+.ts-tb__compile-ms {
+  font: 500 11px var(--tb-mono);
+  opacity: 0.82;
 }
-
-/* Keyboard hint nested in the default (accent) compile button: light-on-accent.
-   Status modifiers don't carry the accent fill, so reset the kbd there too. */
+.ts-tb__compile-count {
+  font: 600 10.5px var(--tb-mono);
+  padding: 1px 5px;
+  margin-left: 2px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.22);
+}
+/* Keyboard hint nested in the (always solid) compile button: light-on-fill. */
 .ts-tb__compile .ts-kbd {
   background: rgba(255, 255, 255, 0.18);
   border-color: transparent;
   color: inherit;
 }
-.ts-tb__compile.is-compiling .ts-kbd,
-.ts-tb__compile.is-success .ts-kbd,
-.ts-tb__compile.is-warn .ts-kbd,
-.ts-tb__compile.is-error .ts-kbd {
-  background: color-mix(in oklab, currentColor 14%, transparent);
-}
 
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes ts-tb-spin { to { transform: rotate(360deg); } }
 
 /* ── Collaborator stack ───────────────────────────────────────────────────── */
 .ts-tb__collab {
@@ -221,7 +263,7 @@
   border: 2px solid var(--mk-bg);
   border-radius: 50%;
   color: #fff;
-  font: 600 9px 'Inter', system-ui, sans-serif;
+  font: 600 9.5px "Inter", system-ui, sans-serif;
   cursor: pointer;
 }
 .ts-tb__av:first-child { margin-left: 0; }
@@ -229,21 +271,20 @@
   position: absolute;
   right: -1px;
   bottom: -1px;
-  width: 7px;
-  height: 7px;
-  border: 2px solid var(--mk-bg);
+  width: 8px;
+  height: 8px;
+  border: 1.5px solid var(--mk-bg);
   border-radius: 50%;
   background: var(--mk-success);
   animation: ts-tb-pulse 1.8s var(--mk-ease) infinite;
 }
 @keyframes ts-tb-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--mk-success) 50%, transparent); }
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--mk-success) 55%, transparent); }
   50%      { box-shadow: 0 0 0 3px color-mix(in oklab, var(--mk-success) 0%, transparent); }
 }
 
 /* ── Right cluster ────────────────────────────────────────────────────────── */
 .ts-tb__right {
-  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -266,55 +307,52 @@
   border: 0;
   border-radius: 5px;
   background: transparent;
-  color: var(--mk-fg3);
+  color: var(--mk-fg2);
   cursor: pointer;
-  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease);
+  transition: background 0.18s var(--mk-ease), color 0.18s var(--mk-ease);
 }
 .ts-tb__util button:hover { background: var(--mk-bg); color: var(--mk-fg); }
 .ts-tb__lang {
   width: auto;
   padding: 0 8px;
-  font: 10px 'JetBrains Mono', ui-monospace, monospace;
+  font: 500 11px var(--tb-mono);
+  text-decoration: none;
 }
 
 /* ── Account avatar + dropdown ────────────────────────────────────────────── */
+.ts-tb__acct { position: relative; flex-shrink: 0; }
 .ts-tb__avatar {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
-  height: 26px;
-  padding: 0 4px 0 0;
-  border: 0;
+  gap: 6px;
+  height: 30px;
+  padding: 3px 7px 3px 3px;
+  border: 1px solid var(--mk-bd);
   border-radius: 9999px;
-  background: transparent;
-  color: var(--mk-fg3);
+  background: var(--mk-bg);
+  color: var(--mk-fg);
   cursor: pointer;
-  flex-shrink: 0;
-  transition: background 200ms var(--mk-ease);
+  transition: background 0.18s var(--mk-ease), border-color 0.18s var(--mk-ease);
 }
-.ts-tb__avatar:hover { background: var(--mk-bg2); }
-.ts-tb__avatar::before {
-  /* the initials disc; copy lives in markup, this just frames it when empty */
-  content: none;
-}
-.ts-tb__avatar .ts-tb__av-disc,
+.ts-tb__avatar:hover { background: var(--mk-bg2); border-color: var(--tb-bd-strong); }
 .ts-tb__avatar > span:first-child {
-  width: 26px;
-  height: 26px;
+  width: 22px;
+  height: 22px;
   display: grid;
   place-items: center;
   border-radius: 50%;
   background: var(--mk-pri-50);
   color: var(--mk-pri);
-  font: 600 10px 'Inter', system-ui, sans-serif;
+  font: 600 10px "Inter", system-ui, sans-serif;
   flex-shrink: 0;
 }
+.ts-tb__avatar svg { color: var(--mk-fg3); }
 
 .ts-tb__menu {
   position: absolute;
   top: 38px;
-  right: 8px;
-  width: 230px;
+  right: 0;
+  width: 240px;
   padding: 6px;
   border: 1px solid var(--mk-bd);
   border-radius: 10px;
@@ -324,23 +362,17 @@
 }
 .ts-tb__menu-who {
   padding: 8px 10px 10px;
-  border-bottom: 1px solid var(--mk-bd);
   margin-bottom: 4px;
+  border-bottom: 1px solid var(--mk-bd);
 }
-.ts-tb__menu-who .ts-tb__menu-name {
-  font: 600 13px 'Inter', system-ui, sans-serif;
-  color: var(--mk-fg);
-}
-.ts-tb__menu-who .ts-tb__menu-email {
-  font: 12px 'Inter', system-ui, sans-serif;
-  color: var(--mk-fg3);
-}
+.ts-tb__menu-name { font: 600 13px "Inter", system-ui, sans-serif; color: var(--mk-fg); }
+.ts-tb__menu-email { font: 12px "Inter", system-ui, sans-serif; color: var(--mk-fg3); }
 .ts-tb__menu-label {
   padding: 8px 10px 2px;
-  font: 600 10px 'Inter', system-ui, sans-serif;
+  font: 600 10px "Inter", system-ui, sans-serif;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--mk-fg4);
+  color: var(--mk-fg3);
 }
 .ts-tb__menu-segs {
   display: flex;
@@ -357,11 +389,10 @@
   border: 1px solid transparent;
   border-radius: 6px;
   background: var(--mk-bg2);
-  color: var(--mk-fg3);
-  font: 500 12px 'Inter', system-ui, sans-serif;
+  color: var(--mk-fg2);
+  font: 500 12px "Inter", system-ui, sans-serif;
   cursor: pointer;
-  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease),
-    border-color 200ms var(--mk-ease);
+  transition: background 0.18s var(--mk-ease), color 0.18s var(--mk-ease);
 }
 .ts-tb__menu-seg:hover { color: var(--mk-fg); }
 .ts-tb__menu-seg.is-active {
@@ -369,28 +400,25 @@
   color: var(--mk-pri);
   border-color: color-mix(in oklab, var(--mk-pri) 30%, transparent);
 }
-.ts-tb__menu-sep {
-  height: 1px;
-  margin: 6px 0;
-  background: var(--mk-bd);
-}
+.ts-tb__menu-sep { height: 1px; margin: 6px 0; background: var(--mk-bd); }
 .ts-tb__menu-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   width: 100%;
-  padding: 7px 8px;
+  padding: 7px 10px;
   border: 0;
-  border-radius: 7px;
+  border-radius: 6px;
   background: transparent;
   color: var(--mk-fg);
-  font: 500 13px 'Inter', system-ui, sans-serif;
+  font: 500 13px "Inter", system-ui, sans-serif;
   text-align: left;
   text-decoration: none;
   cursor: pointer;
-  transition: background 200ms var(--mk-ease);
+  transition: background 0.18s var(--mk-ease);
 }
 .ts-tb__menu-item:hover { background: var(--mk-bg2); }
-.ts-tb__menu-item .ts-kbd { margin-left: auto; }
+.ts-tb__menu-item svg { color: var(--mk-fg3); }
 .ts-tb__menu-item.is-danger { color: var(--mk-error); }
+.ts-tb__menu-item.is-danger svg { color: var(--mk-error); }
 .ts-tb__menu-item.is-danger:hover { background: var(--mk-error-50); }

--- a/assets/css/_editor_topbar.css
+++ b/assets/css/_editor_topbar.css
@@ -1,0 +1,396 @@
+/* ── Editor top bar v3.1 — ts-tb-* class system ──────────────────────────────
+   Merged compact bar: project switcher · breadcrumb · omnibox · compile ·
+   collaborators · utilities · account. Token-driven via --mk-* so light and
+   dark themes flip for free (no per-theme overrides needed here).
+   Mono = 'JetBrains Mono', ui-monospace, monospace · Sans = inherited Inter.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+/* ── The bar ──────────────────────────────────────────────────────────────── */
+.ts-tb {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 44px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--mk-bd);
+  background: var(--mk-bg);
+  font-size: 13px;
+  flex-shrink: 0;
+}
+.ts-tb--dense { height: 36px; }
+
+/* ── Project switcher ─────────────────────────────────────────────────────── */
+.ts-tb__proj {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 28px;
+  padding: 0 8px 0 5px;
+  border: 1px solid transparent;
+  border-radius: var(--mk-r-sm);
+  background: transparent;
+  color: var(--mk-fg);
+  font: 600 12.5px 'JetBrains Mono', ui-monospace, monospace;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 200ms var(--mk-ease), border-color 200ms var(--mk-ease);
+}
+.ts-tb__proj:hover { background: var(--mk-bg2); }
+.ts-tb__proj-glyph {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  background: var(--mk-pri);
+  color: #fff;
+  font-size: 12px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+/* ── Vertical divider ─────────────────────────────────────────────────────── */
+.ts-tb__div {
+  width: 1px;
+  height: 18px;
+  background: var(--mk-bd);
+  flex-shrink: 0;
+}
+
+/* ── Back / forward nav buttons ───────────────────────────────────────────── */
+.ts-tb__navbtn {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--mk-fg3);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease);
+}
+.ts-tb__navbtn:hover { background: var(--mk-bg2); color: var(--mk-fg); }
+
+/* ── Breadcrumb ───────────────────────────────────────────────────────────── */
+.ts-tb__crumb {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  flex-shrink: 1;
+  font-size: 12.5px;
+}
+.ts-tb__seg {
+  padding: 3px 6px;
+  border-radius: 5px;
+  color: var(--mk-fg3);
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease);
+}
+.ts-tb__seg:hover { background: var(--mk-bg2); color: var(--mk-fg); }
+.ts-tb__seg.is-active { color: var(--mk-fg); font-weight: 600; }
+.ts-tb__sep { color: var(--mk-fg4); }
+
+/* ── Omnibox (center search / command field) ──────────────────────────────── */
+.ts-tb__omni {
+  flex: 1;
+  min-width: 120px;
+  max-width: 460px;
+  margin: 0 auto;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border: 1px solid var(--mk-bd);
+  border-radius: 8px;
+  background: var(--mk-bg2);
+  color: var(--mk-fg3);
+  cursor: text;
+  transition: border-color 200ms var(--mk-ease);
+}
+.ts-tb__omni:hover { border-color: var(--mk-pri); }
+.ts-tb__omni-ph {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ts-tb__omni-key {
+  flex-shrink: 0;
+  padding: 1px 5px;
+  border: 1px solid var(--mk-bd);
+  border-radius: 4px;
+  color: var(--mk-fg4);
+  font: 10px 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* ── Compile button (single element + state modifiers) ────────────────────── */
+.ts-tb__compile {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: var(--mk-pri);
+  color: #fff;
+  font: 600 12.5px 'Inter', system-ui, sans-serif;
+  white-space: nowrap;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease),
+    border-color 200ms var(--mk-ease), filter 200ms var(--mk-ease);
+}
+.ts-tb__compile:hover { filter: brightness(1.08); }
+
+.ts-tb__compile.is-compiling {
+  background: var(--mk-bg3);
+  color: var(--mk-fg2);
+  cursor: progress;
+}
+.ts-tb__compile.is-compiling:hover { filter: none; }
+.ts-tb__compile.is-success {
+  background: var(--mk-success-50);
+  color: var(--mk-success);
+  border-color: var(--mk-success-bd);
+}
+.ts-tb__compile.is-warn {
+  background: var(--mk-warning-50);
+  color: var(--mk-warning);
+  border-color: var(--mk-warning-bd);
+}
+.ts-tb__compile.is-error {
+  background: var(--mk-error-50);
+  color: var(--mk-error);
+  border-color: var(--mk-error-bd);
+}
+
+.ts-tb__compile-spin {
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+.ts-tb__compile-ms,
+.ts-tb__compile-count {
+  font-size: 11px;
+  opacity: 0.85;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Keyboard hint nested in the default (accent) compile button: light-on-accent.
+   Status modifiers don't carry the accent fill, so reset the kbd there too. */
+.ts-tb__compile .ts-kbd {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: transparent;
+  color: inherit;
+}
+.ts-tb__compile.is-compiling .ts-kbd,
+.ts-tb__compile.is-success .ts-kbd,
+.ts-tb__compile.is-warn .ts-kbd,
+.ts-tb__compile.is-error .ts-kbd {
+  background: color-mix(in oklab, currentColor 14%, transparent);
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Collaborator stack ───────────────────────────────────────────────────── */
+.ts-tb__collab {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.ts-tb__av {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  margin-left: -6px;
+  border: 2px solid var(--mk-bg);
+  border-radius: 50%;
+  color: #fff;
+  font: 600 9px 'Inter', system-ui, sans-serif;
+  cursor: pointer;
+}
+.ts-tb__av:first-child { margin-left: 0; }
+.ts-tb__pulse {
+  position: absolute;
+  right: -1px;
+  bottom: -1px;
+  width: 7px;
+  height: 7px;
+  border: 2px solid var(--mk-bg);
+  border-radius: 50%;
+  background: var(--mk-success);
+  animation: ts-tb-pulse 1.8s var(--mk-ease) infinite;
+}
+@keyframes ts-tb-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--mk-success) 50%, transparent); }
+  50%      { box-shadow: 0 0 0 3px color-mix(in oklab, var(--mk-success) 0%, transparent); }
+}
+
+/* ── Right cluster ────────────────────────────────────────────────────────── */
+.ts-tb__right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.ts-tb__util {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--mk-bd);
+  border-radius: 8px;
+  background: var(--mk-bg2);
+}
+.ts-tb__util button {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--mk-fg3);
+  cursor: pointer;
+  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease);
+}
+.ts-tb__util button:hover { background: var(--mk-bg); color: var(--mk-fg); }
+.ts-tb__lang {
+  width: auto;
+  padding: 0 8px;
+  font: 10px 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* ── Account avatar + dropdown ────────────────────────────────────────────── */
+.ts-tb__avatar {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 26px;
+  padding: 0 4px 0 0;
+  border: 0;
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--mk-fg3);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 200ms var(--mk-ease);
+}
+.ts-tb__avatar:hover { background: var(--mk-bg2); }
+.ts-tb__avatar::before {
+  /* the initials disc; copy lives in markup, this just frames it when empty */
+  content: none;
+}
+.ts-tb__avatar .ts-tb__av-disc,
+.ts-tb__avatar > span:first-child {
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--mk-pri-50);
+  color: var(--mk-pri);
+  font: 600 10px 'Inter', system-ui, sans-serif;
+  flex-shrink: 0;
+}
+
+.ts-tb__menu {
+  position: absolute;
+  top: 38px;
+  right: 8px;
+  width: 230px;
+  padding: 6px;
+  border: 1px solid var(--mk-bd);
+  border-radius: 10px;
+  background: var(--mk-bg);
+  box-shadow: var(--mk-sh-lg);
+  z-index: 50;
+}
+.ts-tb__menu-who {
+  padding: 8px 10px 10px;
+  border-bottom: 1px solid var(--mk-bd);
+  margin-bottom: 4px;
+}
+.ts-tb__menu-who .ts-tb__menu-name {
+  font: 600 13px 'Inter', system-ui, sans-serif;
+  color: var(--mk-fg);
+}
+.ts-tb__menu-who .ts-tb__menu-email {
+  font: 12px 'Inter', system-ui, sans-serif;
+  color: var(--mk-fg3);
+}
+.ts-tb__menu-label {
+  padding: 8px 10px 2px;
+  font: 600 10px 'Inter', system-ui, sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--mk-fg4);
+}
+.ts-tb__menu-segs {
+  display: flex;
+  gap: 4px;
+  padding: 4px 6px 6px;
+}
+.ts-tb__menu-seg {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 5px 8px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: var(--mk-bg2);
+  color: var(--mk-fg3);
+  font: 500 12px 'Inter', system-ui, sans-serif;
+  cursor: pointer;
+  transition: background 200ms var(--mk-ease), color 200ms var(--mk-ease),
+    border-color 200ms var(--mk-ease);
+}
+.ts-tb__menu-seg:hover { color: var(--mk-fg); }
+.ts-tb__menu-seg.is-active {
+  background: var(--mk-pri-50);
+  color: var(--mk-pri);
+  border-color: color-mix(in oklab, var(--mk-pri) 30%, transparent);
+}
+.ts-tb__menu-sep {
+  height: 1px;
+  margin: 6px 0;
+  background: var(--mk-bd);
+}
+.ts-tb__menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 8px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--mk-fg);
+  font: 500 13px 'Inter', system-ui, sans-serif;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 200ms var(--mk-ease);
+}
+.ts-tb__menu-item:hover { background: var(--mk-bg2); }
+.ts-tb__menu-item .ts-kbd { margin-left: auto; }
+.ts-tb__menu-item.is-danger { color: var(--mk-error); }
+.ts-tb__menu-item.is-danger:hover { background: var(--mk-error-50); }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -7,6 +7,7 @@
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap');
 @import "./salad_ui.css";
 @import "./_typster_ui.css";
+@import "./_editor_topbar.css";
 @source "../css";
 @source "../js";
 @source "../../lib/typster_web";

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -71,11 +71,10 @@ test.describe('Product UI redesign', () => {
     await addMainFile(page)
 
     await expect(page.locator('html')).not.toHaveClass(/is-mac/)
-    // Non-mac: terminal icon + "Ctrl K" shown, ⌘ variant hidden.
-    await expect(page.locator('.ts-cmdk .ts-kbd.ts-other')).toBeVisible()
-    await expect(page.locator('.ts-cmdk .ts-kbd.ts-other')).toHaveText('Ctrl K')
-    await expect(page.locator('.ts-cmdk .ts-kbd.ts-mac')).toBeHidden()
-    await expect(page.locator('.ts-cmdk__icon.ts-mac')).toBeHidden()
+    // Non-mac: "Ctrl K" shown in the merged top-bar omnibox, ⌘ variant hidden.
+    await expect(page.locator('.ts-tb__omni-key .ts-other')).toBeVisible()
+    await expect(page.locator('.ts-tb__omni-key .ts-other')).toHaveText('Ctrl K')
+    await expect(page.locator('.ts-tb__omni-key .ts-mac')).toBeHidden()
 
     // The button still opens the palette regardless of platform labelling.
     await page.getByRole('button', { name: 'Open command palette' }).click()

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,7 +18,7 @@
 // To load it, simply add a second `<link>` to your `root.html.heex` file.
 
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
-import { createIcons, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, Check, ChevronDown, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, LogOut, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Settings, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
+import { createIcons, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, Check, ChevronDown, ChevronLeft, ChevronRight, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GitBranch, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, LogOut, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Settings, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
 import { siGithub, siGoogle } from "simple-icons"
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
@@ -71,7 +71,7 @@ window.liveSocket = liveSocket
 
 const Github = [["path", { d: siGithub.path, fill: "currentColor", stroke: "none" }]]
 const Google = [["path", { d: siGoogle.path, fill: "currentColor", stroke: "none" }]]
-const mkIconSet = { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, Check, ChevronDown, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, LogOut, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Settings, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
+const mkIconSet = { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, Check, ChevronDown, ChevronLeft, ChevronRight, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GitBranch, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, LogOut, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Settings, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
 const mkIcons = (root = document) => {
   createIcons({ icons: mkIconSet, root })
   root.querySelectorAll("svg[data-lucide]").forEach((svg) => svg.removeAttribute("data-lucide"))

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,7 +18,7 @@
 // To load it, simply add a second `<link>` to your `root.html.heex` file.
 
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
-import { createIcons, ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
+import { createIcons, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, Check, ChevronDown, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, LogOut, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Settings, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X as XIcon, Zap } from "lucide"
 import { siGithub, siGoogle } from "simple-icons"
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
@@ -71,13 +71,26 @@ window.liveSocket = liveSocket
 
 const Github = [["path", { d: siGithub.path, fill: "currentColor", stroke: "none" }]]
 const Google = [["path", { d: siGoogle.path, fill: "currentColor", stroke: "none" }]]
-const mkIconSet = { ArrowDown, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, ChevronDown, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
+const mkIconSet = { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bell, Bold, BookText, CaseSensitive, ChartNoAxesColumn, Check, ChevronDown, CircleCheck, CornerDownLeft, CircleX, CloudUpload, Command, Download, Eye, File, FileInput, FileText, Folder, FolderClosed, FolderOpen, GraduationCap, Heading, History, Image, Info, Italic, Link2, List, LogOut, Minus, Moon, NotebookPen, PenLine, Pin, PinOff, Play, Plus, ReceiptText, RefreshCw, Regex, Replace, ReplaceAll, Search, Settings, Share2, Sigma, Sparkles, SquareTerminal, Star, Sun, Table, Trash2, TriangleAlert, Type, Upload, Users, WholeWord, X: XIcon, Zap, Github, Google }
 const mkIcons = (root = document) => {
   createIcons({ icons: mkIconSet, root })
   root.querySelectorAll("svg[data-lucide]").forEach((svg) => svg.removeAttribute("data-lucide"))
 }
 window.mkIcons = mkIcons
 mkIcons()
+
+// ── Set theme explicitly (account-menu appearance segments) ───────────────
+// Mirrors toggleMkTheme's persistence ("phx:theme" + data-theme on <html>).
+// "system" clears the override so the OS preference wins.
+window.setMkTheme = (theme) => {
+  if (theme === "system") {
+    localStorage.removeItem("phx:theme");
+    document.documentElement.removeAttribute("data-theme");
+  } else {
+    localStorage.setItem("phx:theme", theme);
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+};
 
 // ── Theme toggle (view-transition pour reveal) ────────────────────────────
 // The button "pours" the next theme into the page: a round-shaped clip-path

--- a/lib/typster/accounts/scope.ex
+++ b/lib/typster/accounts/scope.ex
@@ -18,15 +18,19 @@ defmodule Typster.Accounts.Scope do
 
   alias Typster.Accounts.User
 
-  defstruct user: nil
+  @type t :: %__MODULE__{user: User.t() | nil, plan: :free | :pro}
+
+  defstruct user: nil, plan: :free
 
   @doc """
   Creates a scope for the given user.
 
-  Returns nil if no user is given.
+  The scope carries the user's nominal billing `plan` (`:free` | `:pro`) so
+  callers and `Typster.Features` can reason about entitlements without
+  re-loading the user. Returns nil if no user is given.
   """
   def for_user(%User{} = user) do
-    %__MODULE__{user: user}
+    %__MODULE__{user: user, plan: user.plan || :free}
   end
 
   def for_user(nil), do: nil

--- a/lib/typster/accounts/user.ex
+++ b/lib/typster/accounts/user.ex
@@ -11,6 +11,8 @@ defmodule Typster.Accounts.User do
   @doc "The accent color keys a user may choose for the product UI."
   def accent_colors, do: @accent_colors
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "users" do
@@ -20,6 +22,9 @@ defmodule Typster.Accounts.User do
     field :confirmed_at, :utc_datetime
     field :authenticated_at, :utc_datetime, virtual: true
     field :accent_color, :string, default: "indigo"
+    # Billing plan for the open-core paywall. Set programmatically by billing
+    # code via `plan_changeset/2` — never from user-submitted params.
+    field :plan, Ecto.Enum, values: [:free, :pro], default: :free
     has_many :projects, Typster.Projects.Project
 
     timestamps(type: :utc_datetime)
@@ -127,6 +132,16 @@ defmodule Typster.Accounts.User do
     |> cast(attrs, [:accent_color])
     |> validate_required([:accent_color])
     |> validate_inclusion(:accent_color, @accent_colors)
+  end
+
+  @doc """
+  Sets the billing plan (`:free` | `:pro`).
+
+  Billing-only: this is driven by billing/admin code, never by user-submitted
+  params, so it uses `change/2` directly rather than `cast/3`.
+  """
+  def plan_changeset(user, plan) when plan in [:free, :pro] do
+    change(user, plan: plan)
   end
 
   @doc """

--- a/lib/typster/application.ex
+++ b/lib/typster/application.ex
@@ -13,6 +13,7 @@ defmodule Typster.Application do
       Typster.Repo,
       {DNSCluster, query: Application.get_env(:typster, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Typster.PubSub},
+      TypsterWeb.Presence,
       {Oban, Application.get_env(:typster, Oban)},
       # Start to serve requests, typically the last entry
       TypsterWeb.Endpoint

--- a/lib/typster/features.ex
+++ b/lib/typster/features.ex
@@ -1,0 +1,86 @@
+defmodule Typster.Features do
+  @moduledoc """
+  Entitlements layer for Typster's open-core model.
+
+  Gate every paid capability through `can?/2`. Never scatter
+  `if scope.plan == :pro` checks across the codebase — route them through here
+  so the free/Pro boundary lives in exactly one place.
+
+  At runtime this dispatches to the private `Typster.Pro.Features` when the Pro
+  submodule is compiled in, and otherwise to `Typster.Features.Free`, which
+  denies every Pro feature. The dispatch uses `Code.ensure_loaded?/1`, so the
+  open-core build contains **no compile-time reference** to `Typster.Pro.*` and
+  stays green under `mix compile --warning-as-errors`.
+
+  The catalog is intentionally tiny — only genuinely paid capabilities. The
+  editor and all of its features, live collaboration, and basic sharing are
+  free and are deliberately *not* listed here.
+  """
+
+  alias Typster.Accounts.Scope
+
+  @typedoc "A gateable Pro capability."
+  @type feature ::
+          :share_write_scoped
+          | :share_advanced_link
+          | :share_link_analytics
+          | :share_embed_sandbox
+          | :share_embed_smart_cta
+          | :share_embed_unbranded
+
+  @features ~w(
+    share_write_scoped
+    share_advanced_link
+    share_link_analytics
+    share_embed_sandbox
+    share_embed_smart_cta
+    share_embed_unbranded
+  )a
+
+  @doc "The full catalog of gateable Pro features."
+  @spec catalog() :: [feature()]
+  def catalog, do: @features
+
+  @doc """
+  Returns true when `scope` is entitled to `feature`.
+
+  Open-core build: always false for every Pro feature (the feature literally
+  cannot run without the Pro code). Pro build: delegates to
+  `Typster.Pro.Features`, which checks the scope's plan and any finer grant.
+
+  Raises `FunctionClauseError` for an unknown feature — a deliberate strict
+  boundary so typos fail loudly instead of silently granting/denying.
+  """
+  @spec can?(Scope.t() | nil, feature()) :: boolean()
+  def can?(scope, feature) when feature in @features do
+    impl().can?(scope, feature)
+  end
+
+  @doc """
+  The nominal plan a scope is on (`:free` | `:pro`), straight from the account.
+
+  This is the *billing* status used for UI ("You're on Free"), independent of
+  whether the Pro code is loaded. Whether a feature can actually run always
+  goes through `can?/2`.
+  """
+  @spec plan(Scope.t() | nil) :: :free | :pro
+  def plan(%Scope{plan: plan}) when plan in [:free, :pro], do: plan
+  def plan(_), do: :free
+
+  @doc "True when the scope is nominally on the Pro plan — for upsell UI."
+  @spec pro?(Scope.t() | nil) :: boolean()
+  def pro?(scope), do: plan(scope) == :pro
+
+  # Runtime dispatch only — never a compile-time reference to Typster.Pro.*.
+  # An explicit `:features_impl` override lets tests inject a fake Pro impl
+  # without the submodule being present.
+  @doc false
+  @spec impl() :: module()
+  def impl do
+    cond do
+      mod = Application.get_env(:typster, :features_impl) -> mod
+      Code.ensure_loaded?(Typster.Pro.Features) -> Typster.Pro.Features
+      true -> Typster.Features.Free
+    end
+  end
+end

--- a/lib/typster/features/free.ex
+++ b/lib/typster/features/free.ex
@@ -1,0 +1,15 @@
+defmodule Typster.Features.Free do
+  @moduledoc """
+  Open-core entitlements: every gateable Pro feature is denied.
+
+  This is the implementation the community build always uses. It exists so the
+  host has a concrete, dependency-free fallback when `Typster.Pro.Features` is
+  not compiled in. A user whose account is nominally `:pro` still gets `false`
+  here when no Pro code is present — correct, because the feature cannot run.
+  """
+
+  @behaviour Typster.Features.Impl
+
+  @impl true
+  def can?(_scope, _feature), do: false
+end

--- a/lib/typster/features/impl.ex
+++ b/lib/typster/features/impl.ex
@@ -1,0 +1,16 @@
+defmodule Typster.Features.Impl do
+  @moduledoc """
+  The behaviour every entitlements implementation follows.
+
+  `Typster.Features.Free` (open core) implements this with `@behaviour`. The
+  private `Typster.Pro.Features` implements it **by convention** — it cannot
+  declare `@behaviour Typster.Features.Impl`, because `:typster_pro` is a
+  dependency of `:typster` and compiles first, so this module is not visible to
+  it at compile time. The contract therefore lives here as documentation and a
+  Dialyzer surface for the host side.
+  """
+
+  alias Typster.Accounts.Scope
+
+  @callback can?(Scope.t() | nil, Typster.Features.feature()) :: boolean()
+end

--- a/lib/typster_web/components/layouts.ex
+++ b/lib/typster_web/components/layouts.ex
@@ -154,12 +154,17 @@ defmodule TypsterWeb.Layouts do
     default: nil,
     doc: "the current [scope](https://hexdocs.pm/phoenix/scopes.html)"
 
+  attr :nav, :boolean,
+    default: true,
+    doc:
+      "render the shared floating nav; set false on screens with their own chrome (e.g. the editor's merged top bar)"
+
   slot :inner_block, required: true
 
   def app(assigns) do
     ~H"""
     <div class="ts-app" data-accent={accent_color(@current_scope)}>
-      <.mk_nav app_mode={true} current_scope={@current_scope}>
+      <.mk_nav :if={@nav} app_mode={true} current_scope={@current_scope}>
         <:nav_links>
           <.link navigate={~p"/projects"}>{gettext("nav.projects")}</.link>
           <.link :if={@current_scope && @current_scope.user} navigate={~p"/users/settings"}>

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -15,9 +15,15 @@ defmodule TypsterWeb.EditorLive.Index do
     assets = Assets.list_assets(scope, project_id)
     main_file = initial_file(file_tree)
 
+    if connected?(socket) and scope.user do
+      TypsterWeb.Presence.track_user(self(), project.id, scope.user)
+      Phoenix.PubSub.subscribe(Typster.PubSub, TypsterWeb.Presence.topic(project.id))
+    end
+
     {:ok,
      socket
      |> assign(:project, project)
+     |> assign(:collaborators, present_collaborators(scope, project.id))
      |> assign(:file_tree, file_tree)
      |> assign(:assets, assets)
      |> assign(:current_file, main_file)
@@ -74,6 +80,14 @@ defmodule TypsterWeb.EditorLive.Index do
   @impl true
   def handle_params(_params, _url, socket) do
     {:noreply, assign(socket, :page_title, socket.assigns.project.name)}
+  end
+
+  @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff"}, socket) do
+    scope = socket.assigns.current_scope
+
+    {:noreply,
+     assign(socket, :collaborators, present_collaborators(scope, socket.assigns.project.id))}
   end
 
   @impl true
@@ -777,13 +791,57 @@ defmodule TypsterWeb.EditorLive.Index do
   defp join_dir("", name), do: name
   defp join_dir(dir, name), do: "#{dir}/#{name}"
 
-  # Breadcrumb segments from the active file's path; the filename is `last`.
-  defp path_segments(nil), do: []
+  # Top-bar breadcrumb: project name + folder path (no filename — the file lives
+  # on the tab and, in v3, on the breadcrumb row under the tabs). Last is active.
+  defp topbar_segments(project, current_file) do
+    folders =
+      case current_file do
+        %{path: path} ->
+          case Path.dirname(path) do
+            "." -> []
+            dir -> Path.split(dir)
+          end
 
-  defp path_segments(%{path: path}) do
-    parts = String.split(path, "/")
-    count = length(parts)
-    parts |> Enum.with_index(1) |> Enum.map(fn {p, i} -> %{name: p, last: i == count} end)
+        _ ->
+          []
+      end
+
+    names = [project.name | folders]
+    count = length(names)
+    names |> Enum.with_index(1) |> Enum.map(fn {n, i} -> %{name: n, last: i == count} end)
+  end
+
+  # The other people currently present in this project's editor (excludes self).
+  defp present_collaborators(scope, project_id) do
+    exclude = scope && scope.user && scope.user.id
+    TypsterWeb.Presence.list_collaborators(project_id, exclude)
+  end
+
+  # Initials/display-name for the account avatar, derived from the email local
+  # part (e.g. "sam.reeves@..." -> "SR" / "Sam Reeves").
+  defp user_initials(%{user: %{email: email}}) when is_binary(email) do
+    email
+    |> email_local_parts()
+    |> Enum.map(&String.first/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.take(2)
+    |> Enum.map_join("", &String.upcase/1)
+    |> case do
+      "" -> "?"
+      s -> s
+    end
+  end
+
+  defp user_initials(_), do: "?"
+
+  defp user_display_name(%{user: %{email: email}}) when is_binary(email) do
+    email |> email_local_parts() |> Enum.map_join(" ", &String.capitalize/1)
+  end
+
+  defp user_display_name(_), do: gettext("editor.topbar.guest")
+
+  defp email_local_parts(email) do
+    email |> String.split("@") |> List.first() |> String.split(~r/[._-]/, trim: true)
   end
 
   # Append a file id to the open-tabs list (keeping order, no duplicates).

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -7,7 +7,7 @@
         class="ts-tb__proj"
         title={gettext("editor.topbar.switch_project")}
       >
-        <span class="ts-tb__proj-glyph ts-serif">T</span>
+        <span class="ts-tb__proj-glyph">T</span>
         <span class="truncate">{@project.name}</span>
         <i data-lucide="chevron-down" aria-hidden="true"></i>
       </.link>
@@ -45,6 +45,10 @@
           <span class="ts-savestat__dot"></span>
         </div>
       </nav>
+
+      <span class="ts-tb__branch" title={gettext("editor.topbar.branch")}>
+        <span class="ts-tb__branch-glyph" aria-hidden="true">⎇</span> main
+      </span>
 
       <button
         type="button"

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -20,7 +20,7 @@
         onclick="history.back()"
         aria-label={gettext("editor.topbar.back")}
       >
-        <i data-lucide="arrow-left" aria-hidden="true"></i>
+        <i data-lucide="chevron-left" aria-hidden="true"></i>
       </button>
       <button
         type="button"
@@ -28,7 +28,7 @@
         onclick="history.forward()"
         aria-label={gettext("editor.topbar.forward")}
       >
-        <i data-lucide="arrow-right" aria-hidden="true"></i>
+        <i data-lucide="chevron-right" aria-hidden="true"></i>
       </button>
 
       <nav class="ts-tb__crumb" aria-label={gettext("editor.breadcrumb")}>
@@ -47,7 +47,7 @@
       </nav>
 
       <span class="ts-tb__branch" title={gettext("editor.topbar.branch")}>
-        <span class="ts-tb__branch-glyph" aria-hidden="true">⎇</span> main
+        <i class="ts-tb__branch-glyph" data-lucide="git-branch" aria-hidden="true"></i> main
       </span>
 
       <button
@@ -69,7 +69,7 @@
         disabled
         title={gettext("editor.share_soon")}
       >
-        <i data-lucide="share-2" aria-hidden="true"></i> {gettext("editor.share")}
+        <i data-lucide="upload" aria-hidden="true"></i> {gettext("editor.share")}
       </button>
 
       <%= cond do %>

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -1,64 +1,199 @@
-<Layouts.app flash={@flash} current_scope={@current_scope}>
+<Layouts.app flash={@flash} current_scope={@current_scope} nav={false}>
   <div class="ts-editor" id="editor-shell" phx-hook="CommandPalette">
-    <%!-- Editor top bar: breadcrumb, save status, actions --%>
-    <div class="ts-editor__bar">
+    <%!-- Top bar v3.1 — merged chrome: project · breadcrumb · omnibox · compile · account --%>
+    <div class="ts-tb" id="editor-topbar" phx-hook="LucideIcons">
       <.link
         navigate={~p"/projects"}
-        class="ts-btn ts-btn--ghost ts-btn--icon ts-btn--sm"
-        aria-label={gettext("nav.projects")}
-        title={gettext("nav.projects")}
+        class="ts-tb__proj"
+        title={gettext("editor.topbar.switch_project")}
       >
-        <.icon name="hero-chevron-left" class="size-3" />
+        <span class="ts-tb__proj-glyph ts-serif">T</span>
+        <span class="truncate">{@project.name}</span>
+        <i data-lucide="chevron-down" aria-hidden="true"></i>
       </.link>
-      <nav class="ts-crumb" aria-label={gettext("editor.breadcrumb")}>
-        <span class="ts-crumb__seg">{@project.name}</span>
-        <span :for={seg <- path_segments(@current_file)}>
-          <span class="ts-crumb__sep">/</span>
-          <span class={["ts-crumb__seg", seg.last && "is-active"]}>{seg.name}</span>
-        </span>
-      </nav>
 
-      <div
-        id="save-status"
-        phx-hook="SaveStatus"
-        class={"ts-savestat ts-savestat--#{@save_status}"}
-      >
-        <span class="ts-savestat__dot"></span>
-        <span class="ts-savestat__label">{save_status_label(@save_status)}</span>
-      </div>
-
-      <div class="ts-spacer" />
+      <span class="ts-tb__div"></span>
 
       <button
         type="button"
-        class="ts-btn ts-btn--ghost ts-btn--sm ts-cmdk"
+        class="ts-tb__navbtn"
+        onclick="history.back()"
+        aria-label={gettext("editor.topbar.back")}
+      >
+        <i data-lucide="arrow-left" aria-hidden="true"></i>
+      </button>
+      <button
+        type="button"
+        class="ts-tb__navbtn"
+        onclick="history.forward()"
+        aria-label={gettext("editor.topbar.forward")}
+      >
+        <i data-lucide="arrow-right" aria-hidden="true"></i>
+      </button>
+
+      <nav class="ts-tb__crumb" aria-label={gettext("editor.breadcrumb")}>
+        <span :for={seg <- topbar_segments(@project, @current_file)}>
+          <span class={["ts-tb__seg", seg.last && "is-active"]}>{seg.name}</span>
+          <span :if={!seg.last} class="ts-tb__sep">/</span>
+        </span>
+        <div
+          id="save-status"
+          phx-hook="SaveStatus"
+          class={"ts-savestat ts-savestat--#{@save_status}"}
+          title={save_status_label(@save_status)}
+        >
+          <span class="ts-savestat__dot"></span>
+        </div>
+      </nav>
+
+      <button
+        type="button"
+        class="ts-tb__omni"
         phx-click="open_palette"
         aria-label={gettext("editor.command_open")}
       >
-        <span class="ts-cmdk__icon ts-mac" aria-hidden="true"><i data-lucide="command"></i></span>
-        <span class="ts-cmdk__icon ts-other" aria-hidden="true">
-          <i data-lucide="square-terminal"></i>
+        <i data-lucide="search" aria-hidden="true"></i>
+        <span class="ts-tb__omni-ph truncate">{gettext("editor.topbar.omni_placeholder")}</span>
+        <span class="ts-tb__omni-key">
+          <span class="ts-mac">⌘K</span><span class="ts-other">Ctrl K</span>
         </span>
-        <%!-- The ⌘ icon already conveys the modifier, so the Mac key is just "K"
-             (avoids a duplicated ⌘). Non-mac spells out "Ctrl" beside the icon. --%>
-        <span class="ts-kbd ts-mac">K</span>
-        <span class="ts-kbd ts-other">Ctrl K</span>
       </button>
+
       <button
         type="button"
-        class="ts-btn ts-btn--ghost ts-btn--sm"
+        class="ts-btn ts-btn--ghost ts-btn--sm ts-tb__share"
         disabled
         title={gettext("editor.share_soon")}
       >
-        <.icon name="hero-arrow-up-tray" class="size-3" /> {gettext("editor.share")}
+        <i data-lucide="share-2" aria-hidden="true"></i> {gettext("editor.share")}
       </button>
-      <button
-        type="button"
-        class="ts-btn ts-btn--primary ts-btn--sm"
-        phx-click={JS.dispatch("phx:editor-command", detail: %{cmd: "compile"})}
+
+      <%= cond do %>
+        <% @preview_compiling -> %>
+          <button type="button" class="ts-tb__compile is-compiling" disabled>
+            <span class="ts-tb__compile-spin"></span> {gettext("editor.compiling")}
+          </button>
+        <% @preview_error -> %>
+          <button
+            type="button"
+            class="ts-tb__compile is-error"
+            phx-click={JS.dispatch("phx:editor-command", detail: %{cmd: "compile"})}
+          >
+            <i data-lucide="triangle-alert" aria-hidden="true"></i>
+            {gettext("editor.topbar.failed")}
+            <span :if={@preview_error_count > 0} class="ts-tb__compile-count">
+              {@preview_error_count}
+            </span>
+          </button>
+        <% @preview_stats -> %>
+          <button
+            type="button"
+            class="ts-tb__compile is-success"
+            phx-click={JS.dispatch("phx:editor-command", detail: %{cmd: "compile"})}
+          >
+            <i data-lucide="check" aria-hidden="true"></i>
+            {gettext("editor.compiled")}
+            <span :if={@preview_stats.ms} class="ts-tb__compile-ms">{@preview_stats.ms}ms</span>
+          </button>
+        <% true -> %>
+          <button
+            type="button"
+            class="ts-tb__compile"
+            phx-click={JS.dispatch("phx:editor-command", detail: %{cmd: "compile"})}
+          >
+            <i data-lucide="play" aria-hidden="true"></i>
+            {gettext("editor.compile")}
+            <span class="ts-kbd">
+              <span class="ts-mac">⌘↩</span><span class="ts-other">Ctrl ↵</span>
+            </span>
+          </button>
+      <% end %>
+
+      <span :if={@collaborators != []} class="ts-tb__div"></span>
+      <div
+        :if={@collaborators != []}
+        class="ts-tb__collab"
+        aria-label={gettext("editor.topbar.collaborators")}
       >
-        <.icon name="hero-play" class="size-3" /> {gettext("editor.compile")}
-      </button>
+        <span
+          :for={c <- @collaborators}
+          class="ts-tb__av"
+          style={"background: #{c.color}"}
+          title={c.name}
+        >
+          {c.initials}<span class="ts-tb__pulse"></span>
+        </span>
+      </div>
+
+      <div class="ts-tb__right">
+        <div class="ts-tb__util">
+          <button
+            type="button"
+            class="mk-theme-toggle"
+            onclick="toggleMkTheme(this)"
+            aria-label={gettext("layout.theme.toggle")}
+          >
+            <i data-lucide="moon" class="mk-icon-moon" aria-hidden="true"></i>
+            <i data-lucide="sun" class="mk-icon-sun" aria-hidden="true"></i>
+          </button>
+          <.link
+            href={
+              ~p"/locale/#{if Gettext.get_locale(TypsterWeb.Gettext) == "ru", do: "en", else: "ru"}"
+            }
+            class="ts-tb__lang"
+            aria-label={gettext("editor.topbar.language")}
+          >
+            {if Gettext.get_locale(TypsterWeb.Gettext) == "ru", do: "RU", else: "EN"}
+          </.link>
+        </div>
+
+        <div class="ts-tb__acct">
+          <button
+            type="button"
+            class="ts-tb__avatar"
+            phx-click={JS.toggle(to: "#tb-account-menu")}
+            aria-label={gettext("editor.topbar.account")}
+          >
+            <span>{user_initials(@current_scope)}</span>
+            <i data-lucide="chevron-down" aria-hidden="true"></i>
+          </button>
+          <div
+            id="tb-account-menu"
+            class="ts-tb__menu hidden"
+            phx-click-away={JS.hide(to: "#tb-account-menu")}
+          >
+            <div class="ts-tb__menu-who">
+              <div class="ts-tb__menu-name">{user_display_name(@current_scope)}</div>
+              <div :if={@current_scope && @current_scope.user} class="ts-tb__menu-email">
+                {@current_scope.user.email}
+              </div>
+            </div>
+            <div class="ts-tb__menu-label">{gettext("editor.topbar.appearance")}</div>
+            <div class="ts-tb__menu-segs">
+              <button type="button" class="ts-tb__menu-seg" onclick="setMkTheme('light')">
+                <i data-lucide="sun" aria-hidden="true"></i> {gettext("layout.theme.light")}
+              </button>
+              <button type="button" class="ts-tb__menu-seg" onclick="setMkTheme('dark')">
+                <i data-lucide="moon" aria-hidden="true"></i> {gettext("layout.theme.dark")}
+              </button>
+              <button type="button" class="ts-tb__menu-seg" onclick="setMkTheme('system')">
+                {gettext("layout.theme.system")}
+              </button>
+            </div>
+            <div class="ts-tb__menu-sep"></div>
+            <.link navigate={~p"/projects"} class="ts-tb__menu-item">
+              <i data-lucide="folder" aria-hidden="true"></i> {gettext("nav.projects")}
+            </.link>
+            <.link navigate={~p"/users/settings"} class="ts-tb__menu-item">
+              <i data-lucide="settings" aria-hidden="true"></i> {gettext("nav.settings")}
+            </.link>
+            <div class="ts-tb__menu-sep"></div>
+            <.link href={~p"/users/log-out"} method="delete" class="ts-tb__menu-item is-danger">
+              <i data-lucide="log-out" aria-hidden="true"></i> {gettext("auth.log_out")}
+            </.link>
+          </div>
+        </div>
+      </div>
     </div>
 
     <%!-- Three-pane window --%>

--- a/lib/typster_web/presence.ex
+++ b/lib/typster_web/presence.ex
@@ -12,6 +12,8 @@ defmodule TypsterWeb.Presence do
     otp_app: :typster,
     pubsub_server: Typster.PubSub
 
+  require Logger
+
   # A small, fixed palette of pleasant hex colors. A user is mapped to one of
   # these deterministically from their id, so the same user always renders with
   # the same color across sessions and clients.
@@ -52,12 +54,28 @@ defmodule TypsterWeb.Presence do
   def list_collaborators(project_id, exclude_user_id \\ nil) do
     project_id
     |> topic()
-    |> list()
+    |> safe_list()
     |> Enum.map(fn {_key, %{metas: [meta | _]}} ->
       %{user_id: meta.user_id, name: meta.name, initials: meta.initials, color: meta.color}
     end)
     |> Enum.reject(&(&1.user_id == exclude_user_id))
     |> Enum.sort_by(& &1.name)
+  end
+
+  # Presence is a supervised core process, but if it is ever unavailable —
+  # e.g. a dev server still running from before it was added to the supervision
+  # tree (its ETS table never started) — degrade to "no collaborators" rather
+  # than crashing the editor mount. A restart brings collaborators back.
+  defp safe_list(topic) do
+    list(topic)
+  rescue
+    ArgumentError ->
+      Logger.warning(
+        "TypsterWeb.Presence is not running — collaborators unavailable. " <>
+          "Restart the server (a newly-added supervision child needs a fresh boot)."
+      )
+
+      %{}
   end
 
   defp display_name(user) do

--- a/lib/typster_web/presence.ex
+++ b/lib/typster_web/presence.ex
@@ -42,6 +42,14 @@ defmodule TypsterWeb.Presence do
       color: color_for(user.id),
       online_at: System.system_time(:second)
     })
+  rescue
+    ArgumentError ->
+      Logger.warning(
+        "TypsterWeb.Presence is not running — cannot track collaborator. " <>
+          "Restart the server (a newly-added supervision child needs a fresh boot)."
+      )
+
+      {:error, :presence_unavailable}
   end
 
   @doc """

--- a/lib/typster_web/presence.ex
+++ b/lib/typster_web/presence.ex
@@ -1,0 +1,95 @@
+defmodule TypsterWeb.Presence do
+  @moduledoc """
+  Tracks live collaborators inside the editor via `Phoenix.Presence`.
+
+  Each project has its own presence topic (`editor:<project_id>`). When a user
+  opens the editor, `track_user/3` records a small meta payload (display name,
+  initials, and a deterministic color) so the UI can render avatar chips for
+  everyone currently present without re-loading user records.
+  """
+
+  use Phoenix.Presence,
+    otp_app: :typster,
+    pubsub_server: Typster.PubSub
+
+  # A small, fixed palette of pleasant hex colors. A user is mapped to one of
+  # these deterministically from their id, so the same user always renders with
+  # the same color across sessions and clients.
+  @palette ~w(#6366f1 #8b5cf6 #0ea5e9 #10b981 #f43f5e #f59e0b)
+
+  @doc """
+  Returns the presence topic for the given project id.
+
+  Accepts a binary id or any struct/value with an `id` we can stringify.
+  """
+  def topic(project_id) when is_binary(project_id), do: "editor:" <> project_id
+  def topic(%{id: id}), do: topic(to_string(id))
+  def topic(project_id), do: topic(to_string(project_id))
+
+  @doc """
+  Tracks `user` as present in the given project's editor topic.
+
+  The presence key is the user's id, so a user opening multiple tabs collapses
+  to a single collaborator entry.
+  """
+  def track_user(pid_or_socket, project_id, user) do
+    track(pid_or_socket, topic(project_id), user.id, %{
+      user_id: user.id,
+      name: display_name(user),
+      initials: initials(user),
+      color: color_for(user.id),
+      online_at: System.system_time(:second)
+    })
+  end
+
+  @doc """
+  Lists the distinct collaborators currently present in a project.
+
+  Returns one `%{user_id, name, initials, color}` map per present user (taking
+  the first meta per key), excluding `exclude_user_id` when given, sorted by
+  name.
+  """
+  def list_collaborators(project_id, exclude_user_id \\ nil) do
+    project_id
+    |> topic()
+    |> list()
+    |> Enum.map(fn {_key, %{metas: [meta | _]}} ->
+      %{user_id: meta.user_id, name: meta.name, initials: meta.initials, color: meta.color}
+    end)
+    |> Enum.reject(&(&1.user_id == exclude_user_id))
+    |> Enum.sort_by(& &1.name)
+  end
+
+  defp display_name(user) do
+    user.email
+    |> local_part()
+    |> String.capitalize()
+  end
+
+  defp initials(user) do
+    user.email
+    |> local_part()
+    |> String.split(~r/[._-]+/, trim: true)
+    |> Enum.map(&String.first/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.take(2)
+    |> Enum.map_join(&String.upcase/1)
+    |> case do
+      "" -> "?"
+      initials -> initials
+    end
+  end
+
+  defp color_for(user_id) do
+    index = :erlang.phash2(user_id, length(@palette))
+    Enum.at(@palette, index)
+  end
+
+  defp local_part(email) do
+    email
+    |> to_string()
+    |> String.split("@", parts: 2)
+    |> List.first()
+    |> Kernel.||("")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -82,7 +82,23 @@ defmodule Typster.MixProject do
       {:sobelow, "~> 0.14", only: [:dev, :test], runtime: false},
       {:igniter, "~> 0.6", runtime: false},
       {:assay, "~> 0.5", only: [:dev, :test], runtime: false}
-    ]
+    ] ++ pro_deps()
+  end
+
+  # Closed-source "Pro" modules live in the private `typster-pro` repo, mounted
+  # here as a git submodule at `pro/` and consumed as a path dependency — but
+  # ONLY when present. A plain public clone (or CI without access) leaves `pro/`
+  # empty, so the dependency is never declared and the open-core build compiles
+  # cleanly under `--warning-as-errors`. Path deps never enter `mix.lock`, so
+  # `deps.unlock --unused` in `precommit` has nothing to strip. The host
+  # dispatches to `Typster.Pro.*` at runtime via `Code.ensure_loaded?/1`
+  # (see `Typster.Features`), never at compile time.
+  defp pro_deps do
+    if File.exists?("pro/mix.exs") do
+      [{:typster_pro, path: "pro"}]
+    else
+      []
+    end
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,7 +21,7 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:182
+#: lib/typster_web/components/layouts.ex:183
 #, elixir-autogen, elixir-format
 msgid "app.connection_lost"
 msgstr ""
@@ -35,7 +35,7 @@ msgstr ""
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:192
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr ""
@@ -134,24 +134,24 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:407
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:105
+#: lib/typster_web/live/editor_live/index.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:711
-#: lib/typster_web/live/editor_live/index.html.heex:712
+#: lib/typster_web/live/editor_live/index.html.heex:715
+#: lib/typster_web/live/editor_live/index.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:215
-#: lib/typster_web/live/editor_live/index.html.heex:288
+#: lib/typster_web/live/editor_live/index.html.heex:219
+#: lib/typster_web/live/editor_live/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
@@ -183,27 +183,27 @@ msgstr ""
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
+#: lib/typster_web/live/editor_live/index.html.heex:242
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:533
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:297
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:727
+#: lib/typster_web/live/editor_live/index.html.heex:731
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
@@ -223,32 +223,32 @@ msgstr ""
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:240
-#: lib/typster_web/live/editor_live/index.html.heex:177
+#: lib/typster_web/components/layouts.ex:241
+#: lib/typster_web/live/editor_live/index.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:232
-#: lib/typster_web/live/editor_live/index.html.heex:174
+#: lib/typster_web/components/layouts.ex:233
+#: lib/typster_web/live/editor_live/index.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/components/layouts.ex:225
+#: lib/typster_web/live/editor_live/index.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr ""
@@ -308,15 +308,15 @@ msgstr ""
 msgid "nav.my_projects"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:168
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/components/layouts.ex:169
+#: lib/typster_web/live/editor_live/index.html.heex:189
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:170
-#: lib/typster_web/live/editor_live/index.html.heex:188
+#: lib/typster_web/components/layouts.ex:171
+#: lib/typster_web/live/editor_live/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr ""
@@ -516,161 +516,161 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:95
-#: lib/typster_web/live/editor_live/index.html.heex:681
+#: lib/typster_web/live/editor_live/index.html.heex:99
+#: lib/typster_web/live/editor_live/index.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
-#: lib/typster_web/live/editor_live/index.html.heex:677
+#: lib/typster_web/live/editor_live/index.html.heex:78
+#: lib/typster_web/live/editor_live/index.html.heex:681
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:212
+#: lib/typster_web/live/editor_live/index.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:538
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
-#: lib/typster_web/live/editor_live/index.html.heex:558
+#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:604
-#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:608
+#: lib/typster_web/live/editor_live/index.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:547
-#: lib/typster_web/live/editor_live/index.html.heex:548
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:585
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:566
-#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:580
+#: lib/typster_web/live/editor_live/index.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:594
-#: lib/typster_web/live/editor_live/index.html.heex:595
+#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:380
+#: lib/typster_web/live/editor_live/index.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:893
-#: lib/typster_web/live/editor_live/index.html.heex:901
-#: lib/typster_web/live/editor_live/index.html.heex:910
+#: lib/typster_web/live/editor_live/index.html.heex:897
+#: lib/typster_web/live/editor_live/index.html.heex:905
+#: lib/typster_web/live/editor_live/index.html.heex:914
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:945
-#: lib/typster_web/live/editor_live/index.html.heex:953
-#: lib/typster_web/live/editor_live/index.html.heex:962
+#: lib/typster_web/live/editor_live/index.html.heex:949
+#: lib/typster_web/live/editor_live/index.html.heex:957
+#: lib/typster_web/live/editor_live/index.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:928
+#: lib/typster_web/live/editor_live/index.html.heex:932
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:950
+#: lib/typster_web/live/editor_live/index.html.heex:954
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:885
+#: lib/typster_web/live/editor_live/index.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:894
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:924
+#: lib/typster_web/live/editor_live/index.html.heex:898
+#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:898
+#: lib/typster_web/live/editor_live/index.html.heex:902
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:946
-#: lib/typster_web/live/editor_live/index.html.heex:965
-#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:950
+#: lib/typster_web/live/editor_live/index.html.heex:969
+#: lib/typster_web/live/editor_live/index.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:672
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:703
+#: lib/typster_web/live/editor_live/index.html.heex:707
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:68
+#: lib/typster_web/live/editor_live/index.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:66
+#: lib/typster_web/live/editor_live/index.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:690
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:695
+#: lib/typster_web/live/editor_live/index.html.heex:699
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:695
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -830,38 +830,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:647
+#: lib/typster_web/live/editor_live/index.html.heex:651
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:659
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:642
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:645
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:614
-#: lib/typster_web/live/editor_live/index.html.heex:615
+#: lib/typster_web/live/editor_live/index.html.heex:618
+#: lib/typster_web/live/editor_live/index.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1989,17 +1989,17 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:221
+#: lib/typster_web/live/editor_live/index.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr ""
@@ -2009,33 +2009,33 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:255
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:254
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:346
+#: lib/typster_web/live/editor_live/index.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "editor.flash.file_exists"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:53
+#: lib/typster_web/live/editor_live/index.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr ""
@@ -2062,14 +2062,14 @@ msgstr ""
 msgid "editor.flash.file_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:279
+#: lib/typster_web/live/editor_live/index.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:470
-#: lib/typster_web/live/editor_live/index.html.heex:471
+#: lib/typster_web/live/editor_live/index.html.heex:474
+#: lib/typster_web/live/editor_live/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
@@ -2085,7 +2085,7 @@ msgid "editor.tree.pin"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
@@ -2095,19 +2095,19 @@ msgstr ""
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:382
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr ""
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "editor.breadcrumb"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:522
+#: lib/typster_web/live/editor_live/index.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr ""
@@ -2127,23 +2127,23 @@ msgstr ""
 msgid "editor.flash.template_saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:443
+#: lib/typster_web/live/editor_live/index.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:469
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:489
+#: lib/typster_web/live/editor_live/index.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
-#: lib/typster_web/live/editor_live/index.html.heex:460
+#: lib/typster_web/live/editor_live/index.html.heex:463
+#: lib/typster_web/live/editor_live/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr ""
@@ -2154,8 +2154,8 @@ msgid "editor.flash.dropped_added"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:907
-#: lib/typster_web/live/editor_live/index.html.heex:670
-#: lib/typster_web/live/editor_live/index.html.heex:858
+#: lib/typster_web/live/editor_live/index.html.heex:674
+#: lib/typster_web/live/editor_live/index.html.heex:862
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2174,53 +2174,53 @@ msgstr[1] ""
 msgid "editor.compile_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:784
+#: lib/typster_web/live/editor_live/index.html.heex:788
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:790
+#: lib/typster_web/live/editor_live/index.html.heex:794
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:766
+#: lib/typster_web/live/editor_live/index.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:741
-#: lib/typster_web/live/editor_live/index.html.heex:860
+#: lib/typster_web/live/editor_live/index.html.heex:745
+#: lib/typster_web/live/editor_live/index.html.heex:864
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:798
+#: lib/typster_web/live/editor_live/index.html.heex:802
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:811
+#: lib/typster_web/live/editor_live/index.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:750
+#: lib/typster_web/live/editor_live/index.html.heex:754
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:851
+#: lib/typster_web/live/editor_live/index.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:771
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:769
+#: lib/typster_web/live/editor_live/index.html.heex:773
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr ""
@@ -2235,12 +2235,12 @@ msgstr ""
 msgid "editor.flash.move_conflict"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:155
+#: lib/typster_web/live/editor_live/index.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:171
+#: lib/typster_web/live/editor_live/index.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr ""
@@ -2250,12 +2250,12 @@ msgstr ""
 msgid "editor.topbar.back"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:116
+#: lib/typster_web/live/editor_live/index.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:83
+#: lib/typster_web/live/editor_live/index.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr ""
@@ -2270,12 +2270,12 @@ msgstr ""
 msgid "editor.topbar.guest"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:144
+#: lib/typster_web/live/editor_live/index.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:56
+#: lib/typster_web/live/editor_live/index.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.omni_placeholder"
 msgstr ""
@@ -2283,4 +2283,9 @@ msgstr ""
 #: lib/typster_web/live/editor_live/index.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.switch_project"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:49
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.branch"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,7 +21,7 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:178
+#: lib/typster_web/components/layouts.ex:182
 #, elixir-autogen, elixir-format
 msgid "app.connection_lost"
 msgstr ""
@@ -35,6 +35,7 @@ msgstr ""
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
+#: lib/typster_web/live/editor_live/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr ""
@@ -133,117 +134,121 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:268
+#: lib/typster_web/live/editor_live/index.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:60
+#: lib/typster_web/live/editor_live/index.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:712
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
-#: lib/typster_web/live/editor_live/index.html.heex:153
+#: lib/typster_web/live/editor_live/index.html.heex:215
+#: lib/typster_web/live/editor_live/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:546
+#: lib/typster_web/live/editor_live/index.ex:540
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:537
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:227
+#: lib/typster_web/live/editor_live/index.ex:241
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:577
+#: lib/typster_web/live/editor_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:384
-#: lib/typster_web/live/editor_live/index.ex:408
-#: lib/typster_web/live/editor_live/index.ex:720
+#: lib/typster_web/live/editor_live/index.ex:398
+#: lib/typster_web/live/editor_live/index.ex:422
+#: lib/typster_web/live/editor_live/index.ex:714
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:238
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:394
+#: lib/typster_web/live/editor_live/index.html.heex:529
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:158
+#: lib/typster_web/live/editor_live/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:664
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:592
+#: lib/typster_web/live/editor_live/index.html.heex:727
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:654
+#: lib/typster_web/live/editor_live/index.ex:648
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:652
+#: lib/typster_web/live/editor_live/index.ex:646
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:653
+#: lib/typster_web/live/editor_live/index.ex:647
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:273
-#: lib/typster_web/live/editor_live/index.html.heex:302
+#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:236
+#: lib/typster_web/components/layouts.ex:240
+#: lib/typster_web/live/editor_live/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:228
+#: lib/typster_web/components/layouts.ex:232
+#: lib/typster_web/live/editor_live/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:220
+#: lib/typster_web/components/layouts.ex:224
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:101
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr ""
@@ -303,15 +308,15 @@ msgstr ""
 msgid "nav.my_projects"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:164
-#: lib/typster_web/live/editor_live/index.html.heex:8
-#: lib/typster_web/live/editor_live/index.html.heex:9
+#: lib/typster_web/components/layouts.ex:168
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr ""
 
-#: lib/typster_web/components/layouts.ex:166
+#: lib/typster_web/components/layouts.ex:170
+#: lib/typster_web/live/editor_live/index.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr ""
@@ -511,159 +516,161 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:95
+#: lib/typster_web/live/editor_live/index.html.heex:681
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:73
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:538
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
-#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:469
-#: lib/typster_web/live/editor_live/index.html.heex:470
+#: lib/typster_web/live/editor_live/index.html.heex:604
+#: lib/typster_web/live/editor_live/index.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
-#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:548
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:431
-#: lib/typster_web/live/editor_live/index.html.heex:432
+#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:567
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:441
-#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:577
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
-#: lib/typster_web/live/editor_live/index.html.heex:460
+#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:245
+#: lib/typster_web/live/editor_live/index.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:252
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:758
-#: lib/typster_web/live/editor_live/index.html.heex:766
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:893
+#: lib/typster_web/live/editor_live/index.html.heex:901
+#: lib/typster_web/live/editor_live/index.html.heex:910
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:810
-#: lib/typster_web/live/editor_live/index.html.heex:818
-#: lib/typster_web/live/editor_live/index.html.heex:827
+#: lib/typster_web/live/editor_live/index.html.heex:945
+#: lib/typster_web/live/editor_live/index.html.heex:953
+#: lib/typster_web/live/editor_live/index.html.heex:962
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:793
+#: lib/typster_web/live/editor_live/index.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:815
+#: lib/typster_web/live/editor_live/index.html.heex:950
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:750
+#: lib/typster_web/live/editor_live/index.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:759
-#: lib/typster_web/live/editor_live/index.html.heex:783
-#: lib/typster_web/live/editor_live/index.html.heex:789
+#: lib/typster_web/live/editor_live/index.html.heex:894
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:924
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:763
+#: lib/typster_web/live/editor_live/index.html.heex:898
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:811
-#: lib/typster_web/live/editor_live/index.html.heex:830
-#: lib/typster_web/live/editor_live/index.html.heex:839
+#: lib/typster_web/live/editor_live/index.html.heex:946
+#: lib/typster_web/live/editor_live/index.html.heex:965
+#: lib/typster_web/live/editor_live/index.html.heex:974
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:568
+#: lib/typster_web/live/editor_live/index.html.heex:703
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:53
+#: lib/typster_web/live/editor_live/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:51
+#: lib/typster_web/live/editor_live/index.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:686
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:695
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -823,38 +830,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:512
+#: lib/typster_web/live/editor_live/index.html.heex:647
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:520
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:644
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:653
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:506
+#: lib/typster_web/live/editor_live/index.html.heex:641
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:479
-#: lib/typster_web/live/editor_live/index.html.heex:480
+#: lib/typster_web/live/editor_live/index.html.heex:614
+#: lib/typster_web/live/editor_live/index.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1982,17 +1989,17 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:86
+#: lib/typster_web/live/editor_live/index.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr ""
@@ -2002,67 +2009,67 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:120
+#: lib/typster_web/live/editor_live/index.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:119
+#: lib/typster_web/live/editor_live/index.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:118
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:118
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:211
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:349
-#: lib/typster_web/live/editor_live/index.ex:395
-#: lib/typster_web/live/editor_live/index.ex:576
+#: lib/typster_web/live/editor_live/index.ex:363
+#: lib/typster_web/live/editor_live/index.ex:409
+#: lib/typster_web/live/editor_live/index.ex:570
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:36
+#: lib/typster_web/live/editor_live/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:513
+#: lib/typster_web/live/editor_live/index.ex:507
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:144
+#: lib/typster_web/live/editor_live/index.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:335
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:470
+#: lib/typster_web/live/editor_live/index.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
@@ -2078,7 +2085,7 @@ msgid "editor.tree.pin"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:374
+#: lib/typster_web/live/editor_live/index.html.heex:509
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
@@ -2088,142 +2095,192 @@ msgstr ""
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:247
+#: lib/typster_web/live/editor_live/index.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:95
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:197
+#: lib/typster_web/live/editor_live/index.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:13
+#: lib/typster_web/live/editor_live/index.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "editor.breadcrumb"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:670
+#: lib/typster_web/live/editor_live/index.ex:664
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:324
-#: lib/typster_web/live/editor_live/index.html.heex:325
+#: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:721
+#: lib/typster_web/live/editor_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:846
-#: lib/typster_web/live/editor_live/index.html.heex:535
-#: lib/typster_web/live/editor_live/index.html.heex:723
+#: lib/typster_web/live/editor_live/index.ex:907
+#: lib/typster_web/live/editor_live/index.html.heex:670
+#: lib/typster_web/live/editor_live/index.html.heex:858
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:848
+#: lib/typster_web/live/editor_live/index.ex:909
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:852
+#: lib/typster_web/live/editor_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:784
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:790
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:631
+#: lib/typster_web/live/editor_live/index.html.heex:766
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:606
-#: lib/typster_web/live/editor_live/index.html.heex:725
+#: lib/typster_web/live/editor_live/index.html.heex:741
+#: lib/typster_web/live/editor_live/index.html.heex:860
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:663
+#: lib/typster_web/live/editor_live/index.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:811
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:615
+#: lib/typster_web/live/editor_live/index.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:716
+#: lib/typster_web/live/editor_live/index.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:636
+#: lib/typster_web/live/editor_live/index.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:634
+#: lib/typster_web/live/editor_live/index.html.heex:769
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:443
+#: lib/typster_web/live/editor_live/index.ex:769
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:756
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:155
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.account"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:171
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.appearance"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:21
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.back"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.collaborators"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:83
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.failed"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.forward"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:841
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.guest"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:144
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.language"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.omni_placeholder"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.switch_project"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "Actions"
 msgid "close"
 msgstr "close"
 
-#: lib/typster_web/components/layouts.ex:182
+#: lib/typster_web/components/layouts.ex:183
 #, elixir-autogen, elixir-format
 msgid "app.connection_lost"
 msgstr "Connection dropped — reconnecting"
@@ -35,7 +35,7 @@ msgstr "Log in"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:192
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Log out"
@@ -134,24 +134,24 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:407
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
 
-#: lib/typster_web/live/editor_live/index.html.heex:105
+#: lib/typster_web/live/editor_live/index.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:711
-#: lib/typster_web/live/editor_live/index.html.heex:712
+#: lib/typster_web/live/editor_live/index.html.heex:715
+#: lib/typster_web/live/editor_live/index.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
-#: lib/typster_web/live/editor_live/index.html.heex:215
-#: lib/typster_web/live/editor_live/index.html.heex:288
+#: lib/typster_web/live/editor_live/index.html.heex:219
+#: lib/typster_web/live/editor_live/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
@@ -183,27 +183,27 @@ msgstr "File could not be created."
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
+#: lib/typster_web/live/editor_live/index.html.heex:242
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:533
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:297
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:727
+#: lib/typster_web/live/editor_live/index.html.heex:731
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
@@ -223,32 +223,32 @@ msgstr "Saved"
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
 
-#: lib/typster_web/components/layouts.ex:240
-#: lib/typster_web/live/editor_live/index.html.heex:177
+#: lib/typster_web/components/layouts.ex:241
+#: lib/typster_web/live/editor_live/index.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Dark theme"
 
-#: lib/typster_web/components/layouts.ex:232
-#: lib/typster_web/live/editor_live/index.html.heex:174
+#: lib/typster_web/components/layouts.ex:233
+#: lib/typster_web/live/editor_live/index.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Light theme"
 
-#: lib/typster_web/components/layouts.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/components/layouts.ex:225
+#: lib/typster_web/live/editor_live/index.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Use system theme"
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Toggle theme"
@@ -308,15 +308,15 @@ msgstr "Log in to"
 msgid "nav.my_projects"
 msgstr "My projects"
 
-#: lib/typster_web/components/layouts.ex:168
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/components/layouts.ex:169
+#: lib/typster_web/live/editor_live/index.html.heex:189
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Projects"
 
-#: lib/typster_web/components/layouts.ex:170
-#: lib/typster_web/live/editor_live/index.html.heex:188
+#: lib/typster_web/components/layouts.ex:171
+#: lib/typster_web/live/editor_live/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Settings"
@@ -516,161 +516,161 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:95
-#: lib/typster_web/live/editor_live/index.html.heex:681
+#: lib/typster_web/live/editor_live/index.html.heex:99
+#: lib/typster_web/live/editor_live/index.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
-#: lib/typster_web/live/editor_live/index.html.heex:677
+#: lib/typster_web/live/editor_live/index.html.heex:78
+#: lib/typster_web/live/editor_live/index.html.heex:681
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:212
+#: lib/typster_web/live/editor_live/index.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:538
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
-#: lib/typster_web/live/editor_live/index.html.heex:558
+#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:604
-#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:608
+#: lib/typster_web/live/editor_live/index.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:547
-#: lib/typster_web/live/editor_live/index.html.heex:548
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:585
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:566
-#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:580
+#: lib/typster_web/live/editor_live/index.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:594
-#: lib/typster_web/live/editor_live/index.html.heex:595
+#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:380
+#: lib/typster_web/live/editor_live/index.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:893
-#: lib/typster_web/live/editor_live/index.html.heex:901
-#: lib/typster_web/live/editor_live/index.html.heex:910
+#: lib/typster_web/live/editor_live/index.html.heex:897
+#: lib/typster_web/live/editor_live/index.html.heex:905
+#: lib/typster_web/live/editor_live/index.html.heex:914
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:945
-#: lib/typster_web/live/editor_live/index.html.heex:953
-#: lib/typster_web/live/editor_live/index.html.heex:962
+#: lib/typster_web/live/editor_live/index.html.heex:949
+#: lib/typster_web/live/editor_live/index.html.heex:957
+#: lib/typster_web/live/editor_live/index.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:928
+#: lib/typster_web/live/editor_live/index.html.heex:932
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:950
+#: lib/typster_web/live/editor_live/index.html.heex:954
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:885
+#: lib/typster_web/live/editor_live/index.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:894
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:924
+#: lib/typster_web/live/editor_live/index.html.heex:898
+#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:898
+#: lib/typster_web/live/editor_live/index.html.heex:902
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:946
-#: lib/typster_web/live/editor_live/index.html.heex:965
-#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:950
+#: lib/typster_web/live/editor_live/index.html.heex:969
+#: lib/typster_web/live/editor_live/index.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:672
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:703
+#: lib/typster_web/live/editor_live/index.html.heex:707
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:68
+#: lib/typster_web/live/editor_live/index.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.html.heex:66
+#: lib/typster_web/live/editor_live/index.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:690
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:695
+#: lib/typster_web/live/editor_live/index.html.heex:699
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:695
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -830,38 +830,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:647
+#: lib/typster_web/live/editor_live/index.html.heex:651
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:659
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:642
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:645
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:614
-#: lib/typster_web/live/editor_live/index.html.heex:615
+#: lib/typster_web/live/editor_live/index.html.heex:618
+#: lib/typster_web/live/editor_live/index.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1989,17 +1989,17 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:221
+#: lib/typster_web/live/editor_live/index.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
@@ -2009,33 +2009,33 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:255
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:254
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:346
+#: lib/typster_web/live/editor_live/index.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
@@ -2047,7 +2047,7 @@ msgstr "filename"
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
 
-#: lib/typster_web/live/editor_live/index.html.heex:53
+#: lib/typster_web/live/editor_live/index.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Open command palette"
@@ -2062,14 +2062,14 @@ msgstr "Asset deleted."
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
 
-#: lib/typster_web/live/editor_live/index.html.heex:279
+#: lib/typster_web/live/editor_live/index.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Pinned"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:470
-#: lib/typster_web/live/editor_live/index.html.heex:471
+#: lib/typster_web/live/editor_live/index.html.heex:474
+#: lib/typster_web/live/editor_live/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
@@ -2085,7 +2085,7 @@ msgid "editor.tree.pin"
 msgstr "Pin file"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
@@ -2095,19 +2095,19 @@ msgstr "Pinned"
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:382
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] "%{count} section"
 msgstr[1] "%{count} sections"
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "New folder"
 
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "folder name"
@@ -2117,7 +2117,7 @@ msgstr "folder name"
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
 
-#: lib/typster_web/live/editor_live/index.html.heex:522
+#: lib/typster_web/live/editor_live/index.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Close tab"
@@ -2127,23 +2127,23 @@ msgstr "Close tab"
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
 
-#: lib/typster_web/live/editor_live/index.html.heex:443
+#: lib/typster_web/live/editor_live/index.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Your templates"
 
-#: lib/typster_web/live/editor_live/index.html.heex:469
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Remove this template?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:489
+#: lib/typster_web/live/editor_live/index.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Upload a file to reuse"
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
-#: lib/typster_web/live/editor_live/index.html.heex:460
+#: lib/typster_web/live/editor_live/index.html.heex:463
+#: lib/typster_web/live/editor_live/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
@@ -2154,8 +2154,8 @@ msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
 #: lib/typster_web/live/editor_live/index.ex:907
-#: lib/typster_web/live/editor_live/index.html.heex:670
-#: lib/typster_web/live/editor_live/index.html.heex:858
+#: lib/typster_web/live/editor_live/index.html.heex:674
+#: lib/typster_web/live/editor_live/index.html.heex:862
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2174,53 +2174,53 @@ msgstr[1] ""
 msgid "editor.compile_failed"
 msgstr "Compile failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:784
+#: lib/typster_web/live/editor_live/index.html.heex:788
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Clear log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:790
+#: lib/typster_web/live/editor_live/index.html.heex:794
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Close panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:766
+#: lib/typster_web/live/editor_live/index.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "Jump to first"
 
-#: lib/typster_web/live/editor_live/index.html.heex:741
-#: lib/typster_web/live/editor_live/index.html.heex:860
+#: lib/typster_web/live/editor_live/index.html.heex:745
+#: lib/typster_web/live/editor_live/index.html.heex:864
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Compile log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:798
+#: lib/typster_web/live/editor_live/index.html.heex:802
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "No compiles yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:811
+#: lib/typster_web/live/editor_live/index.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "No problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:750
+#: lib/typster_web/live/editor_live/index.html.heex:754
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:851
+#: lib/typster_web/live/editor_live/index.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Toggle compile panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:771
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Off"
 
-#: lib/typster_web/live/editor_live/index.html.heex:769
+#: lib/typster_web/live/editor_live/index.html.heex:773
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
@@ -2235,12 +2235,12 @@ msgstr "File moved."
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
 
-#: lib/typster_web/live/editor_live/index.html.heex:155
+#: lib/typster_web/live/editor_live/index.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr "Account"
 
-#: lib/typster_web/live/editor_live/index.html.heex:171
+#: lib/typster_web/live/editor_live/index.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr "Appearance"
@@ -2250,12 +2250,12 @@ msgstr "Appearance"
 msgid "editor.topbar.back"
 msgstr "Back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:116
+#: lib/typster_web/live/editor_live/index.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr "Collaborators"
 
-#: lib/typster_web/live/editor_live/index.html.heex:83
+#: lib/typster_web/live/editor_live/index.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr "Failed"
@@ -2270,12 +2270,12 @@ msgstr "Forward"
 msgid "editor.topbar.guest"
 msgstr "Guest"
 
-#: lib/typster_web/live/editor_live/index.html.heex:144
+#: lib/typster_web/live/editor_live/index.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr "Language"
 
-#: lib/typster_web/live/editor_live/index.html.heex:56
+#: lib/typster_web/live/editor_live/index.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.omni_placeholder"
 msgstr "Search files, run commands, jump to…"
@@ -2284,3 +2284,8 @@ msgstr "Search files, run commands, jump to…"
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.switch_project"
 msgstr "Switch project"
+
+#: lib/typster_web/live/editor_live/index.html.heex:49
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.branch"
+msgstr "Branch"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "Actions"
 msgid "close"
 msgstr "close"
 
-#: lib/typster_web/components/layouts.ex:178
+#: lib/typster_web/components/layouts.ex:182
 #, elixir-autogen, elixir-format
 msgid "app.connection_lost"
 msgstr "Connection dropped — reconnecting"
@@ -35,6 +35,7 @@ msgstr "Log in"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
+#: lib/typster_web/live/editor_live/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Log out"
@@ -133,117 +134,121 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:268
+#: lib/typster_web/live/editor_live/index.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
 
-#: lib/typster_web/live/editor_live/index.html.heex:60
+#: lib/typster_web/live/editor_live/index.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:712
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
-#: lib/typster_web/live/editor_live/index.html.heex:153
+#: lib/typster_web/live/editor_live/index.html.heex:215
+#: lib/typster_web/live/editor_live/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:546
+#: lib/typster_web/live/editor_live/index.ex:540
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:537
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:227
+#: lib/typster_web/live/editor_live/index.ex:241
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:577
+#: lib/typster_web/live/editor_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:384
-#: lib/typster_web/live/editor_live/index.ex:408
-#: lib/typster_web/live/editor_live/index.ex:720
+#: lib/typster_web/live/editor_live/index.ex:398
+#: lib/typster_web/live/editor_live/index.ex:422
+#: lib/typster_web/live/editor_live/index.ex:714
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:238
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:394
+#: lib/typster_web/live/editor_live/index.html.heex:529
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:158
+#: lib/typster_web/live/editor_live/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:664
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:592
+#: lib/typster_web/live/editor_live/index.html.heex:727
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:654
+#: lib/typster_web/live/editor_live/index.ex:648
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:652
+#: lib/typster_web/live/editor_live/index.ex:646
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:653
+#: lib/typster_web/live/editor_live/index.ex:647
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:273
-#: lib/typster_web/live/editor_live/index.html.heex:302
+#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
 
-#: lib/typster_web/components/layouts.ex:236
+#: lib/typster_web/components/layouts.ex:240
+#: lib/typster_web/live/editor_live/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Dark theme"
 
-#: lib/typster_web/components/layouts.ex:228
+#: lib/typster_web/components/layouts.ex:232
+#: lib/typster_web/live/editor_live/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Light theme"
 
-#: lib/typster_web/components/layouts.ex:220
+#: lib/typster_web/components/layouts.ex:224
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Use system theme"
 
 #: lib/typster_web/components/layouts.ex:101
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Toggle theme"
@@ -303,15 +308,15 @@ msgstr "Log in to"
 msgid "nav.my_projects"
 msgstr "My projects"
 
-#: lib/typster_web/components/layouts.ex:164
-#: lib/typster_web/live/editor_live/index.html.heex:8
-#: lib/typster_web/live/editor_live/index.html.heex:9
+#: lib/typster_web/components/layouts.ex:168
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Projects"
 
-#: lib/typster_web/components/layouts.ex:166
+#: lib/typster_web/components/layouts.ex:170
+#: lib/typster_web/live/editor_live/index.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Settings"
@@ -511,159 +516,161 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:95
+#: lib/typster_web/live/editor_live/index.html.heex:681
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:73
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:538
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
-#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:469
-#: lib/typster_web/live/editor_live/index.html.heex:470
+#: lib/typster_web/live/editor_live/index.html.heex:604
+#: lib/typster_web/live/editor_live/index.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
-#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:548
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:431
-#: lib/typster_web/live/editor_live/index.html.heex:432
+#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:567
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:441
-#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:577
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
-#: lib/typster_web/live/editor_live/index.html.heex:460
+#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:245
+#: lib/typster_web/live/editor_live/index.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:252
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:758
-#: lib/typster_web/live/editor_live/index.html.heex:766
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:893
+#: lib/typster_web/live/editor_live/index.html.heex:901
+#: lib/typster_web/live/editor_live/index.html.heex:910
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:810
-#: lib/typster_web/live/editor_live/index.html.heex:818
-#: lib/typster_web/live/editor_live/index.html.heex:827
+#: lib/typster_web/live/editor_live/index.html.heex:945
+#: lib/typster_web/live/editor_live/index.html.heex:953
+#: lib/typster_web/live/editor_live/index.html.heex:962
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:793
+#: lib/typster_web/live/editor_live/index.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:815
+#: lib/typster_web/live/editor_live/index.html.heex:950
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:750
+#: lib/typster_web/live/editor_live/index.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:759
-#: lib/typster_web/live/editor_live/index.html.heex:783
-#: lib/typster_web/live/editor_live/index.html.heex:789
+#: lib/typster_web/live/editor_live/index.html.heex:894
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:924
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:763
+#: lib/typster_web/live/editor_live/index.html.heex:898
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:811
-#: lib/typster_web/live/editor_live/index.html.heex:830
-#: lib/typster_web/live/editor_live/index.html.heex:839
+#: lib/typster_web/live/editor_live/index.html.heex:946
+#: lib/typster_web/live/editor_live/index.html.heex:965
+#: lib/typster_web/live/editor_live/index.html.heex:974
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:568
+#: lib/typster_web/live/editor_live/index.html.heex:703
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:53
+#: lib/typster_web/live/editor_live/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.html.heex:51
+#: lib/typster_web/live/editor_live/index.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Sharing is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:686
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:695
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -823,38 +830,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:512
+#: lib/typster_web/live/editor_live/index.html.heex:647
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:520
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:644
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:653
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:506
+#: lib/typster_web/live/editor_live/index.html.heex:641
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:479
-#: lib/typster_web/live/editor_live/index.html.heex:480
+#: lib/typster_web/live/editor_live/index.html.heex:614
+#: lib/typster_web/live/editor_live/index.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1982,17 +1989,17 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:86
+#: lib/typster_web/live/editor_live/index.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
@@ -2002,67 +2009,67 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:120
+#: lib/typster_web/live/editor_live/index.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:119
+#: lib/typster_web/live/editor_live/index.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:118
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:118
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:211
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:349
-#: lib/typster_web/live/editor_live/index.ex:395
-#: lib/typster_web/live/editor_live/index.ex:576
+#: lib/typster_web/live/editor_live/index.ex:363
+#: lib/typster_web/live/editor_live/index.ex:409
+#: lib/typster_web/live/editor_live/index.ex:570
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
 
-#: lib/typster_web/live/editor_live/index.html.heex:36
+#: lib/typster_web/live/editor_live/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:513
+#: lib/typster_web/live/editor_live/index.ex:507
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
 
-#: lib/typster_web/live/editor_live/index.html.heex:144
+#: lib/typster_web/live/editor_live/index.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Pinned"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:335
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:470
+#: lib/typster_web/live/editor_live/index.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
@@ -2078,7 +2085,7 @@ msgid "editor.tree.pin"
 msgstr "Pin file"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:374
+#: lib/typster_web/live/editor_live/index.html.heex:509
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
@@ -2088,142 +2095,192 @@ msgstr "Pinned"
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:247
+#: lib/typster_web/live/editor_live/index.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] "%{count} section"
 msgstr[1] "%{count} sections"
 
-#: lib/typster_web/live/editor_live/index.html.heex:95
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "New folder"
 
-#: lib/typster_web/live/editor_live/index.html.heex:197
+#: lib/typster_web/live/editor_live/index.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "folder name"
 
-#: lib/typster_web/live/editor_live/index.html.heex:13
+#: lib/typster_web/live/editor_live/index.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:670
+#: lib/typster_web/live/editor_live/index.ex:664
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
 
-#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Your templates"
 
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Remove this template?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Upload a file to reuse"
 
-#: lib/typster_web/live/editor_live/index.html.heex:324
-#: lib/typster_web/live/editor_live/index.html.heex:325
+#: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:721
+#: lib/typster_web/live/editor_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:846
-#: lib/typster_web/live/editor_live/index.html.heex:535
-#: lib/typster_web/live/editor_live/index.html.heex:723
+#: lib/typster_web/live/editor_live/index.ex:907
+#: lib/typster_web/live/editor_live/index.html.heex:670
+#: lib/typster_web/live/editor_live/index.html.heex:858
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:848
+#: lib/typster_web/live/editor_live/index.ex:909
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:852
+#: lib/typster_web/live/editor_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:784
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Clear log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:790
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Close panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:631
+#: lib/typster_web/live/editor_live/index.html.heex:766
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "Jump to first"
 
-#: lib/typster_web/live/editor_live/index.html.heex:606
-#: lib/typster_web/live/editor_live/index.html.heex:725
+#: lib/typster_web/live/editor_live/index.html.heex:741
+#: lib/typster_web/live/editor_live/index.html.heex:860
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Compile log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:663
+#: lib/typster_web/live/editor_live/index.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "No compiles yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:811
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "No problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:615
+#: lib/typster_web/live/editor_live/index.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:716
+#: lib/typster_web/live/editor_live/index.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Toggle compile panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:636
+#: lib/typster_web/live/editor_live/index.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Off"
 
-#: lib/typster_web/live/editor_live/index.html.heex:634
+#: lib/typster_web/live/editor_live/index.html.heex:769
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:443
+#: lib/typster_web/live/editor_live/index.ex:769
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:756
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
+
+#: lib/typster_web/live/editor_live/index.html.heex:155
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.account"
+msgstr "Account"
+
+#: lib/typster_web/live/editor_live/index.html.heex:171
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.appearance"
+msgstr "Appearance"
+
+#: lib/typster_web/live/editor_live/index.html.heex:21
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.back"
+msgstr "Back"
+
+#: lib/typster_web/live/editor_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.collaborators"
+msgstr "Collaborators"
+
+#: lib/typster_web/live/editor_live/index.html.heex:83
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.failed"
+msgstr "Failed"
+
+#: lib/typster_web/live/editor_live/index.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.forward"
+msgstr "Forward"
+
+#: lib/typster_web/live/editor_live/index.ex:841
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.guest"
+msgstr "Guest"
+
+#: lib/typster_web/live/editor_live/index.html.heex:144
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.language"
+msgstr "Language"
+
+#: lib/typster_web/live/editor_live/index.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.omni_placeholder"
+msgstr "Search files, run commands, jump to…"
+
+#: lib/typster_web/live/editor_live/index.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.switch_project"
+msgstr "Switch project"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "Действия"
 msgid "close"
 msgstr "закрыть"
 
-#: lib/typster_web/components/layouts.ex:182
+#: lib/typster_web/components/layouts.ex:183
 #, elixir-autogen, elixir-format
 msgid "app.connection_lost"
 msgstr "Связь прервалась — переподключаемся"
@@ -35,7 +35,7 @@ msgstr "Войти"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:192
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Выйти"
@@ -134,24 +134,24 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
+#: lib/typster_web/live/editor_live/index.html.heex:407
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:105
+#: lib/typster_web/live/editor_live/index.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:711
-#: lib/typster_web/live/editor_live/index.html.heex:712
+#: lib/typster_web/live/editor_live/index.html.heex:715
+#: lib/typster_web/live/editor_live/index.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:215
-#: lib/typster_web/live/editor_live/index.html.heex:288
+#: lib/typster_web/live/editor_live/index.html.heex:219
+#: lib/typster_web/live/editor_live/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
@@ -183,27 +183,27 @@ msgstr "Файл не удалось создать."
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
+#: lib/typster_web/live/editor_live/index.html.heex:242
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:533
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:297
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:727
+#: lib/typster_web/live/editor_live/index.html.heex:731
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
@@ -223,32 +223,32 @@ msgstr "Сохранено"
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
-#: lib/typster_web/live/editor_live/index.html.heex:437
+#: lib/typster_web/live/editor_live/index.html.heex:412
+#: lib/typster_web/live/editor_live/index.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
 
-#: lib/typster_web/components/layouts.ex:240
-#: lib/typster_web/live/editor_live/index.html.heex:177
+#: lib/typster_web/components/layouts.ex:241
+#: lib/typster_web/live/editor_live/index.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Темная тема"
 
-#: lib/typster_web/components/layouts.ex:232
-#: lib/typster_web/live/editor_live/index.html.heex:174
+#: lib/typster_web/components/layouts.ex:233
+#: lib/typster_web/live/editor_live/index.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Светлая тема"
 
-#: lib/typster_web/components/layouts.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:180
+#: lib/typster_web/components/layouts.ex:225
+#: lib/typster_web/live/editor_live/index.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Как в системе"
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:134
+#: lib/typster_web/live/editor_live/index.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Переключить тему"
@@ -308,15 +308,15 @@ msgstr "Войти в"
 msgid "nav.my_projects"
 msgstr "Мои проекты"
 
-#: lib/typster_web/components/layouts.ex:168
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/components/layouts.ex:169
+#: lib/typster_web/live/editor_live/index.html.heex:189
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Проекты"
 
-#: lib/typster_web/components/layouts.ex:170
-#: lib/typster_web/live/editor_live/index.html.heex:188
+#: lib/typster_web/components/layouts.ex:171
+#: lib/typster_web/live/editor_live/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Настройки"
@@ -518,161 +518,161 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:95
-#: lib/typster_web/live/editor_live/index.html.heex:681
+#: lib/typster_web/live/editor_live/index.html.heex:99
+#: lib/typster_web/live/editor_live/index.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
-#: lib/typster_web/live/editor_live/index.html.heex:677
+#: lib/typster_web/live/editor_live/index.html.heex:78
+#: lib/typster_web/live/editor_live/index.html.heex:681
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:208
-#: lib/typster_web/live/editor_live/index.html.heex:209
+#: lib/typster_web/live/editor_live/index.html.heex:212
+#: lib/typster_web/live/editor_live/index.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:538
-#: lib/typster_web/live/editor_live/index.html.heex:539
+#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:557
-#: lib/typster_web/live/editor_live/index.html.heex:558
+#: lib/typster_web/live/editor_live/index.html.heex:561
+#: lib/typster_web/live/editor_live/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:604
-#: lib/typster_web/live/editor_live/index.html.heex:605
+#: lib/typster_web/live/editor_live/index.html.heex:608
+#: lib/typster_web/live/editor_live/index.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:547
-#: lib/typster_web/live/editor_live/index.html.heex:548
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:585
-#: lib/typster_web/live/editor_live/index.html.heex:586
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:566
-#: lib/typster_web/live/editor_live/index.html.heex:567
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:580
+#: lib/typster_web/live/editor_live/index.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:594
-#: lib/typster_web/live/editor_live/index.html.heex:595
+#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:380
+#: lib/typster_web/live/editor_live/index.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:893
-#: lib/typster_web/live/editor_live/index.html.heex:901
-#: lib/typster_web/live/editor_live/index.html.heex:910
+#: lib/typster_web/live/editor_live/index.html.heex:897
+#: lib/typster_web/live/editor_live/index.html.heex:905
+#: lib/typster_web/live/editor_live/index.html.heex:914
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:945
-#: lib/typster_web/live/editor_live/index.html.heex:953
-#: lib/typster_web/live/editor_live/index.html.heex:962
+#: lib/typster_web/live/editor_live/index.html.heex:949
+#: lib/typster_web/live/editor_live/index.html.heex:957
+#: lib/typster_web/live/editor_live/index.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:928
+#: lib/typster_web/live/editor_live/index.html.heex:932
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:950
+#: lib/typster_web/live/editor_live/index.html.heex:954
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:885
+#: lib/typster_web/live/editor_live/index.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:894
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:924
+#: lib/typster_web/live/editor_live/index.html.heex:898
+#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:898
+#: lib/typster_web/live/editor_live/index.html.heex:902
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:946
-#: lib/typster_web/live/editor_live/index.html.heex:965
-#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:950
+#: lib/typster_web/live/editor_live/index.html.heex:969
+#: lib/typster_web/live/editor_live/index.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:672
+#: lib/typster_web/live/editor_live/index.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:703
+#: lib/typster_web/live/editor_live/index.html.heex:707
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:68
+#: lib/typster_web/live/editor_live/index.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.html.heex:66
+#: lib/typster_web/live/editor_live/index.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:690
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:695
+#: lib/typster_web/live/editor_live/index.html.heex:699
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:695
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -836,38 +836,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:647
+#: lib/typster_web/live/editor_live/index.html.heex:651
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:659
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:644
+#: lib/typster_web/live/editor_live/index.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:642
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:641
+#: lib/typster_web/live/editor_live/index.html.heex:645
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:614
-#: lib/typster_web/live/editor_live/index.html.heex:615
+#: lib/typster_web/live/editor_live/index.html.heex:618
+#: lib/typster_web/live/editor_live/index.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1995,17 +1995,17 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:256
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:221
+#: lib/typster_web/live/editor_live/index.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
@@ -2015,33 +2015,33 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:255
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:254
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:253
+#: lib/typster_web/live/editor_live/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:346
+#: lib/typster_web/live/editor_live/index.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:333
+#: lib/typster_web/live/editor_live/index.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
@@ -2053,7 +2053,7 @@ msgstr "имя файла"
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
 
-#: lib/typster_web/live/editor_live/index.html.heex:53
+#: lib/typster_web/live/editor_live/index.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
@@ -2068,14 +2068,14 @@ msgstr "Ассет удалён."
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:279
+#: lib/typster_web/live/editor_live/index.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:470
-#: lib/typster_web/live/editor_live/index.html.heex:471
+#: lib/typster_web/live/editor_live/index.html.heex:474
+#: lib/typster_web/live/editor_live/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
@@ -2091,7 +2091,7 @@ msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
@@ -2101,7 +2101,7 @@ msgstr "Закреплён"
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:382
+#: lib/typster_web/live/editor_live/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2109,12 +2109,12 @@ msgstr[0] "%{count} раздел"
 msgstr[1] "%{count} раздела"
 msgstr[2] "%{count} разделов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:230
+#: lib/typster_web/live/editor_live/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "Новая папка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:332
+#: lib/typster_web/live/editor_live/index.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "имя папки"
@@ -2124,7 +2124,7 @@ msgstr "имя папки"
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:522
+#: lib/typster_web/live/editor_live/index.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
@@ -2134,23 +2134,23 @@ msgstr "Закрыть вкладку"
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:443
+#: lib/typster_web/live/editor_live/index.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Ваши шаблоны"
 
-#: lib/typster_web/live/editor_live/index.html.heex:469
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Удалить этот шаблон?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:489
+#: lib/typster_web/live/editor_live/index.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Загрузите файл для повторного использования"
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
-#: lib/typster_web/live/editor_live/index.html.heex:460
+#: lib/typster_web/live/editor_live/index.html.heex:463
+#: lib/typster_web/live/editor_live/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
@@ -2161,8 +2161,8 @@ msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
 #: lib/typster_web/live/editor_live/index.ex:907
-#: lib/typster_web/live/editor_live/index.html.heex:670
-#: lib/typster_web/live/editor_live/index.html.heex:858
+#: lib/typster_web/live/editor_live/index.html.heex:674
+#: lib/typster_web/live/editor_live/index.html.heex:862
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2183,53 +2183,53 @@ msgstr[2] ""
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:784
+#: lib/typster_web/live/editor_live/index.html.heex:788
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Очистить лог"
 
-#: lib/typster_web/live/editor_live/index.html.heex:790
+#: lib/typster_web/live/editor_live/index.html.heex:794
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Закрыть панель"
 
-#: lib/typster_web/live/editor_live/index.html.heex:766
+#: lib/typster_web/live/editor_live/index.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "К первой"
 
-#: lib/typster_web/live/editor_live/index.html.heex:741
-#: lib/typster_web/live/editor_live/index.html.heex:860
+#: lib/typster_web/live/editor_live/index.html.heex:745
+#: lib/typster_web/live/editor_live/index.html.heex:864
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Лог компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:798
+#: lib/typster_web/live/editor_live/index.html.heex:802
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "Пока нет компиляций"
 
-#: lib/typster_web/live/editor_live/index.html.heex:811
+#: lib/typster_web/live/editor_live/index.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "Нет проблем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:750
+#: lib/typster_web/live/editor_live/index.html.heex:754
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Проблемы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:851
+#: lib/typster_web/live/editor_live/index.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Показать панель компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:771
+#: lib/typster_web/live/editor_live/index.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Выкл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:769
+#: lib/typster_web/live/editor_live/index.html.heex:773
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
@@ -2244,12 +2244,12 @@ msgstr "Файл перемещён."
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
 
-#: lib/typster_web/live/editor_live/index.html.heex:155
+#: lib/typster_web/live/editor_live/index.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr "Аккаунт"
 
-#: lib/typster_web/live/editor_live/index.html.heex:171
+#: lib/typster_web/live/editor_live/index.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr "Оформление"
@@ -2259,12 +2259,12 @@ msgstr "Оформление"
 msgid "editor.topbar.back"
 msgstr "Назад"
 
-#: lib/typster_web/live/editor_live/index.html.heex:116
+#: lib/typster_web/live/editor_live/index.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr "Соавторы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:83
+#: lib/typster_web/live/editor_live/index.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr "Ошибка"
@@ -2279,12 +2279,12 @@ msgstr "Вперёд"
 msgid "editor.topbar.guest"
 msgstr "Гость"
 
-#: lib/typster_web/live/editor_live/index.html.heex:144
+#: lib/typster_web/live/editor_live/index.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr "Язык"
 
-#: lib/typster_web/live/editor_live/index.html.heex:56
+#: lib/typster_web/live/editor_live/index.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.omni_placeholder"
 msgstr "Поиск файлов, команды, переходы…"
@@ -2293,3 +2293,8 @@ msgstr "Поиск файлов, команды, переходы…"
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.switch_project"
 msgstr "Сменить проект"
+
+#: lib/typster_web/live/editor_live/index.html.heex:49
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.branch"
+msgstr "Ветка"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "Действия"
 msgid "close"
 msgstr "закрыть"
 
-#: lib/typster_web/components/layouts.ex:178
+#: lib/typster_web/components/layouts.ex:182
 #, elixir-autogen, elixir-format
 msgid "app.connection_lost"
 msgstr "Связь прервалась — переподключаемся"
@@ -35,6 +35,7 @@ msgstr "Войти"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
+#: lib/typster_web/live/editor_live/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Выйти"
@@ -133,117 +134,121 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:268
+#: lib/typster_web/live/editor_live/index.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:60
+#: lib/typster_web/live/editor_live/index.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:576
-#: lib/typster_web/live/editor_live/index.html.heex:577
+#: lib/typster_web/live/editor_live/index.html.heex:711
+#: lib/typster_web/live/editor_live/index.html.heex:712
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:80
-#: lib/typster_web/live/editor_live/index.html.heex:153
+#: lib/typster_web/live/editor_live/index.html.heex:215
+#: lib/typster_web/live/editor_live/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:546
+#: lib/typster_web/live/editor_live/index.ex:540
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:537
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:227
+#: lib/typster_web/live/editor_live/index.ex:241
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:577
+#: lib/typster_web/live/editor_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:384
-#: lib/typster_web/live/editor_live/index.ex:408
-#: lib/typster_web/live/editor_live/index.ex:720
+#: lib/typster_web/live/editor_live/index.ex:398
+#: lib/typster_web/live/editor_live/index.ex:422
+#: lib/typster_web/live/editor_live/index.ex:714
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:238
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:394
+#: lib/typster_web/live/editor_live/index.html.heex:529
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:158
+#: lib/typster_web/live/editor_live/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:529
+#: lib/typster_web/live/editor_live/index.html.heex:664
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:592
+#: lib/typster_web/live/editor_live/index.html.heex:727
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:654
+#: lib/typster_web/live/editor_live/index.ex:648
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:652
+#: lib/typster_web/live/editor_live/index.ex:646
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:653
+#: lib/typster_web/live/editor_live/index.ex:647
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:273
-#: lib/typster_web/live/editor_live/index.html.heex:302
+#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
 
-#: lib/typster_web/components/layouts.ex:236
+#: lib/typster_web/components/layouts.ex:240
+#: lib/typster_web/live/editor_live/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Темная тема"
 
-#: lib/typster_web/components/layouts.ex:228
+#: lib/typster_web/components/layouts.ex:232
+#: lib/typster_web/live/editor_live/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Светлая тема"
 
-#: lib/typster_web/components/layouts.ex:220
+#: lib/typster_web/components/layouts.ex:224
+#: lib/typster_web/live/editor_live/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Как в системе"
 
 #: lib/typster_web/components/layouts.ex:101
+#: lib/typster_web/live/editor_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Переключить тему"
@@ -303,15 +308,15 @@ msgstr "Войти в"
 msgid "nav.my_projects"
 msgstr "Мои проекты"
 
-#: lib/typster_web/components/layouts.ex:164
-#: lib/typster_web/live/editor_live/index.html.heex:8
-#: lib/typster_web/live/editor_live/index.html.heex:9
+#: lib/typster_web/components/layouts.ex:168
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Проекты"
 
-#: lib/typster_web/components/layouts.ex:166
+#: lib/typster_web/components/layouts.ex:170
+#: lib/typster_web/live/editor_live/index.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Настройки"
@@ -513,159 +518,161 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:95
+#: lib/typster_web/live/editor_live/index.html.heex:681
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:73
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:208
+#: lib/typster_web/live/editor_live/index.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:403
-#: lib/typster_web/live/editor_live/index.html.heex:404
+#: lib/typster_web/live/editor_live/index.html.heex:538
+#: lib/typster_web/live/editor_live/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:422
-#: lib/typster_web/live/editor_live/index.html.heex:423
+#: lib/typster_web/live/editor_live/index.html.heex:557
+#: lib/typster_web/live/editor_live/index.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:469
-#: lib/typster_web/live/editor_live/index.html.heex:470
+#: lib/typster_web/live/editor_live/index.html.heex:604
+#: lib/typster_web/live/editor_live/index.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
-#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:548
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:450
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:431
-#: lib/typster_web/live/editor_live/index.html.heex:432
+#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:567
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:441
-#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:576
+#: lib/typster_web/live/editor_live/index.html.heex:577
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:459
-#: lib/typster_web/live/editor_live/index.html.heex:460
+#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:245
+#: lib/typster_web/live/editor_live/index.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:252
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:758
-#: lib/typster_web/live/editor_live/index.html.heex:766
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:893
+#: lib/typster_web/live/editor_live/index.html.heex:901
+#: lib/typster_web/live/editor_live/index.html.heex:910
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:810
-#: lib/typster_web/live/editor_live/index.html.heex:818
-#: lib/typster_web/live/editor_live/index.html.heex:827
+#: lib/typster_web/live/editor_live/index.html.heex:945
+#: lib/typster_web/live/editor_live/index.html.heex:953
+#: lib/typster_web/live/editor_live/index.html.heex:962
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:793
+#: lib/typster_web/live/editor_live/index.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:815
+#: lib/typster_web/live/editor_live/index.html.heex:950
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:750
+#: lib/typster_web/live/editor_live/index.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:759
-#: lib/typster_web/live/editor_live/index.html.heex:783
-#: lib/typster_web/live/editor_live/index.html.heex:789
+#: lib/typster_web/live/editor_live/index.html.heex:894
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:924
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:763
+#: lib/typster_web/live/editor_live/index.html.heex:898
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:811
-#: lib/typster_web/live/editor_live/index.html.heex:830
-#: lib/typster_web/live/editor_live/index.html.heex:839
+#: lib/typster_web/live/editor_live/index.html.heex:946
+#: lib/typster_web/live/editor_live/index.html.heex:965
+#: lib/typster_web/live/editor_live/index.html.heex:974
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:568
+#: lib/typster_web/live/editor_live/index.html.heex:703
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:53
+#: lib/typster_web/live/editor_live/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.html.heex:51
+#: lib/typster_web/live/editor_live/index.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "editor.share_soon"
 msgstr "Совместный доступ скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:686
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:695
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -829,38 +836,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:512
+#: lib/typster_web/live/editor_live/index.html.heex:647
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:520
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:509
+#: lib/typster_web/live/editor_live/index.html.heex:644
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:518
+#: lib/typster_web/live/editor_live/index.html.heex:653
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:507
+#: lib/typster_web/live/editor_live/index.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:506
+#: lib/typster_web/live/editor_live/index.html.heex:641
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:479
-#: lib/typster_web/live/editor_live/index.html.heex:480
+#: lib/typster_web/live/editor_live/index.html.heex:614
+#: lib/typster_web/live/editor_live/index.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1988,17 +1995,17 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:86
+#: lib/typster_web/live/editor_live/index.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
@@ -2008,67 +2015,67 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:120
+#: lib/typster_web/live/editor_live/index.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:119
+#: lib/typster_web/live/editor_live/index.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:118
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:118
+#: lib/typster_web/live/editor_live/index.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:211
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:198
+#: lib/typster_web/live/editor_live/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:349
-#: lib/typster_web/live/editor_live/index.ex:395
-#: lib/typster_web/live/editor_live/index.ex:576
+#: lib/typster_web/live/editor_live/index.ex:363
+#: lib/typster_web/live/editor_live/index.ex:409
+#: lib/typster_web/live/editor_live/index.ex:570
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
 
-#: lib/typster_web/live/editor_live/index.html.heex:36
+#: lib/typster_web/live/editor_live/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:513
+#: lib/typster_web/live/editor_live/index.ex:507
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:482
+#: lib/typster_web/live/editor_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:144
+#: lib/typster_web/live/editor_live/index.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:335
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:470
+#: lib/typster_web/live/editor_live/index.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
@@ -2084,7 +2091,7 @@ msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:374
+#: lib/typster_web/live/editor_live/index.html.heex:509
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
@@ -2094,7 +2101,7 @@ msgstr "Закреплён"
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:247
+#: lib/typster_web/live/editor_live/index.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2102,60 +2109,60 @@ msgstr[0] "%{count} раздел"
 msgstr[1] "%{count} раздела"
 msgstr[2] "%{count} разделов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:95
+#: lib/typster_web/live/editor_live/index.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "Новая папка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:197
+#: lib/typster_web/live/editor_live/index.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "имя папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:13
+#: lib/typster_web/live/editor_live/index.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:670
+#: lib/typster_web/live/editor_live/index.ex:664
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:308
+#: lib/typster_web/live/editor_live/index.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Ваши шаблоны"
 
-#: lib/typster_web/live/editor_live/index.html.heex:334
+#: lib/typster_web/live/editor_live/index.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Удалить этот шаблон?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Загрузите файл для повторного использования"
 
-#: lib/typster_web/live/editor_live/index.html.heex:324
-#: lib/typster_web/live/editor_live/index.html.heex:325
+#: lib/typster_web/live/editor_live/index.html.heex:459
+#: lib/typster_web/live/editor_live/index.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:721
+#: lib/typster_web/live/editor_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:846
-#: lib/typster_web/live/editor_live/index.html.heex:535
-#: lib/typster_web/live/editor_live/index.html.heex:723
+#: lib/typster_web/live/editor_live/index.ex:907
+#: lib/typster_web/live/editor_live/index.html.heex:670
+#: lib/typster_web/live/editor_live/index.html.heex:858
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2163,7 +2170,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:848
+#: lib/typster_web/live/editor_live/index.ex:909
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2171,68 +2178,118 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:852
+#: lib/typster_web/live/editor_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:784
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Очистить лог"
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:790
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Закрыть панель"
 
-#: lib/typster_web/live/editor_live/index.html.heex:631
+#: lib/typster_web/live/editor_live/index.html.heex:766
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "К первой"
 
-#: lib/typster_web/live/editor_live/index.html.heex:606
-#: lib/typster_web/live/editor_live/index.html.heex:725
+#: lib/typster_web/live/editor_live/index.html.heex:741
+#: lib/typster_web/live/editor_live/index.html.heex:860
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Лог компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:663
+#: lib/typster_web/live/editor_live/index.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "Пока нет компиляций"
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:811
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "Нет проблем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:615
+#: lib/typster_web/live/editor_live/index.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Проблемы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:716
+#: lib/typster_web/live/editor_live/index.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Показать панель компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:636
+#: lib/typster_web/live/editor_live/index.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Выкл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:634
+#: lib/typster_web/live/editor_live/index.html.heex:769
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:443
+#: lib/typster_web/live/editor_live/index.ex:769
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:453
+#: lib/typster_web/live/editor_live/index.ex:756
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
+
+#: lib/typster_web/live/editor_live/index.html.heex:155
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.account"
+msgstr "Аккаунт"
+
+#: lib/typster_web/live/editor_live/index.html.heex:171
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.appearance"
+msgstr "Оформление"
+
+#: lib/typster_web/live/editor_live/index.html.heex:21
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.back"
+msgstr "Назад"
+
+#: lib/typster_web/live/editor_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.collaborators"
+msgstr "Соавторы"
+
+#: lib/typster_web/live/editor_live/index.html.heex:83
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.failed"
+msgstr "Ошибка"
+
+#: lib/typster_web/live/editor_live/index.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.forward"
+msgstr "Вперёд"
+
+#: lib/typster_web/live/editor_live/index.ex:841
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.guest"
+msgstr "Гость"
+
+#: lib/typster_web/live/editor_live/index.html.heex:144
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.language"
+msgstr "Язык"
+
+#: lib/typster_web/live/editor_live/index.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.omni_placeholder"
+msgstr "Поиск файлов, команды, переходы…"
+
+#: lib/typster_web/live/editor_live/index.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "editor.topbar.switch_project"
+msgstr "Сменить проект"

--- a/priv/repo/migrations/20260601010151_add_plan_to_users.exs
+++ b/priv/repo/migrations/20260601010151_add_plan_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Typster.Repo.Migrations.AddPlanToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :plan, :string, null: false, default: "free"
+    end
+  end
+end

--- a/test/typster/features_test.exs
+++ b/test/typster/features_test.exs
@@ -1,0 +1,71 @@
+defmodule Typster.FeaturesTest do
+  use ExUnit.Case, async: false
+
+  alias Typster.Accounts.Scope
+  alias Typster.Features
+
+  # A stand-in for the private Typster.Pro.Features, injected via the
+  # :features_impl override so we can exercise dispatch without the submodule.
+  defmodule FakePro do
+    def can?(%Scope{plan: :pro}, _feature), do: true
+    def can?(_scope, _feature), do: false
+  end
+
+  setup do
+    on_exit(fn -> Application.delete_env(:typster, :features_impl) end)
+    :ok
+  end
+
+  describe "catalog/0" do
+    test "lists only paid Share features, never editor features" do
+      catalog = Features.catalog()
+      assert :share_write_scoped in catalog
+      assert :share_embed_sandbox in catalog
+      refute :compile in catalog
+      refute :live_collaborators in catalog
+    end
+  end
+
+  describe "can?/2 (open-core fallback)" do
+    test "denies every Pro feature when no Pro impl is loaded" do
+      scope = %Scope{user: nil, plan: :free}
+
+      for feature <- Features.catalog() do
+        refute Features.can?(scope, feature), "expected #{feature} denied on free build"
+      end
+    end
+
+    test "denies Pro features even for a nominally :pro scope without Pro code" do
+      scope = %Scope{plan: :pro}
+      refute Features.can?(scope, :share_embed_sandbox)
+    end
+
+    test "raises on an unknown feature (strict boundary)" do
+      assert_raise FunctionClauseError, fn ->
+        Features.can?(%Scope{}, :not_a_real_feature)
+      end
+    end
+  end
+
+  describe "can?/2 (dispatch to Pro)" do
+    test "delegates to the injected Pro implementation" do
+      Application.put_env(:typster, :features_impl, FakePro)
+      assert Features.can?(%Scope{plan: :pro}, :share_advanced_link)
+      refute Features.can?(%Scope{plan: :free}, :share_advanced_link)
+    end
+  end
+
+  describe "plan/1 and pro?/1" do
+    test "reads the scope's nominal plan, defaulting to free" do
+      assert Features.plan(%Scope{plan: :pro}) == :pro
+      assert Features.plan(%Scope{plan: :free}) == :free
+      assert Features.plan(nil) == :free
+    end
+
+    test "pro?/1 reflects the nominal plan" do
+      assert Features.pro?(%Scope{plan: :pro})
+      refute Features.pro?(%Scope{plan: :free})
+      refute Features.pro?(nil)
+    end
+  end
+end

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -229,13 +229,50 @@ defmodule TypsterWeb.EditorLiveTest do
     assert has_element?(view, ".ts-log__row--ok", "compiled")
   end
 
-  test "the header breadcrumb shows the active file's path segments",
+  test "the merged top bar breadcrumb shows the active file's folder path (no filename)",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "sections/intro.typ"})
     view = open_editor(conn, project)
 
-    assert has_element?(view, ".ts-crumb .ts-crumb__seg", "sections")
-    assert has_element?(view, ".ts-crumb .ts-crumb__seg.is-active", "intro.typ")
+    # v3.1 merged top bar: project + folder segments, the last folder is active,
+    # and the filename is no longer in the crumb — it lives on the tab.
+    assert has_element?(view, ".ts-tb__crumb .ts-tb__seg", "sections")
+    assert has_element?(view, ".ts-tb__crumb .ts-tb__seg.is-active", "sections")
+    refute has_element?(view, ".ts-tb__crumb .ts-tb__seg", "intro.typ")
+    assert has_element?(view, ".ts-tab", "intro.typ")
+  end
+
+  test "the merged top bar renders the project switcher, omnibox and account menu",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    assert has_element?(view, ".ts-tb__proj", project.name)
+    assert has_element?(view, ".ts-tb__omni")
+    assert has_element?(view, ".ts-tb__avatar")
+    # The account dropdown is in the DOM (hidden until toggled) with a logout row.
+    assert has_element?(view, "#tb-account-menu .ts-tb__menu-item.is-danger")
+  end
+
+  test "the top bar compile button reflects the latest successful compile",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "update_preview", %{"ms" => 47, "pages" => 1})
+
+    assert has_element?(view, ".ts-tb__compile.is-success", "47")
+    refute has_element?(view, ".ts-tb__compile.is-error")
+  end
+
+  test "the top bar compile button reflects a failed compile",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "preview_error", %{"message" => "boom", "errors" => 2})
+
+    assert has_element?(view, ".ts-tb__compile.is-error", "2")
   end
 
   test "outline numbers headings and shows a section count",

--- a/test/typster_web/live/project_live_test.exs
+++ b/test/typster_web/live/project_live_test.exs
@@ -72,7 +72,7 @@ defmodule TypsterWeb.ProjectLiveTest do
     assert has_element?(view, ".ts-preview__bar .ts-pill")
     refute has_element?(view, "#command-palette")
 
-    view |> element("button.ts-cmdk") |> render_click()
+    view |> element("button.ts-tb__omni") |> render_click()
 
     assert has_element?(view, "#command-palette")
     assert has_element?(view, "#command-palette #palette-input")

--- a/test/typster_web/presence_test.exs
+++ b/test/typster_web/presence_test.exs
@@ -1,0 +1,104 @@
+defmodule TypsterWeb.PresenceTest do
+  # async: false — Presence is a shared, app-started process so tracked entries
+  # from concurrent tests could otherwise leak across topics.
+  use ExUnit.Case, async: false
+
+  alias Typster.Accounts.User
+  alias TypsterWeb.Presence
+
+  setup do
+    # A unique project id per test keeps topics isolated from each other.
+    %{project_id: Ecto.UUID.generate()}
+  end
+
+  defp user(email) do
+    %User{id: Ecto.UUID.generate(), email: email}
+  end
+
+  # Track a user from a separate, supervised-by-the-test process so its presence
+  # stays alive for the duration of the test and is cleaned up automatically.
+  defp track_in_process(project_id, user) do
+    test_pid = self()
+
+    pid =
+      spawn_link(fn ->
+        Presence.track_user(self(), project_id, user)
+        send(test_pid, :tracked)
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive :tracked
+    wait_for_presence(project_id, user.id)
+    pid
+  end
+
+  # Presence propagates asynchronously; poll briefly until the user shows up.
+  defp wait_for_presence(project_id, user_id, attempts \\ 50) do
+    present? =
+      project_id
+      |> Presence.topic()
+      |> Presence.list()
+      |> Map.has_key?(user_id)
+
+    cond do
+      present? ->
+        :ok
+
+      attempts == 0 ->
+        flunk("presence for #{user_id} never propagated")
+
+      true ->
+        Process.sleep(20)
+        wait_for_presence(project_id, user_id, attempts - 1)
+    end
+  end
+
+  test "topic/1 stringifies binary and struct ids" do
+    assert Presence.topic("abc") == "editor:abc"
+    assert Presence.topic(%{id: "abc"}) == "editor:abc"
+    assert Presence.topic(123) == "editor:123"
+  end
+
+  test "list_collaborators returns derived name, initials and color", %{project_id: project_id} do
+    ada = user("ada.lovelace@typster.app")
+    track_in_process(project_id, ada)
+
+    assert [%{user_id: user_id, name: "Ada.lovelace", initials: "AL", color: color}] =
+             Presence.list_collaborators(project_id)
+
+    assert user_id == ada.id
+    assert color =~ ~r/^#[0-9a-f]{6}$/
+  end
+
+  test "single local-part yields a single initial", %{project_id: project_id} do
+    grace = user("grace@typster.app")
+    track_in_process(project_id, grace)
+
+    assert [%{name: "Grace", initials: "G"}] = Presence.list_collaborators(project_id)
+  end
+
+  test "list_collaborators sorts by name and excludes a user", %{project_id: project_id} do
+    ada = user("ada@typster.app")
+    bob = user("bob@typster.app")
+    track_in_process(project_id, ada)
+    track_in_process(project_id, bob)
+
+    names = project_id |> Presence.list_collaborators() |> Enum.map(& &1.name)
+    assert names == ["Ada", "Bob"]
+
+    excluded = Presence.list_collaborators(project_id, ada.id)
+    assert Enum.map(excluded, & &1.user_id) == [bob.id]
+  end
+
+  test "color is stable for the same user id across calls", %{project_id: project_id} do
+    ada = user("ada@typster.app")
+    track_in_process(project_id, ada)
+
+    [%{color: first}] = Presence.list_collaborators(project_id)
+    [%{color: second}] = Presence.list_collaborators(project_id)
+    assert first == second
+  end
+end


### PR DESCRIPTION
First of the editor v3.1 / Share redesign PRs (epic #108). Establishes the **open-core architecture** and ships the **merged top bar v3.1**. Reviewable on its own; later PRs build on it.

## What this does

### Open-core foundation
- **`Typster.Features.can?/2`** — single entitlements gate. Runtime dispatch via `Code.ensure_loaded?/1` to the private `Typster.Pro.Features` when present, else `Typster.Features.Free` (denies all). **No compile-time reference to `Typster.Pro.*`**, so the community build stays green under `--warning-as-errors`.
- **`plan` on the account** (`:free | :pro`, billing-set only) + `Scope.plan`.
- **`typster-pro` git submodule** at `pro/`, consumed as a **guarded path dependency** — declared only when `pro/mix.exs` exists (`File.exists?` guard in `mix.exs`). A plain public clone leaves `pro/` empty and builds the free edition. Path-deps never touch `mix.lock`, so `deps.unlock --unused` has nothing to strip.

### Top bar v3.1
- Merges the floating marketing nav + the old editor bar into **one 44px bar**: project switcher, folder breadcrumb (filename now lives on the tab), save dot, omnibox (-> command palette), Share, **5-state Compile button** wired to real compile assigns, theme/lang, and an account dropdown.
- **Live collaborators** via `Phoenix.Presence` — real presence avatars with a live pulse (open-source; not paywalled).
- `Layouts.app` gains `nav={false}` so the editor renders its own chrome. Token-driven CSS (`_editor_topbar.css`, all `--mk-*` -> light/dark for free). en/ru gettext filled.

## Free vs Pro
Only four **Share** capabilities are Pro (tracked in typster-pro#5). The editor, its features, and collaboration are all open. Branch/git chip is deferred (#107 — no project VCS yet) rather than faked.

## Verification
- `mix precommit` green (compile `--warning-as-errors`, format, sobelow `--skip`, **192 tests, 0 failures**).
- New: `Typster.Features` (7), `TypsterWeb.Presence` (5), top-bar render/compile-state tests.
- Submodule mechanics verified: builds with `pro/` present **and** absent; `mix.lock` untouched.

## Review notes
- Switching editions locally needs a clean `_build`/`deps` (delete both) — a stale `_build` from the other edition errors. CI builds each edition from a clean checkout.
- `.gitmodules` exposes the private repo **URL** (SSH), not its contents — expected for open-core.

## Next
PR2 editor features (#105) · PR3 Share free backend + modal (#106) · PR4 Pro Share (typster-pro#5).

Closes part of #108.