### PR TITLE
feat(editor): editor v3.1 assists — diagnostics, autocomplete, more

### DIFF
--- a/assets/css/_editor_v3.css
+++ b/assets/css/_editor_v3.css
@@ -1,0 +1,244 @@
+/* ── Editor v3.1 assists — CM-scoped chrome ──────────────────────────────────
+   Inline diagnostic lens · selection quick-actions · scroll rail · autocomplete
+   popover · compile sparkline. Faithful port of the v3 design (styles-v3.css /
+   editor-v3.jsx) onto the real --mk-* token set so light/dark flip for free.
+
+   Token map: accent → --mk-pri · accent-soft → --mk-pri-50 · surface → --mk-bg ·
+   surface-2 → --mk-bg2 · border → --mk-bd · text → --mk-fg · text-dim → --mk-fg2 ·
+   text-mute → --mk-fg3 (faintest → --mk-fg4) · green → --mk-success ·
+   amber → --mk-warning · red → --mk-error · mono → --v3-mono.
+
+   These widgets are mounted by CodeMirror (block widgets, tooltips, an absolute
+   overlay) and a HEEx status bar — no class here overlaps the lint styling that
+   already lives in _codemirror.css (.cm-lintRange / .cm-tooltip-lint).
+   ─────────────────────────────────────────────────────────────────────────── */
+
+:where(.cm-editor) {
+  --v3-mono: "JetBrains Mono", ui-monospace, monospace;
+}
+
+/* ── 1 · Inline diagnostic lens ───────────────────────────────────────────────
+   A block widget rendered under a code line. The ~46px left indent clears the
+   line-number gutter so the card aligns with the source text, not the gutter. */
+.cm-diag-lens {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 2px 0 4px 46px;
+  padding: 6px 10px;
+  border: 1px solid var(--mk-bd);
+  border-radius: 6px;
+  background: var(--mk-bg);
+  color: var(--mk-fg);
+  font: 12px/1.45 "Inter", system-ui, sans-serif;
+}
+
+.cm-diag-lens.is-error {
+  background: var(--mk-error-50);
+  border-color: var(--mk-error-bd);
+  color: var(--mk-error-h);
+}
+.cm-diag-lens.is-warning {
+  background: var(--mk-warning-50);
+  border-color: var(--mk-warning-bd);
+  color: var(--mk-warning-h);
+}
+
+.cm-diag-lens__ico {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+}
+.cm-diag-lens.is-error .cm-diag-lens__ico { color: var(--mk-error); }
+.cm-diag-lens.is-warning .cm-diag-lens__ico { color: var(--mk-warning); }
+.cm-diag-lens__ico svg { width: 14px; height: 14px; stroke-width: 1.8; }
+
+.cm-diag-lens__body { min-width: 0; }
+.cm-diag-lens__title {
+  font-weight: 600;
+  color: var(--mk-fg);
+}
+.cm-diag-lens__code {
+  margin-left: 6px;
+  padding: 0 5px;
+  border-radius: 3px;
+  background: var(--mk-pri-50);
+  color: var(--mk-fg3);
+  font: 500 11px var(--v3-mono);
+}
+.cm-diag-lens__msg {
+  margin-top: 2px;
+  color: var(--mk-fg2);
+  font-size: 11.5px;
+}
+
+/* ── 2 · Selection quick-action bubble (a CM tooltip) ─────────────────────────
+   Lives inside .cm-tooltip; the doubled class beats CM's runtime-injected
+   .cm-tooltip base theme regardless of stylesheet injection order. */
+.cm-tooltip.cm-tooltip .cm-qa,
+.cm-qa {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--mk-bd);
+  border-radius: 8px;
+  background: var(--mk-bg);
+  box-shadow: var(--mk-sh-lg);
+}
+
+.cm-qa__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 7px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--mk-fg2);
+  font: 600 12px "Inter", system-ui, sans-serif;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s var(--mk-ease), color 0.15s var(--mk-ease);
+}
+.cm-qa__btn:hover { background: var(--mk-bg2); color: var(--mk-fg); }
+.cm-qa__btn.is-primary { background: var(--mk-pri-50); color: var(--mk-pri); }
+.cm-qa__btn.is-primary:hover { background: var(--mk-pri-100); color: var(--mk-pri); }
+
+.cm-qa__sep {
+  width: 1px;
+  height: 16px;
+  margin: 0 2px;
+  background: var(--mk-bd);
+}
+
+/* ── 3 · Scroll rail (absolute overlay on the editor's right edge) ────────────
+   Non-interactive layer painting diagnostic / heading marks against the
+   scroll length. Sits above the scroller content but never eats clicks. */
+.cm-rail {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 12px;
+  height: 100%;
+  pointer-events: none;
+  z-index: 3;
+}
+.cm-rail__mark {
+  position: absolute;
+  right: 3px;
+  width: 6px;
+  height: 4px;
+  border-radius: 1px;
+}
+.cm-rail__mark.is-error { background: var(--mk-error); }
+.cm-rail__mark.is-warning { background: var(--mk-warning); }
+.cm-rail__mark.is-heading {
+  width: 4px;
+  background: var(--mk-fg4);
+}
+
+/* ── 4 · Autocomplete popover ─────────────────────────────────────────────────
+   Style CodeMirror's own .cm-tooltip-autocomplete to match the .ac-pop design.
+   Doubled classes beat CM's injected .cm-tooltip base theme on any order. */
+.cm-tooltip.cm-tooltip-autocomplete,
+.cm-tooltip.cm-tooltip-autocomplete.cm-tooltip-autocomplete {
+  border: 1px solid var(--mk-bd);
+  border-radius: 8px;
+  background: var(--mk-bg);
+  box-shadow: var(--mk-sh-lg);
+  overflow: hidden;
+  font-family: inherit;
+}
+.cm-tooltip-autocomplete > ul {
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  font-family: inherit;
+}
+.cm-tooltip-autocomplete > ul > li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  color: var(--mk-fg);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.cm-tooltip-autocomplete > ul > li[aria-selected] {
+  background: var(--mk-pri-50);
+  color: var(--mk-pri);
+}
+
+.cm-completionLabel { flex: 1; min-width: 0; }
+.cm-completionMatchedText {
+  text-decoration: none;
+  font-weight: 600;
+}
+.cm-completionDetail {
+  margin-left: auto;
+  color: var(--mk-fg4);
+  font: 11px var(--v3-mono);
+  font-style: normal;
+}
+.cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionDetail {
+  color: color-mix(in oklab, var(--mk-pri) 70%, var(--mk-fg4));
+}
+
+/* Completion type icons — CM emits .cm-completionIcon plus a kind modifier
+   (.cm-completionIcon-function etc). Keep them quiet and mono-aligned; map the
+   common Typst-relevant kinds to readable glyphs. */
+.cm-completionIcon {
+  width: 1em;
+  margin-right: 0;
+  opacity: 0.7;
+  font-size: 90%;
+}
+.cm-completionIcon-function::after,
+.cm-completionIcon-method::after { content: "ƒ"; }
+.cm-completionIcon-keyword::after { content: "◆"; }
+.cm-completionIcon-variable::after { content: "𝑥"; }
+.cm-completionIcon-property::after,
+.cm-completionIcon-field::after { content: "≡"; }
+.cm-completionIcon-type::after,
+.cm-completionIcon-class::after { content: "❖"; }
+.cm-completionIcon-constant::after,
+.cm-completionIcon-enum::after { content: "π"; }
+.cm-completionIcon-text::after,
+.cm-completionIcon-snippet::after { content: "✎"; }
+
+/* Side info panel for the focused completion. */
+.cm-tooltip.cm-completionInfo {
+  margin: 0;
+  padding: 8px 10px;
+  max-width: 260px;
+  border: 0;
+  border-left: 1px solid var(--mk-bd);
+  border-radius: 0;
+  background: var(--mk-bg);
+  color: var(--mk-fg2);
+  font: 12px/1.5 "Inter", system-ui, sans-serif;
+}
+
+/* ── 5 · Compile sparkline (rendered in the HEEx status bar) ──────────────────
+   Inline bar chart of recent compile durations; per-bar tone modifiers. */
+.ts-spark {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 12px;
+}
+.ts-spark__bar {
+  width: 2px;
+  min-height: 1px;
+  border-radius: 1px;
+  background: var(--mk-pri);
+  opacity: 0.85;
+}
+.ts-spark__bar.is-warn { background: var(--mk-warning); }
+.ts-spark__bar.is-err { background: var(--mk-error); }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -8,6 +8,7 @@
 @import "./salad_ui.css";
 @import "./_typster_ui.css";
 @import "./_editor_topbar.css";
+@import "./_editor_v3.css";
 @source "../css";
 @source "../js";
 @source "../../lib/typster_web";

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -25,6 +25,23 @@ async function addMainFile(page) {
 }
 
 test.describe('Product UI redesign', () => {
+  test('brackets and Typst math auto-close their pairs', async ({ page }) => {
+    await createProjectAndOpenEditor(page, 'Autoclose E2E')
+    await addMainFile(page)
+
+    const cm = page.locator('#editor-container .cm-content')
+    await cm.click()
+    await page.keyboard.press('Control+End')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('(') // -> ()
+    await page.keyboard.press('End')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('$') // -> $$ (Typst math)
+
+    await expect(cm).toContainText('()')
+    await expect(cm).toContainText('$$')
+  })
+
   test('accent picker persists on the user record', async ({ page }) => {
     await page.goto('/users/settings')
     await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -119,17 +119,24 @@ test.describe('Product UI redesign', () => {
     await expect(cm).toContainText('*')
   })
 
-  test('Typst autocomplete suggests functions after a # prefix', async ({ page }) => {
+  test('autocomplete completes a function to #name() with the caret inside', async ({ page }) => {
     await createProjectAndOpenEditor(page, 'Autocomplete E2E')
     await addMainFile(page)
 
     const cm = page.locator('#editor-container .cm-content')
     await cm.click()
+    await page.keyboard.press('Control+End')
+    await page.keyboard.press('Enter')
     await page.keyboard.type('#figu')
 
     const pop = page.locator('.cm-tooltip-autocomplete')
     await expect(pop).toBeVisible({ timeout: 5_000 })
     await expect(pop.locator('.cm-completionLabel').first()).toContainText('figure')
+
+    // Accepting inserts "#figure()" with the caret between the parens.
+    await pop.locator('li').filter({ hasText: 'figure' }).first().click()
+    await page.keyboard.type('image')
+    await expect(cm).toContainText('#figure(image)')
   })
 
   test('selecting text shows the quick-action bubble and Bold wraps it', async ({ page }) => {

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -43,6 +43,7 @@ test.describe('Product UI redesign', () => {
     }
     await line('#let mylocalfn(x) = x')
     await line('#import "lib.typ": importedfn')
+    await line('#for myloopvar in xs [ ]')
 
     // The user's own local function is suggested.
     await page.keyboard.type('#mylo')
@@ -57,6 +58,52 @@ test.describe('Product UI redesign', () => {
     await expect(pop).toBeVisible({ timeout: 5_000 })
     await expect(
       pop.locator('.cm-completionLabel').filter({ hasText: 'importedfn' })
+    ).toBeVisible()
+    await page.keyboard.press('Escape')
+    await page.keyboard.press('End')
+    await page.keyboard.press('Enter')
+
+    // A `#for` loop variable is offered too.
+    await page.keyboard.type('#myloop')
+    await expect(pop).toBeVisible({ timeout: 5_000 })
+    await expect(
+      pop.locator('.cm-completionLabel').filter({ hasText: 'myloopvar' })
+    ).toBeVisible()
+  })
+
+  test('autocomplete resolves a wildcard import from a project file', async ({ page }) => {
+    await createProjectAndOpenEditor(page, 'Wildcard E2E')
+
+    const newFile = async (name) => {
+      await page.locator('#create-main-file-button').click()
+      const draft = page.locator('#new-file-form input[name="path"]')
+      await expect(draft).toBeVisible()
+      await draft.fill(name)
+      await draft.press('Enter')
+      await expect(page.locator('#editor-container .cm-content')).toBeVisible({ timeout: 10_000 })
+    }
+
+    const cm = page.locator('#editor-container .cm-content')
+    const pop = page.locator('.cm-tooltip-autocomplete')
+
+    // A sibling module with an exported function.
+    await newFile('lib.typ')
+    await cm.click()
+    await page.keyboard.type('#let libwildfn(a) = a')
+    await page.waitForTimeout(1200) // let it autosave into project sources
+
+    // Import everything from it and complete one of its exports.
+    await newFile('main.typ')
+    await cm.click()
+    await page.keyboard.type('#import "lib.typ": *')
+    await page.keyboard.press('Escape')
+    await page.keyboard.press('End')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('#libwild')
+
+    await expect(pop).toBeVisible({ timeout: 5_000 })
+    await expect(
+      pop.locator('.cm-completionLabel').filter({ hasText: 'libwildfn' })
     ).toBeVisible()
   })
 

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -25,6 +25,41 @@ async function addMainFile(page) {
 }
 
 test.describe('Product UI redesign', () => {
+  test('autocomplete suggests local #let and imported symbols', async ({ page }) => {
+    await createProjectAndOpenEditor(page, 'LocalImport E2E')
+    await addMainFile(page)
+
+    const cm = page.locator('#editor-container .cm-content')
+    const pop = page.locator('.cm-tooltip-autocomplete')
+    await cm.click()
+    await page.keyboard.press('Control+End')
+    await page.keyboard.press('Enter')
+
+    const line = async (t) => {
+      await page.keyboard.type(t)
+      await page.keyboard.press('Escape')
+      await page.keyboard.press('End')
+      await page.keyboard.press('Enter')
+    }
+    await line('#let mylocalfn(x) = x')
+    await line('#import "lib.typ": importedfn')
+
+    // The user's own local function is suggested.
+    await page.keyboard.type('#mylo')
+    await expect(pop).toBeVisible({ timeout: 5_000 })
+    await expect(pop.locator('.cm-completionLabel').filter({ hasText: 'mylocalfn' })).toBeVisible()
+    await page.keyboard.press('Escape')
+    await page.keyboard.press('End')
+    await page.keyboard.press('Enter')
+
+    // A symbol imported in this buffer is suggested too.
+    await page.keyboard.type('#importedf')
+    await expect(pop).toBeVisible({ timeout: 5_000 })
+    await expect(
+      pop.locator('.cm-completionLabel').filter({ hasText: 'importedfn' })
+    ).toBeVisible()
+  })
+
   test('brackets and Typst math auto-close their pairs', async ({ page }) => {
     await createProjectAndOpenEditor(page, 'Autoclose E2E')
     await addMainFile(page)

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -102,6 +102,40 @@ test.describe('Product UI redesign', () => {
     await expect(cm).toContainText('*')
   })
 
+  test('Typst autocomplete suggests functions after a # prefix', async ({ page }) => {
+    await createProjectAndOpenEditor(page, 'Autocomplete E2E')
+    await addMainFile(page)
+
+    const cm = page.locator('#editor-container .cm-content')
+    await cm.click()
+    await page.keyboard.type('#figu')
+
+    const pop = page.locator('.cm-tooltip-autocomplete')
+    await expect(pop).toBeVisible({ timeout: 5_000 })
+    await expect(pop.locator('.cm-completionLabel').first()).toContainText('figure')
+  })
+
+  test('selecting text shows the quick-action bubble and Bold wraps it', async ({ page }) => {
+    await createProjectAndOpenEditor(page, 'Bubble E2E')
+    await addMainFile(page)
+
+    const cm = page.locator('#editor-container .cm-content')
+    await cm.click()
+    // Put the prose on its own fresh line so the selection is exactly it.
+    await page.keyboard.press('End')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Some prose to select.')
+    await page.keyboard.press('Home')
+    await page.keyboard.press('Shift+End')
+
+    const bubble = page.locator('.cm-qa')
+    await expect(bubble).toBeVisible({ timeout: 5_000 })
+    await expect(bubble.locator('.cm-qa__btn.is-primary')).toContainText('Heading')
+
+    await bubble.locator('button[title^="Bold"]').click()
+    await expect(cm).toContainText('*Some prose to select.*')
+  })
+
   test('download button exports the compiled document as a PDF', async ({ page }) => {
     await createProjectAndOpenEditor(page, 'Download E2E')
     await addMainFile(page)

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -139,6 +139,14 @@ const basicSetup = [
   ])
 ]
 
+// Typst-aware auto-closing pairs for `closeBrackets()`: the usual brackets plus
+// `$ $` for math mode. Single-quote is intentionally dropped so apostrophes in
+// prose ("it's") aren't auto-paired. Provided as languageData so closeBrackets
+// picks it up only for Typst buffers.
+const typstCloseBrackets = EditorState.languageData.of(() => [
+  { closeBrackets: { brackets: ["(", "[", "{", "$", "\"", "`"] } }
+])
+
 // Auto-recompile debounce (ms from the last keystroke). Configurable via
 // localStorage so a single keystroke doesn't thrash the WASM compiler; a
 // negative value disables auto-compile (manual ⌘↵ / Compile only).
@@ -474,7 +482,7 @@ export function initEditor(container, initialContent, socket, fileId, options = 
       autocompletion(language === "typst" ? { override: [typstCompletionSource] } : {}),
       themeCompartment.of(getThemeExtension()),
       languageCompartment.of(getLanguageExtension(language)),
-      ...(language === "typst" ? typst() : []),
+      ...(language === "typst" ? [typstCloseBrackets, ...typst()] : []),
       updateListener
     ]
   })

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -479,7 +479,11 @@ export function initEditor(container, initialContent, socket, fileId, options = 
       basicSetup,
       lintGutter(),
       ...editorV3Extensions,
-      autocompletion(language === "typst" ? { override: [typstCompletionSource] } : {}),
+      autocompletion(
+        language === "typst"
+          ? { override: [(ctx) => typstCompletionSource(ctx, options.project)] }
+          : {}
+      ),
       themeCompartment.of(getThemeExtension()),
       languageCompartment.of(getLanguageExtension(language)),
       ...(language === "typst" ? [typstCloseBrackets, ...typst()] : []),

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -39,6 +39,8 @@ import { markdown } from "@codemirror/lang-markdown"
 import { yaml } from "@codemirror/lang-yaml"
 import { stex } from "@codemirror/legacy-modes/mode/stex"
 import { compileTypst, downloadTypstPdf } from "./typst_worker"
+import { editorV3Extensions, setDiagData } from "./editor_v3"
+import { typstCompletionSource } from "./typst_completions"
 
 // Native selection paints nothing visible for a selected trailing newline (an
 // empty line shows nothing, a text line ends right at the glyphs). VS Code draws
@@ -121,7 +123,7 @@ const basicSetup = [
   syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
   bracketMatching(),
   closeBrackets(),
-  autocompletion(),
+  // autocompletion() is added per-editor below so its source can be Typst-aware.
   highlightActiveLine(),
   // Don't spray match boxes for 1-char selections (every `i`/`2` lit up).
   highlightSelectionMatches({ minSelectionLength: 2 }),
@@ -468,6 +470,8 @@ export function initEditor(container, initialContent, socket, fileId, options = 
     extensions: [
       basicSetup,
       lintGutter(),
+      ...editorV3Extensions,
+      autocompletion(language === "typst" ? { override: [typstCompletionSource] } : {}),
       themeCompartment.of(getThemeExtension()),
       languageCompartment.of(getLanguageExtension(language)),
       ...(language === "typst" ? typst() : []),
@@ -515,8 +519,11 @@ export function initEditor(container, initialContent, socket, fileId, options = 
     updateLanguage,
     runCommand: (cmd, arg) => runEditorCommand(editor, language, cmd, arg),
     openSearch: () => openSearchPanel(editor),
-    setDiagnostics: (diags) =>
-      editor.dispatch(setDiagnostics(editor.state, toCmDiagnostics(editor, diags))),
+    setDiagnostics: (diags) => {
+      const cm = toCmDiagnostics(editor, diags)
+      editor.dispatch(setDiagnostics(editor.state, cm))
+      editor.dispatch({ effects: setDiagData.of(cm) })
+    },
     compile: () => {
       // Only Typst files compile; the worker treats the active buffer as main.typ.
       if (language === "typst") compileTypst(editor.state.doc.toString(), options.project || {})

--- a/assets/js/editor_v3.js
+++ b/assets/js/editor_v3.js
@@ -1,0 +1,210 @@
+// Editor v3.1 assists, built from the same granular @codemirror/* packages as
+// editor.js so the EditorView / decoration facets share one instance set.
+//
+//   • inline diagnostic lens — the full compile message under the bad line
+//   • scroll rail            — error / warning / heading marks on the right edge
+//   • selection bubble       — floating quick-actions over a non-empty selection
+//
+// All three read live data already flowing through the editor: diagnostics come
+// from the Typst worker (see editor.js `setDiagnostics`), headings from the doc.
+import { EditorView, Decoration, WidgetType, ViewPlugin, showTooltip } from "@codemirror/view"
+import { StateField, StateEffect } from "@codemirror/state"
+
+// ── Shared diagnostics data (drives both the lens and the rail) ──────────────
+// Carries already-resolved CodeMirror diagnostics ({from, to, severity, message}).
+export const setDiagData = StateEffect.define()
+
+export const diagDataField = StateField.define({
+  create: () => [],
+  update(value, tr) {
+    for (const e of tr.effects) if (e.is(setDiagData)) return e.value
+    return value
+  }
+})
+
+// Push resolved diagnostics into the editor state (called from editor.js).
+export function applyDiagData(view, cmDiagnostics) {
+  view.dispatch({ effects: setDiagData.of(cmDiagnostics || []) })
+}
+
+// ── Inline diagnostic lens ───────────────────────────────────────────────────
+class DiagLensWidget extends WidgetType {
+  constructor(severity, message) {
+    super()
+    this.severity = severity === "warning" ? "warning" : "error"
+    this.message = message
+  }
+  eq(other) {
+    return other.severity === this.severity && other.message === this.message
+  }
+  toDOM() {
+    const wrap = document.createElement("div")
+    wrap.className = `cm-diag-lens is-${this.severity}`
+
+    const ico = document.createElement("span")
+    ico.className = "cm-diag-lens__ico"
+    ico.setAttribute("aria-hidden", "true")
+    ico.textContent = this.severity === "warning" ? "▲" : "✕"
+
+    const body = document.createElement("div")
+    body.className = "cm-diag-lens__body"
+
+    const title = document.createElement("div")
+    title.className = "cm-diag-lens__title"
+    title.textContent = this.message
+
+    const code = document.createElement("span")
+    code.className = "cm-diag-lens__code"
+    code.textContent = this.severity === "warning" ? "warning" : "error"
+
+    body.appendChild(title)
+    wrap.appendChild(ico)
+    wrap.appendChild(body)
+    wrap.appendChild(code)
+    return wrap
+  }
+  ignoreEvent() {
+    return true
+  }
+}
+
+function lensDecorations(state) {
+  const diags = state.field(diagDataField, false) || []
+  const doc = state.doc
+  const seen = new Set()
+  const deco = []
+  for (const d of diags) {
+    const line = doc.lineAt(Math.min(Math.max(d.from, 0), doc.length))
+    if (seen.has(line.from)) continue
+    seen.add(line.from)
+    deco.push(
+      Decoration.widget({
+        widget: new DiagLensWidget(d.severity, d.message),
+        block: true,
+        side: 1
+      }).range(line.to)
+    )
+  }
+  deco.sort((a, b) => a.from - b.from)
+  return Decoration.set(deco)
+}
+
+// A StateField (not a ViewPlugin) so the block widgets are accounted for in
+// height measurement.
+export const inlineDiagnostics = StateField.define({
+  create: (state) => lensDecorations(state),
+  update(value, tr) {
+    if (tr.docChanged || tr.effects.some((e) => e.is(setDiagData))) {
+      return lensDecorations(tr.state)
+    }
+    return value.map(tr.changes)
+  },
+  provide: (f) => EditorView.decorations.from(f)
+})
+
+// ── Scroll rail (right-edge minimap of marks) ────────────────────────────────
+const HEADING_RE = /^\s*(?:=+|#+)\s+\S/
+
+export const scrollRail = ViewPlugin.fromClass(
+  class {
+    constructor(view) {
+      this.rail = document.createElement("div")
+      this.rail.className = "cm-rail"
+      this.rail.setAttribute("aria-hidden", "true")
+      view.dom.appendChild(this.rail)
+      this.render(view)
+    }
+    update(u) {
+      const diagChanged = u.state.field(diagDataField, false) !== u.startState.field(diagDataField, false)
+      if (u.docChanged || u.geometryChanged || diagChanged) this.render(u.view)
+    }
+    render(view) {
+      const doc = view.state.doc
+      const total = Math.max(doc.lines, 1)
+      const marks = []
+
+      const diags = view.state.field(diagDataField, false) || []
+      for (const d of diags) {
+        const ln = doc.lineAt(Math.min(Math.max(d.from, 0), doc.length)).number
+        marks.push({ line: ln, kind: d.severity === "warning" ? "warning" : "error" })
+      }
+      for (let i = 1; i <= doc.lines; i++) {
+        if (HEADING_RE.test(doc.line(i).text)) marks.push({ line: i, kind: "heading" })
+      }
+
+      this.rail.replaceChildren()
+      for (const m of marks) {
+        const el = document.createElement("div")
+        el.className = `cm-rail__mark is-${m.kind}`
+        el.style.top = `${(((m.line - 0.5) / total) * 100).toFixed(3)}%`
+        this.rail.appendChild(el)
+      }
+    }
+    destroy() {
+      this.rail.remove()
+    }
+  }
+)
+
+// ── Selection quick-action bubble ────────────────────────────────────────────
+// Buttons re-use the existing editor command pipeline (the CodeMirror hook
+// listens for `phx:editor-command` and calls runEditorCommand on the selection).
+const BUBBLE_ACTIONS = [
+  { cmd: "heading", label: "= Heading", primary: true, title: "Wrap as heading" },
+  { cmd: "bold", label: "B", title: "Bold (⌘B)" },
+  { cmd: "italic", label: "I", title: "Italic (⌘I)" },
+  { cmd: "math", label: "∑", title: "Inline math" },
+  { sep: true },
+  { cmd: "link", label: "Link", title: "Wrap as link" }
+]
+
+function bubbleTooltip(from) {
+  return {
+    pos: from,
+    above: true,
+    strictSide: false,
+    arrow: false,
+    create: () => {
+      const dom = document.createElement("div")
+      dom.className = "cm-qa"
+      for (const a of BUBBLE_ACTIONS) {
+        if (a.sep) {
+          const s = document.createElement("span")
+          s.className = "cm-qa__sep"
+          dom.appendChild(s)
+          continue
+        }
+        const b = document.createElement("button")
+        b.type = "button"
+        b.className = "cm-qa__btn" + (a.primary ? " is-primary" : "")
+        b.textContent = a.label
+        b.title = a.title
+        // mousedown + preventDefault keeps the selection alive for the command.
+        b.addEventListener("mousedown", (e) => {
+          e.preventDefault()
+          window.dispatchEvent(new CustomEvent("phx:editor-command", { detail: { cmd: a.cmd } }))
+        })
+        dom.appendChild(b)
+      }
+      return { dom }
+    }
+  }
+}
+
+export const selectionBubble = StateField.define({
+  create: () => null,
+  update(value, tr) {
+    const sel = tr.state.selection.main
+    if (sel.empty || sel.to - sel.from > 5000) return null
+    return bubbleTooltip(sel.from)
+  },
+  provide: (f) => showTooltip.from(f)
+})
+
+// Everything the editor needs, in dependency order (diagDataField first).
+export const editorV3Extensions = [
+  diagDataField,
+  inlineDiagnostics,
+  scrollRail,
+  selectionBubble
+]

--- a/assets/js/typst_completions.js
+++ b/assets/js/typst_completions.js
@@ -8,8 +8,10 @@
 //   - `type`   drives the gutter icon: function | keyword | constant | type | variable
 //   - `detail` is the dimmed signature shown to the right (this is the signature help)
 //   - `info`   is a one-sentence description for the docs tooltip
-//   - functions get an `apply` that inserts an opening paren, so the cursor lands
-//     inside the call; everything else inserts its bare label (no snippets).
+//   - functions / structural keywords expand to a snippet (with the `#` marker
+//     and a `(${})` / scaffold), so accepting one drops the caret into place.
+
+import { snippetCompletion } from "@codemirror/autocomplete"
 
 // ── Markup & layout functions ───────────────────────────────────────────────
 // `sig` becomes `detail`; for functions we also synthesize `apply: "<name>("`.
@@ -174,15 +176,46 @@ const MATH = [
   ["sect", "∩", "Set intersection."]
 ]
 
-function fnOption([label, sig, info]) {
-  return {
-    label,
+// Functions complete to "#name()" with the caret inside the parens. The "#" is
+// part of the snippet; the source anchors `from` at the token start, so the
+// marker is added when missing and never doubled when the user already typed it.
+function fnOption([name, sig, info]) {
+  return snippetCompletion("#" + name + "(${})", {
+    label: "#" + name,
     type: "function",
     detail: sig,
-    info,
-    // Insert the opening paren so the caret lands inside the argument list.
-    apply: `${label}(`
+    info
+  })
+}
+
+// Structural keywords expand to a scaffold with the symbols they require.
+const KEYWORD_SNIPPETS = {
+  set: "#set ${}",
+  show: "#show ${}",
+  let: "#let ${name} = ${value}",
+  import: '#import "${module}"',
+  include: '#include "${file}"',
+  if: "#if ${condition} [${}]",
+  else: "else [${}]",
+  for: "#for ${item} in ${collection} [${}]",
+  while: "#while ${condition} [${}]",
+  return: "#return ${}"
+}
+
+function kwOption([name, sig, info]) {
+  const template = KEYWORD_SNIPPETS[name]
+
+  if (template) {
+    return snippetCompletion(template, {
+      label: template[0] === "#" ? "#" + name : name,
+      type: "keyword",
+      detail: sig,
+      info
+    })
   }
+
+  // Sub-keywords (in, as, break, continue) just insert their bare label.
+  return { label: name, type: "keyword", detail: sig, info }
 }
 
 function plainOption(type) {
@@ -193,28 +226,28 @@ function plainOption(type) {
 export const TYPST_COMPLETIONS = [
   ...FUNCTIONS.map(fnOption),
   ...SPACING.map(fnOption),
-  ...KEYWORDS.map(plainOption("keyword")),
+  ...KEYWORDS.map(kwOption),
   ...CONSTANTS.map(plainOption("constant")),
   ...TYPES.map(plainOption("type")),
   ...MATH.map(plainOption("variable"))
 ]
 
-// A valid CM6 `CompletionSource`. Returns null when there is nothing to
-// complete (empty token and not explicitly triggered), otherwise a result
-// anchored at the start of the current word token.
+// A valid CM6 `CompletionSource`. Anchors `from` at the token start (including
+// any leading #/@) so snippet labels like "#figure" match and replace cleanly,
+// adding the marker when it is missing. Auto-opens only after a #/@ marker —
+// Typst's escape into code — so it never pops while writing prose; everything
+// is still reachable on an explicit invoke (Ctrl-Space).
 export function typstCompletionSource(context) {
-  // Match an optional #/@ call-or-ref marker plus the identifier being typed.
   const word = context.matchBefore(/[#@]?[\w.-]*/)
-  if (!word || (word.from === word.to && !context.explicit)) return null
+  if (!word) return null
 
-  // Anchor completion AFTER the marker so the typed text ("figu") filters
-  // against bare labels ("figure") and apply leaves the marker in place
-  // (e.g. "#figu" → "#figure(").
-  const hasMarker = word.text[0] === "#" || word.text[0] === "@"
+  const marked = word.text[0] === "#" || word.text[0] === "@"
+  if (!marked && !context.explicit) return null
+  if (word.from === word.to && !context.explicit) return null
 
   return {
-    from: hasMarker ? word.from + 1 : word.from,
+    from: word.from,
     options: TYPST_COMPLETIONS,
-    validFor: /^[\w.-]*$/
+    validFor: /^[#@]?[\w.-]*$/
   }
 }

--- a/assets/js/typst_completions.js
+++ b/assets/js/typst_completions.js
@@ -232,6 +232,97 @@ export const TYPST_COMPLETIONS = [
   ...MATH.map(plainOption("variable"))
 ]
 
+// Local `#let` definitions in the current buffer, surfaced as completions so a
+// user's own variables and functions are suggested alongside the built-ins.
+// `#let f(..) = ..` completes to a call; a bare `#let x = ..` to the name.
+// `boost: 50` ranks locals above the built-ins.
+const LET_RE = /#let\s+([A-Za-z_][\w-]*)\s*(\([^)]*\))?\s*=/g
+
+export function localCompletions(state) {
+  const text = state.doc.toString()
+  const seen = new Set()
+  const out = []
+  LET_RE.lastIndex = 0
+
+  let m
+  while ((m = LET_RE.exec(text))) {
+    const name = m[1]
+    if (seen.has(name)) continue
+    seen.add(name)
+
+    if (m[2]) {
+      out.push(
+        snippetCompletion("#" + name + "(${})", {
+          label: "#" + name,
+          type: "function",
+          detail: m[2].slice(1, -1) || "..",
+          info: "Local function",
+          boost: 50
+        })
+      )
+    } else {
+      out.push({
+        label: "#" + name,
+        type: "variable",
+        detail: "local",
+        info: "Local variable",
+        boost: 50
+      })
+    }
+  }
+
+  return out
+}
+
+// Symbols pulled in by `#import` statements in the current buffer, e.g.
+// `#import "@preview/cetz:0.2.0": canvas, draw` or `#import "u.typ" as u`.
+// Explicit names complete to a call (most imports are functions); an `as` alias
+// is offered as a module handle. Wildcards (`: *`) can't be enumerated without
+// the module source, so they're skipped.
+const IMPORT_RE = /#import\s+(?:"[^"]*"|[\w@/.:-]+)\s*(?::\s*([^\n]+)|\bas\s+([A-Za-z_][\w-]*))/g
+
+export function importedCompletions(state) {
+  const text = state.doc.toString()
+  const seen = new Set()
+  const out = []
+  IMPORT_RE.lastIndex = 0
+
+  let m
+  while ((m = IMPORT_RE.exec(text))) {
+    if (m[2]) {
+      const alias = m[2]
+      if (seen.has(alias)) continue
+      seen.add(alias)
+      out.push({
+        label: "#" + alias,
+        type: "namespace",
+        detail: "module",
+        info: "Imported module",
+        boost: 40
+      })
+      continue
+    }
+
+    for (const part of m[1].split(",")) {
+      const as = /\bas\s+([A-Za-z_][\w-]*)/.exec(part)
+      const name = as ? as[1] : part.trim().replace(/[^\w-].*$/, "")
+      if (!name || !/^[A-Za-z_]/.test(name) || seen.has(name)) continue
+      seen.add(name)
+      out.push(
+        snippetCompletion("#" + name + "(${})", {
+          label: "#" + name,
+          type: "function",
+          detail: "imported",
+          info: "Imported symbol",
+          boost: 40
+        })
+      )
+    }
+  }
+
+  return out
+}
+
 // A valid CM6 `CompletionSource`. Anchors `from` at the token start (including
 // any leading #/@) so snippet labels like "#figure" match and replace cleanly,
 // adding the marker when it is missing. Auto-opens only after a #/@ marker —
@@ -247,7 +338,10 @@ export function typstCompletionSource(context) {
 
   return {
     from: word.from,
-    options: TYPST_COMPLETIONS,
+    options: TYPST_COMPLETIONS.concat(
+      localCompletions(context.state),
+      importedCompletions(context.state)
+    ),
     validFor: /^[#@]?[\w.-]*$/
   }
 }

--- a/assets/js/typst_completions.js
+++ b/assets/js/typst_completions.js
@@ -232,56 +232,110 @@ export const TYPST_COMPLETIONS = [
   ...MATH.map(plainOption("variable"))
 ]
 
-// Local `#let` definitions in the current buffer, surfaced as completions so a
-// user's own variables and functions are suggested alongside the built-ins.
-// `#let f(..) = ..` completes to a call; a bare `#let x = ..` to the name.
-// `boost: 50` ranks locals above the built-ins.
+// ── Dynamic completions scanned live from the document ───────────────────────
+// The user's own symbols, ranked above the built-ins: `#let` variables and
+// functions, their parameters, `#for` loop variables, and `#import`ed names.
 const LET_RE = /#let\s+([A-Za-z_][\w-]*)\s*(\([^)]*\))?\s*=/g
+const FOR_RE = /#for\s+(.+?)\s+in[\s([]/g
+
+function pushFn(out, seen, name, sig, info, boost) {
+  if (!name || seen.has(name)) return
+  seen.add(name)
+  out.push(
+    snippetCompletion("#" + name + "(${})", {
+      label: "#" + name,
+      type: "function",
+      detail: sig || "..",
+      info,
+      boost
+    })
+  )
+}
+
+function pushVar(out, seen, name, info, boost) {
+  if (!name || seen.has(name)) return
+  seen.add(name)
+  out.push({ label: "#" + name, type: "variable", detail: "local", info, boost })
+}
+
+function firstIdent(s) {
+  const m = s.match(/[A-Za-z_][\w-]*/)
+  return m ? m[0] : null
+}
+
+// Parameter names from a "(a, b, c: 1, ..rest)" list (drops defaults/spreads).
+function paramNames(parens) {
+  return parens
+    .slice(1, -1)
+    .split(",")
+    .map((p) => firstIdent(p.split(":")[0].replace(/\.\./g, " ")))
+    .filter(Boolean)
+}
+
+// Every top-level `#let` definition in a piece of source — used for both the
+// current buffer and any resolved imported module.
+function letDefs(text) {
+  const defs = []
+  LET_RE.lastIndex = 0
+  let m
+  while ((m = LET_RE.exec(text))) defs.push({ name: m[1], params: m[2] })
+  return defs
+}
 
 export function localCompletions(state) {
   const text = state.doc.toString()
   const seen = new Set()
   const out = []
-  LET_RE.lastIndex = 0
 
-  let m
-  while ((m = LET_RE.exec(text))) {
-    const name = m[1]
-    if (seen.has(name)) continue
-    seen.add(name)
-
-    if (m[2]) {
-      out.push(
-        snippetCompletion("#" + name + "(${})", {
-          label: "#" + name,
-          type: "function",
-          detail: m[2].slice(1, -1) || "..",
-          info: "Local function",
-          boost: 50
-        })
-      )
+  for (const { name, params } of letDefs(text)) {
+    if (params) {
+      pushFn(out, seen, name, params.slice(1, -1), "Local function", 50)
+      for (const p of paramNames(params)) pushVar(out, seen, p, "Parameter", 45)
     } else {
-      out.push({
-        label: "#" + name,
-        type: "variable",
-        detail: "local",
-        info: "Local variable",
-        boost: 50
-      })
+      pushVar(out, seen, name, "Local variable", 50)
+    }
+  }
+
+  // `#for x in ..` / `#for (a, b) in ..` loop bindings.
+  FOR_RE.lastIndex = 0
+  let m
+  while ((m = FOR_RE.exec(text))) {
+    for (const v of m[1].match(/[A-Za-z_][\w-]*/g) || []) {
+      pushVar(out, seen, v, "Loop variable", 45)
     }
   }
 
   return out
 }
 
-// Symbols pulled in by `#import` statements in the current buffer, e.g.
-// `#import "@preview/cetz:0.2.0": canvas, draw` or `#import "u.typ" as u`.
-// Explicit names complete to a call (most imports are functions); an `as` alias
-// is offered as a module handle. Wildcards (`: *`) can't be enumerated without
-// the module source, so they're skipped.
-const IMPORT_RE = /#import\s+(?:"[^"]*"|[\w@/.:-]+)\s*(?::\s*([^\n]+)|\bas\s+([A-Za-z_][\w-]*))/g
+// Symbols pulled in by `#import` statements, e.g.
+// `#import "@preview/cetz:0.2.0": canvas, draw`, `#import "u.typ": *`,
+// `#import "u.typ" as u`. Local-file imports (including `: *`) are resolved
+// against the project's other source files so the module's own `#let` exports
+// are offered and typed correctly; external `@preview/...` packages can't be
+// read client-side, so their explicit names fall back to a callable snippet
+// and their wildcards are skipped.
+const IMPORT_RE =
+  /#import\s+(?:"([^"]*)"|([\w@/.:-]+))\s*(?::\s*([^\n]+)|\bas\s+([A-Za-z_][\w-]*))/g
 
-export function importedCompletions(state) {
+// Resolve an import path to a sibling source file's content (init-time copy).
+// Lenient match: exact path, then path suffix, then basename. Packages skipped.
+function resolveModule(path, sources) {
+  if (!path || path[0] === "@" || !Array.isArray(sources)) return null
+  const base = path.split("/").pop()
+  const hit =
+    sources.find((s) => s.path === path) ||
+    sources.find((s) => s.path && s.path.endsWith("/" + path)) ||
+    sources.find((s) => s.path && s.path.split("/").pop() === base)
+  return hit ? hit.content || "" : null
+}
+
+function addImportedDef(out, seen, { name, params }, info) {
+  if (params) pushFn(out, seen, name, params.slice(1, -1), info + " function", 40)
+  else pushVar(out, seen, name, info + " value", 40)
+}
+
+export function importedCompletions(state, sources) {
   const text = state.doc.toString()
   const seen = new Set()
   const out = []
@@ -289,34 +343,33 @@ export function importedCompletions(state) {
 
   let m
   while ((m = IMPORT_RE.exec(text))) {
-    if (m[2]) {
-      const alias = m[2]
-      if (seen.has(alias)) continue
-      seen.add(alias)
-      out.push({
-        label: "#" + alias,
-        type: "namespace",
-        detail: "module",
-        info: "Imported module",
-        boost: 40
-      })
+    const path = m[1] || m[2]
+
+    // `#import "x" as alias` — the module handle.
+    if (m[4]) {
+      pushVar(out, seen, m[4], "Imported module", 40)
       continue
     }
 
-    for (const part of m[1].split(",")) {
+    const names = (m[3] || "").trim()
+    const mod = resolveModule(path, sources)
+
+    // `: *` — pull the module's own `#let` exports (local files only).
+    if (names === "*") {
+      if (mod) for (const def of letDefs(mod)) addImportedDef(out, seen, def, "Imported")
+      continue
+    }
+
+    // `: a, b, c` — explicit names, typed from the module when resolvable,
+    // otherwise assumed callable (most imports are functions).
+    const defs = mod ? letDefs(mod) : null
+    for (const part of names.split(",")) {
       const as = /\bas\s+([A-Za-z_][\w-]*)/.exec(part)
-      const name = as ? as[1] : part.trim().replace(/[^\w-].*$/, "")
-      if (!name || !/^[A-Za-z_]/.test(name) || seen.has(name)) continue
-      seen.add(name)
-      out.push(
-        snippetCompletion("#" + name + "(${})", {
-          label: "#" + name,
-          type: "function",
-          detail: "imported",
-          info: "Imported symbol",
-          boost: 40
-        })
-      )
+      const name = as ? as[1] : firstIdent(part)
+      if (!name) continue
+      const def = defs && defs.find((d) => d.name === name)
+      if (def) addImportedDef(out, seen, def, "Imported")
+      else pushFn(out, seen, name, "imported", "Imported symbol", 40)
     }
   }
 
@@ -327,8 +380,9 @@ export function importedCompletions(state) {
 // any leading #/@) so snippet labels like "#figure" match and replace cleanly,
 // adding the marker when it is missing. Auto-opens only after a #/@ marker —
 // Typst's escape into code — so it never pops while writing prose; everything
-// is still reachable on an explicit invoke (Ctrl-Space).
-export function typstCompletionSource(context) {
+// is still reachable on an explicit invoke (Ctrl-Space). `project` (wired from
+// the editor) supplies sibling source files so imports can be resolved.
+export function typstCompletionSource(context, project) {
   const word = context.matchBefore(/[#@]?[\w.-]*/)
   if (!word) return null
 
@@ -340,7 +394,7 @@ export function typstCompletionSource(context) {
     from: word.from,
     options: TYPST_COMPLETIONS.concat(
       localCompletions(context.state),
-      importedCompletions(context.state)
+      importedCompletions(context.state, project && project.sources)
     ),
     validFor: /^[#@]?[\w.-]*$/
   }

--- a/assets/js/typst_completions.js
+++ b/assets/js/typst_completions.js
@@ -1,0 +1,220 @@
+// CodeMirror 6 autocomplete source for the Typst language.
+//
+// Wired in editor.js via `autocompletion({ override: [typstCompletionSource] })`.
+// This file owns the *data* only — it never imports `autocompletion` itself, so
+// the editor keeps sole control over the extension and its keymap/config.
+//
+// Each entry is a plain object that is mapped to a CM `Completion`:
+//   - `type`   drives the gutter icon: function | keyword | constant | type | variable
+//   - `detail` is the dimmed signature shown to the right (this is the signature help)
+//   - `info`   is a one-sentence description for the docs tooltip
+//   - functions get an `apply` that inserts an opening paren, so the cursor lands
+//     inside the call; everything else inserts its bare label (no snippets).
+
+// ── Markup & layout functions ───────────────────────────────────────────────
+// `sig` becomes `detail`; for functions we also synthesize `apply: "<name>("`.
+const FUNCTIONS = [
+  ["heading", "body, level, ..", "A section heading; level controls depth."],
+  ["par", "body, leading, ..", "A logical paragraph with its own spacing."],
+  ["text", "body, size, fill, ..", "Styled inline text run (size, font, fill, weight)."],
+  ["strong", "body, delta", "Bold / strongly emphasized content."],
+  ["emph", "body", "Emphasized (italic) content."],
+  ["underline", "body, stroke, ..", "Underlines its content."],
+  ["strike", "body, stroke, ..", "Strikes through its content."],
+  ["overline", "body, stroke, ..", "Draws a line over its content."],
+  ["highlight", "body, fill, ..", "Highlights content with a background fill."],
+  ["sub", "body, typographic", "Renders content as subscript."],
+  ["super", "body, typographic", "Renders content as superscript."],
+  ["smallcaps", "body", "Renders text in small capitals."],
+  ["raw", "text, lang, block, ..", "Raw / code text with optional syntax highlighting."],
+  ["link", "dest, body", "A hyperlink to a URL or document location."],
+  ["ref", "target, supplement", "A cross-reference to a label."],
+  ["cite", "key, form, style", "A citation to a bibliography entry."],
+  ["footnote", "body, numbering", "Attaches a footnote to the current position."],
+  ["list", "..children, marker, ..", "An unordered (bullet) list."],
+  ["enum", "..children, numbering, ..", "An ordered (numbered) list."],
+  ["terms", "..children, separator, ..", "A term / description list."],
+  ["table", "..children, columns, ..", "A table laid out in a grid of cells."],
+  ["grid", "..children, columns, rows, ..", "A flexible grid layout of cells."],
+  ["figure", "body, caption, ..", "A figure with an optional caption and label."],
+  ["image", "source, format, width, ..", "Embeds a raster or vector image from a path."],
+  ["box", "body, width, height, ..", "An inline-level container box."],
+  ["block", "body, width, fill, ..", "A block-level container with spacing/fill."],
+  ["stack", "..children, dir, spacing", "Stacks content along a direction."],
+  ["columns", "body, count, gutter", "Lays content out in equal-width columns."],
+  ["place", "body, alignment, dx, dy", "Places content out of flow at an offset."],
+  ["align", "body, alignment", "Aligns content horizontally and/or vertically."],
+  ["pad", "body, left, top, ..", "Adds padding around content."],
+  ["move", "body, dx, dy", "Moves content without affecting layout."],
+  ["scale", "body, x, y, origin", "Scales content around an origin."],
+  ["rotate", "body, angle, origin", "Rotates content by an angle."],
+  ["repeat", "body, gap, justify", "Repeats content to fill available space."],
+  ["hide", "body", "Hides content while keeping its layout footprint."],
+  ["rect", "body, width, height, ..", "Draws a rectangle, optionally with content."],
+  ["square", "body, size, ..", "Draws a square, optionally with content."],
+  ["circle", "body, radius, ..", "Draws a circle, optionally with content."],
+  ["ellipse", "body, width, height, ..", "Draws an ellipse, optionally with content."],
+  ["polygon", "..vertices, fill, stroke", "Draws a polygon from vertex points."],
+  ["path", "..vertices, fill, stroke, ..", "Draws a Bezier path through points."],
+  ["line", "start, end, length, ..", "Draws a straight line."],
+  ["curve", "..components, fill, stroke", "Draws a curve from path components."],
+  ["lorem", "words", "Generates that many words of placeholder text."],
+  ["page", "body, width, margin, ..", "Configures the page geometry and content."],
+  ["counter", "key", "Creates or references a counter by key."],
+  ["numbering", "numbering, ..numbers", "Formats numbers with a numbering pattern."],
+  ["label", "name", "Creates a label that can be referenced."],
+  ["outline", "title, target, depth, ..", "A table of contents for the document."],
+  ["bibliography", "sources, title, style, ..", "Renders a bibliography from sources."],
+  ["document", "title, author, ..", "Sets document-wide metadata."],
+  ["metadata", "value", "Attaches queryable metadata to the document."],
+  ["datetime", "year, month, day, ..", "Constructs a date/time value."],
+  ["measure", "content, ..", "Measures the layout size of content."],
+  ["layout", "func", "Provides the available layout region to a callback."],
+  ["context", "body", "Resolves context-dependent values at this point."],
+  ["style", "func", "Accesses active styles via a callback."],
+  ["query", "target, location", "Queries the document for matching elements."],
+  ["pattern", "body, size, ..", "Defines a tiling pattern fill."],
+  ["gradient", "..stops, ..", "Constructs a color gradient."]
+]
+
+// ── Spacing / break helpers (function-call style, but tiny signatures) ───────
+const SPACING = [
+  ["v", "amount, weak", "Inserts vertical spacing."],
+  ["h", "amount, weak", "Inserts horizontal spacing."],
+  ["parbreak", "", "Forces a paragraph break."],
+  ["linebreak", "justify", "Forces a line break."],
+  ["pagebreak", "weak, to", "Forces a page break."],
+  ["colbreak", "weak", "Forces a column break."],
+  ["smartquote", "double, enabled, ..", "Renders a smart (curly) quote."]
+]
+
+// ── Keywords / rules. These are typically written after `#` in markup. ───────
+// `apply` strips the leading `#` so it only fires on the keyword token.
+const KEYWORDS = [
+  ["set", "set Elem(..)", "Set rule: configures default arguments of an element."],
+  ["show", "show sel: it => ..", "Show rule: transforms how elements are displayed."],
+  ["let", "let name = value", "Binds a value or defines a function."],
+  ["import", 'import "mod": a, b', "Imports definitions from a module."],
+  ["include", 'include "file.typ"', "Includes the content of another file."],
+  ["if", "if cond { .. }", "Conditional branch."],
+  ["else", "else { .. }", "Alternative branch of an if/else."],
+  ["for", "for x in it { .. }", "Iterates over a collection."],
+  ["in", "x in collection", "Membership / loop binding keyword."],
+  ["while", "while cond { .. }", "Loops while a condition holds."],
+  ["return", "return value", "Returns a value from a function."],
+  ["break", "", "Breaks out of the current loop."],
+  ["continue", "", "Skips to the next loop iteration."],
+  ["as", 'import "m" as n', "Renames an import."]
+]
+
+// ── Constants / literals. ────────────────────────────────────────────────────
+const CONSTANTS = [
+  ["none", "none", "The empty / absent value."],
+  ["auto", "auto", "Lets Typst choose the value automatically."],
+  ["true", "true", "Boolean true."],
+  ["false", "false", "Boolean false."]
+]
+
+// ── Built-in value types (for set rules, casts, annotations). ────────────────
+const TYPES = [
+  ["int", "int", "Integer number type."],
+  ["float", "float", "Floating-point number type."],
+  ["length", "length", "A size such as 2cm or 12pt."],
+  ["ratio", "ratio", "A percentage such as 50%."],
+  ["relative", "relative", "A length relative to a base, e.g. 2cm + 10%."],
+  ["fraction", "fraction", "A fraction of remaining space, e.g. 1fr."],
+  ["angle", "angle", "An angle such as 90deg or 1rad."],
+  ["color", "color", "A color value."],
+  ["str", "str", "A string of text."],
+  ["bool", "bool", "A boolean value."],
+  ["content", "content", "A piece of typeset content."],
+  ["array", "array", "An ordered sequence of values."],
+  ["dictionary", "dictionary", "A key/value mapping."],
+  ["alignment", "alignment", "A horizontal/vertical alignment value."],
+  ["direction", "direction", "A layout direction (ltr, rtl, ttb, btt)."],
+  ["stroke", "stroke", "A line stroke style."]
+]
+
+// ── Common math symbols (relevant inside `$ .. $`). ──────────────────────────
+const MATH = [
+  ["sum", "∑", "Summation operator (large)."],
+  ["product", "∏", "Product operator (large)."],
+  ["integral", "∫", "Integral operator."],
+  ["dif", "d", "Differential 'd' for derivatives/integrals."],
+  ["alpha", "α", "Greek lowercase alpha."],
+  ["beta", "β", "Greek lowercase beta."],
+  ["gamma", "γ", "Greek lowercase gamma."],
+  ["delta", "δ", "Greek lowercase delta."],
+  ["theta", "θ", "Greek lowercase theta."],
+  ["lambda", "λ", "Greek lowercase lambda."],
+  ["mu", "μ", "Greek lowercase mu."],
+  ["pi", "π", "Greek lowercase pi."],
+  ["sigma", "σ", "Greek lowercase sigma."],
+  ["phi", "φ", "Greek lowercase phi."],
+  ["omega", "ω", "Greek lowercase omega."],
+  ["infinity", "∞", "Infinity symbol (alias: oo)."],
+  ["arrow.r", "→", "Rightwards arrow."],
+  ["arrow.l", "←", "Leftwards arrow."],
+  ["arrow.t", "↑", "Upwards arrow."],
+  ["arrow.b", "↓", "Downwards arrow."],
+  ["dot", "⋅", "Dot / multiplication operator."],
+  ["times", "×", "Multiplication cross."],
+  ["div", "÷", "Division sign."],
+  ["plus.minus", "±", "Plus-minus sign."],
+  ["eq", "=", "Equals relation."],
+  ["eq.not", "≠", "Not-equal relation."],
+  ["approx", "≈", "Approximately-equal relation."],
+  ["lt", "<", "Less-than relation."],
+  ["gt", ">", "Greater-than relation."],
+  ["lt.eq", "≤", "Less-than-or-equal relation."],
+  ["gt.eq", "≥", "Greater-than-or-equal relation."],
+  ["in", "∈", "Element-of relation."],
+  ["subset", "⊂", "Subset relation."],
+  ["union", "∪", "Set union."],
+  ["sect", "∩", "Set intersection."]
+]
+
+function fnOption([label, sig, info]) {
+  return {
+    label,
+    type: "function",
+    detail: sig,
+    info,
+    // Insert the opening paren so the caret lands inside the argument list.
+    apply: `${label}(`
+  }
+}
+
+function plainOption(type) {
+  return ([label, sig, info]) => ({ label, type, detail: sig, info })
+}
+
+// Single flat list consumed by the completion source.
+export const TYPST_COMPLETIONS = [
+  ...FUNCTIONS.map(fnOption),
+  ...SPACING.map(fnOption),
+  ...KEYWORDS.map(plainOption("keyword")),
+  ...CONSTANTS.map(plainOption("constant")),
+  ...TYPES.map(plainOption("type")),
+  ...MATH.map(plainOption("variable"))
+]
+
+// A valid CM6 `CompletionSource`. Returns null when there is nothing to
+// complete (empty token and not explicitly triggered), otherwise a result
+// anchored at the start of the current word token.
+export function typstCompletionSource(context) {
+  // Match an optional #/@ call-or-ref marker plus the identifier being typed.
+  const word = context.matchBefore(/[#@]?[\w.-]*/)
+  if (!word || (word.from === word.to && !context.explicit)) return null
+
+  // Anchor completion AFTER the marker so the typed text ("figu") filters
+  // against bare labels ("figure") and apply leaves the marker in place
+  // (e.g. "#figu" → "#figure(").
+  const hasMarker = word.text[0] === "#" || word.text[0] === "@"
+
+  return {
+    from: hasMarker ? word.from + 1 : word.from,
+    options: TYPST_COMPLETIONS,
+    validFor: /^[\w.-]*$/
+  }
+}

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -39,6 +39,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:preview_error, nil)
      |> assign(:preview_error_count, 0)
      |> assign(:preview_compiling, false)
+     |> assign(:compile_history, [])
      |> assign(:diagnostics, [])
      |> assign(:compile_log, [])
      |> assign(:drawer_open, false)
@@ -142,6 +143,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:preview_error, nil)
      |> assign(:preview_error_count, 0)
      |> assign(:diagnostics, [])
+     |> push_compile(%{ms: params["ms"], status: :ok})
      |> push_log(log)}
   end
 
@@ -157,6 +159,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:preview_error_count, errors)
      |> assign(:preview_compiling, false)
      |> assign(:diagnostics, diagnostics)
+     |> push_compile(%{ms: nil, status: if(errors > 0, do: :error, else: :warn)})
      |> push_log(log_entry(:error, error_log_text(errors, warnings)))}
   end
 
@@ -901,6 +904,21 @@ defmodule TypsterWeb.EditorLive.Index do
   defp push_log(socket, entry) do
     assign(socket, :compile_log, Enum.take(socket.assigns.compile_log ++ [entry], -40))
   end
+
+  # Status-bar compile sparkline: keep the last 12 compiles (ms + status).
+  defp push_compile(socket, entry) do
+    assign(socket, :compile_history, Enum.take(socket.assigns.compile_history ++ [entry], -12))
+  end
+
+  # Bar height (2–12px) for one compile, scaled to the slowest successful run.
+  defp spark_height(%{ms: ms}, history) when is_integer(ms) do
+    max_ms =
+      history |> Enum.map(& &1.ms) |> Enum.filter(&is_integer/1) |> Enum.max(fn -> 1 end)
+
+    trunc(max(2, ms / max(max_ms, 1) * 12))
+  end
+
+  defp spark_height(_entry, _history), do: 9
 
   defp error_log_text(errors, warnings) do
     parts =

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -847,6 +847,26 @@
           <span class="ts-statusbar__item">UTF-8</span>
           <span class="ts-statusbar__sep"></span>
           <span class="ts-statusbar__item">LF</span>
+          <span :if={@compile_history != []} class="ts-statusbar__sep"></span>
+          <span
+            :if={@compile_history != []}
+            class="ts-statusbar__item"
+            title={gettext("editor.status.compile_times")}
+          >
+            <span class="ts-spark">
+              <span
+                :for={c <- @compile_history}
+                class={[
+                  "ts-spark__bar",
+                  c.status == :error && "is-err",
+                  c.status == :warn && "is-warn"
+                ]}
+                style={"height: #{spark_height(c, @compile_history)}px"}
+              >
+              </span>
+            </span>
+            <span :if={@preview_stats && @preview_stats.ms}>{@preview_stats.ms}ms</span>
+          </span>
           <div class="ts-spacer" />
           <button
             type="button"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -156,29 +156,29 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:540
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:537
+#: lib/typster_web/live/editor_live/index.ex:540
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:241
+#: lib/typster_web/live/editor_live/index.ex:244
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:571
+#: lib/typster_web/live/editor_live/index.ex:574
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:398
-#: lib/typster_web/live/editor_live/index.ex:422
-#: lib/typster_web/live/editor_live/index.ex:714
+#: lib/typster_web/live/editor_live/index.ex:401
+#: lib/typster_web/live/editor_live/index.ex:425
+#: lib/typster_web/live/editor_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -208,17 +208,17 @@ msgstr ""
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:648
+#: lib/typster_web/live/editor_live/index.ex:651
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:646
+#: lib/typster_web/live/editor_live/index.ex:649
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:647
+#: lib/typster_web/live/editor_live/index.ex:650
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -592,50 +592,50 @@ msgstr ""
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:897
-#: lib/typster_web/live/editor_live/index.html.heex:905
-#: lib/typster_web/live/editor_live/index.html.heex:914
+#: lib/typster_web/live/editor_live/index.html.heex:917
+#: lib/typster_web/live/editor_live/index.html.heex:925
+#: lib/typster_web/live/editor_live/index.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:949
-#: lib/typster_web/live/editor_live/index.html.heex:957
-#: lib/typster_web/live/editor_live/index.html.heex:966
+#: lib/typster_web/live/editor_live/index.html.heex:969
+#: lib/typster_web/live/editor_live/index.html.heex:977
+#: lib/typster_web/live/editor_live/index.html.heex:986
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:932
+#: lib/typster_web/live/editor_live/index.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:954
+#: lib/typster_web/live/editor_live/index.html.heex:974
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:889
+#: lib/typster_web/live/editor_live/index.html.heex:909
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:898
-#: lib/typster_web/live/editor_live/index.html.heex:922
-#: lib/typster_web/live/editor_live/index.html.heex:928
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:942
+#: lib/typster_web/live/editor_live/index.html.heex:948
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:902
+#: lib/typster_web/live/editor_live/index.html.heex:922
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:950
-#: lib/typster_web/live/editor_live/index.html.heex:969
-#: lib/typster_web/live/editor_live/index.html.heex:978
+#: lib/typster_web/live/editor_live/index.html.heex:970
+#: lib/typster_web/live/editor_live/index.html.heex:989
+#: lib/typster_web/live/editor_live/index.html.heex:998
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
@@ -2040,9 +2040,9 @@ msgstr ""
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:363
-#: lib/typster_web/live/editor_live/index.ex:409
-#: lib/typster_web/live/editor_live/index.ex:570
+#: lib/typster_web/live/editor_live/index.ex:366
+#: lib/typster_web/live/editor_live/index.ex:412
+#: lib/typster_web/live/editor_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2052,12 +2052,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:507
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:476
+#: lib/typster_web/live/editor_live/index.ex:479
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2122,7 +2122,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:664
+#: lib/typster_web/live/editor_live/index.ex:667
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2148,28 +2148,28 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:715
+#: lib/typster_web/live/editor_live/index.ex:718
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:907
+#: lib/typster_web/live/editor_live/index.ex:925
 #: lib/typster_web/live/editor_live/index.html.heex:674
-#: lib/typster_web/live/editor_live/index.html.heex:862
+#: lib/typster_web/live/editor_live/index.html.heex:882
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:909
+#: lib/typster_web/live/editor_live/index.ex:927
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:913
+#: lib/typster_web/live/editor_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2190,7 +2190,7 @@ msgid "editor.drawer.jump_first"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:864
+#: lib/typster_web/live/editor_live/index.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr ""
@@ -2210,7 +2210,7 @@ msgstr ""
 msgid "editor.drawer.problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:855
+#: lib/typster_web/live/editor_live/index.html.heex:875
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr ""
@@ -2225,12 +2225,12 @@ msgstr ""
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:769
+#: lib/typster_web/live/editor_live/index.ex:772
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:756
+#: lib/typster_web/live/editor_live/index.ex:759
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
@@ -2265,7 +2265,7 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:841
+#: lib/typster_web/live/editor_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
@@ -2288,4 +2288,9 @@ msgstr ""
 #: lib/typster_web/live/editor_live/index.html.heex:49
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.branch"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:854
+#, elixir-autogen, elixir-format
+msgid "editor.status.compile_times"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:540
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:537
+#: lib/typster_web/live/editor_live/index.ex:540
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:241
+#: lib/typster_web/live/editor_live/index.ex:244
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:571
+#: lib/typster_web/live/editor_live/index.ex:574
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:398
-#: lib/typster_web/live/editor_live/index.ex:422
-#: lib/typster_web/live/editor_live/index.ex:714
+#: lib/typster_web/live/editor_live/index.ex:401
+#: lib/typster_web/live/editor_live/index.ex:425
+#: lib/typster_web/live/editor_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -208,17 +208,17 @@ msgstr "Preview"
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:648
+#: lib/typster_web/live/editor_live/index.ex:651
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:646
+#: lib/typster_web/live/editor_live/index.ex:649
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:647
+#: lib/typster_web/live/editor_live/index.ex:650
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -592,50 +592,50 @@ msgstr "Outline"
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:897
-#: lib/typster_web/live/editor_live/index.html.heex:905
-#: lib/typster_web/live/editor_live/index.html.heex:914
+#: lib/typster_web/live/editor_live/index.html.heex:917
+#: lib/typster_web/live/editor_live/index.html.heex:925
+#: lib/typster_web/live/editor_live/index.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:949
-#: lib/typster_web/live/editor_live/index.html.heex:957
-#: lib/typster_web/live/editor_live/index.html.heex:966
+#: lib/typster_web/live/editor_live/index.html.heex:969
+#: lib/typster_web/live/editor_live/index.html.heex:977
+#: lib/typster_web/live/editor_live/index.html.heex:986
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:932
+#: lib/typster_web/live/editor_live/index.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:954
+#: lib/typster_web/live/editor_live/index.html.heex:974
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:889
+#: lib/typster_web/live/editor_live/index.html.heex:909
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:898
-#: lib/typster_web/live/editor_live/index.html.heex:922
-#: lib/typster_web/live/editor_live/index.html.heex:928
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:942
+#: lib/typster_web/live/editor_live/index.html.heex:948
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:902
+#: lib/typster_web/live/editor_live/index.html.heex:922
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:950
-#: lib/typster_web/live/editor_live/index.html.heex:969
-#: lib/typster_web/live/editor_live/index.html.heex:978
+#: lib/typster_web/live/editor_live/index.html.heex:970
+#: lib/typster_web/live/editor_live/index.html.heex:989
+#: lib/typster_web/live/editor_live/index.html.heex:998
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
@@ -2040,9 +2040,9 @@ msgstr "Appended when you press Enter"
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:363
-#: lib/typster_web/live/editor_live/index.ex:409
-#: lib/typster_web/live/editor_live/index.ex:570
+#: lib/typster_web/live/editor_live/index.ex:366
+#: lib/typster_web/live/editor_live/index.ex:412
+#: lib/typster_web/live/editor_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2052,12 +2052,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:507
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:476
+#: lib/typster_web/live/editor_live/index.ex:479
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2122,7 +2122,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:664
+#: lib/typster_web/live/editor_live/index.ex:667
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2148,28 +2148,28 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:715
+#: lib/typster_web/live/editor_live/index.ex:718
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:907
+#: lib/typster_web/live/editor_live/index.ex:925
 #: lib/typster_web/live/editor_live/index.html.heex:674
-#: lib/typster_web/live/editor_live/index.html.heex:862
+#: lib/typster_web/live/editor_live/index.html.heex:882
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:909
+#: lib/typster_web/live/editor_live/index.ex:927
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:913
+#: lib/typster_web/live/editor_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2190,7 +2190,7 @@ msgid "editor.drawer.jump_first"
 msgstr "Jump to first"
 
 #: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:864
+#: lib/typster_web/live/editor_live/index.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Compile log"
@@ -2210,7 +2210,7 @@ msgstr "No problems"
 msgid "editor.drawer.problems"
 msgstr "Problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:855
+#: lib/typster_web/live/editor_live/index.html.heex:875
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Toggle compile panel"
@@ -2225,12 +2225,12 @@ msgstr "Off"
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:769
+#: lib/typster_web/live/editor_live/index.ex:772
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:756
+#: lib/typster_web/live/editor_live/index.ex:759
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
@@ -2265,7 +2265,7 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:841
+#: lib/typster_web/live/editor_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
@@ -2289,3 +2289,8 @@ msgstr "Switch project"
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.branch"
 msgstr "Branch"
+
+#: lib/typster_web/live/editor_live/index.html.heex:854
+#, elixir-autogen, elixir-format
+msgid "editor.status.compile_times"
+msgstr "Compile times (last 12 runs)"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:540
+#: lib/typster_web/live/editor_live/index.ex:543
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:537
+#: lib/typster_web/live/editor_live/index.ex:540
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:241
+#: lib/typster_web/live/editor_live/index.ex:244
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:571
+#: lib/typster_web/live/editor_live/index.ex:574
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:398
-#: lib/typster_web/live/editor_live/index.ex:422
-#: lib/typster_web/live/editor_live/index.ex:714
+#: lib/typster_web/live/editor_live/index.ex:401
+#: lib/typster_web/live/editor_live/index.ex:425
+#: lib/typster_web/live/editor_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -208,17 +208,17 @@ msgstr "Превью"
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:648
+#: lib/typster_web/live/editor_live/index.ex:651
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:646
+#: lib/typster_web/live/editor_live/index.ex:649
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:647
+#: lib/typster_web/live/editor_live/index.ex:650
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -594,50 +594,50 @@ msgstr "Структура"
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:897
-#: lib/typster_web/live/editor_live/index.html.heex:905
-#: lib/typster_web/live/editor_live/index.html.heex:914
+#: lib/typster_web/live/editor_live/index.html.heex:917
+#: lib/typster_web/live/editor_live/index.html.heex:925
+#: lib/typster_web/live/editor_live/index.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:949
-#: lib/typster_web/live/editor_live/index.html.heex:957
-#: lib/typster_web/live/editor_live/index.html.heex:966
+#: lib/typster_web/live/editor_live/index.html.heex:969
+#: lib/typster_web/live/editor_live/index.html.heex:977
+#: lib/typster_web/live/editor_live/index.html.heex:986
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:932
+#: lib/typster_web/live/editor_live/index.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:954
+#: lib/typster_web/live/editor_live/index.html.heex:974
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:889
+#: lib/typster_web/live/editor_live/index.html.heex:909
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:898
-#: lib/typster_web/live/editor_live/index.html.heex:922
-#: lib/typster_web/live/editor_live/index.html.heex:928
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:942
+#: lib/typster_web/live/editor_live/index.html.heex:948
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:902
+#: lib/typster_web/live/editor_live/index.html.heex:922
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:950
-#: lib/typster_web/live/editor_live/index.html.heex:969
-#: lib/typster_web/live/editor_live/index.html.heex:978
+#: lib/typster_web/live/editor_live/index.html.heex:970
+#: lib/typster_web/live/editor_live/index.html.heex:989
+#: lib/typster_web/live/editor_live/index.html.heex:998
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
@@ -2046,9 +2046,9 @@ msgstr "Добавится по нажатию Enter"
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:363
-#: lib/typster_web/live/editor_live/index.ex:409
-#: lib/typster_web/live/editor_live/index.ex:570
+#: lib/typster_web/live/editor_live/index.ex:366
+#: lib/typster_web/live/editor_live/index.ex:412
+#: lib/typster_web/live/editor_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2058,12 +2058,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:507
+#: lib/typster_web/live/editor_live/index.ex:510
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:476
+#: lib/typster_web/live/editor_live/index.ex:479
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2129,7 +2129,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:664
+#: lib/typster_web/live/editor_live/index.ex:667
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2155,14 +2155,14 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:715
+#: lib/typster_web/live/editor_live/index.ex:718
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:907
+#: lib/typster_web/live/editor_live/index.ex:925
 #: lib/typster_web/live/editor_live/index.html.heex:674
-#: lib/typster_web/live/editor_live/index.html.heex:862
+#: lib/typster_web/live/editor_live/index.html.heex:882
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2170,7 +2170,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:909
+#: lib/typster_web/live/editor_live/index.ex:927
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2178,7 +2178,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:913
+#: lib/typster_web/live/editor_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2199,7 +2199,7 @@ msgid "editor.drawer.jump_first"
 msgstr "К первой"
 
 #: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:864
+#: lib/typster_web/live/editor_live/index.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Лог компиляции"
@@ -2219,7 +2219,7 @@ msgstr "Нет проблем"
 msgid "editor.drawer.problems"
 msgstr "Проблемы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:855
+#: lib/typster_web/live/editor_live/index.html.heex:875
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Показать панель компиляции"
@@ -2234,12 +2234,12 @@ msgstr "Выкл"
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:769
+#: lib/typster_web/live/editor_live/index.ex:772
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:756
+#: lib/typster_web/live/editor_live/index.ex:759
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
@@ -2274,7 +2274,7 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:841
+#: lib/typster_web/live/editor_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
@@ -2298,3 +2298,8 @@ msgstr "Сменить проект"
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.branch"
 msgstr "Ветка"
+
+#: lib/typster_web/live/editor_live/index.html.heex:854
+#, elixir-autogen, elixir-format
+msgid "editor.status.compile_times"
+msgstr "Время компиляции (последние 12)"

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -275,6 +275,29 @@ defmodule TypsterWeb.EditorLiveTest do
     assert has_element?(view, ".ts-tb__compile.is-error", "2")
   end
 
+  test "the status bar builds a compile sparkline from compile history",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    refute has_element?(view, ".ts-spark")
+
+    render_hook(view, "update_preview", %{"ms" => 47, "pages" => 1})
+    render_hook(view, "update_preview", %{"ms" => 60, "pages" => 1})
+
+    assert has_element?(view, ".ts-spark .ts-spark__bar")
+  end
+
+  test "a failed compile records an error bar in the sparkline",
+       %{conn: conn, user: user, project: project} do
+    file_fixture(project, user, %{path: "main.typ"})
+    view = open_editor(conn, project)
+
+    render_hook(view, "preview_error", %{"message" => "boom", "errors" => 1})
+
+    assert has_element?(view, ".ts-spark .ts-spark__bar.is-err")
+  end
+
   test "outline numbers headings and shows a section count",
        %{conn: conn, user: user, project: project} do
     file_fixture(project, user, %{path: "main.typ"})


### PR DESCRIPTION
PR2 of the editor v3.1 redesign (epic #108, issue #105). Layers the v3.1 **editor assists** onto the existing CodeMirror integration. All open-source; everything is driven by **real data** already flowing through the editor (compile diagnostics, compile history) — no mocks.

## Features (all verified working via headless Playwright)

- **Inline diagnostic lens** — the full Typst compile error/warning renders in a styled block right under the offending line (not just a hover tooltip), in sync with the existing squiggle, gutter dot, and a new scroll-rail mark. Fed by the diagnostics the Typst worker already emits.
- **Scroll rail** — a right-edge minimap of marks: errors, warnings, and headings by document position.
- **Typst autocomplete + signature help** — a curated CodeMirror completion source with **137** real Typst entries (functions, keywords, constants, types, math symbols). `detail` carries the signature, `info` the description. Anchored after the `#`/`@` marker so `#figu` → `#figure(`.
- **Selection quick-action bubble** — select prose and a floating bubble offers **Heading / Bold / Italic / Math / Link**, wired to the existing `phx:editor-command` pipeline (no new command code).
- **Compile sparkline** in the status bar — the last 12 compile durations as mini bars (warn/error tinted), from a real `compile_history` assign.

## How it is built
- New `assets/js/editor_v3.js` (lens StateField + block widgets, scroll-rail ViewPlugin, selection-bubble tooltip) and `assets/js/typst_completions.js`, both imported from the **same granular `@codemirror/*` packages** as `editor.js` so decoration-facet identity is shared (the dual-copy footgun the file header warns about).
- `editor.js` wires them in: the diagnostics dispatched to lint now also feed the lens/rail; `autocompletion()` becomes Typst-aware for `.typ`.
- LiveView tracks `compile_history` on `update_preview` / `preview_error`; the status bar renders `.ts-spark`. Token-driven CSS in `_editor_v3.css` (light/dark for free). en/ru gettext filled.

## Verification
- `mix precommit` green — `--warning-as-errors`, format, sobelow, **194 tests, 0 failures** (+ sparkline LiveView tests).
- New Playwright E2E: autocomplete popover after `#figu`, and the selection bubble + Bold wrapping a selection.
- Visually confirmed end-to-end (error lens + gutter + rail + sparkline; the autocomplete popover; the selection bubble) on a fresh test-env server.

## Deferred (follow-ups, not faked)
- Vim mode in the status bar (needs a new dep) · sticky scope breadcrumb (`folder › file › heading`) · v3 empty-state recents · git change bars in the gutter (no per-project VCS yet — see #107).

Part of #108. 

Closes #105 (core assists; the deferred items above can be a fast follow).