### PR TITLE
feat(share): Share — links, collaborators, embed, export + public view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ npm-debug.log
 
 # Ignore sarif files (security scan results).
 *.sarif
+
+# Playwright MCP screenshot/snapshot artifacts
+.playwright-mcp/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pro"]
-	path = pro
+	path = vendor/pro
 	url = git@github.com:typster-io/typster-pro.git

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -1793,9 +1793,9 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font: 600 11px var(--font-sans);
-  padding: 4px 11px;
-  border-radius: 6px;
+  font: 600 10.5px var(--font-sans);
+  padding: 3px 9px;
+  border-radius: 5px;
   background: var(--accent);
   color: var(--accent-text);
   text-decoration: none;
@@ -1804,6 +1804,17 @@
 }
 .share-public .embed-foot__cta:hover {
   filter: brightness(1.07);
+}
+
+/* Live embed preview inside the Share modal — a real (static, socket-free)
+   iframe of /embed, so highlight, the compiled PDF and theme are all genuine. */
+.embed-live-frame {
+  display: block;
+  width: 100%;
+  height: 380px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
 }
 
 /* invalid / expired link panel */

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -699,10 +699,10 @@
   border-color: var(--border-strong);
 }
 .cfg-chip .check {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   border: 1.5px solid var(--border-strong);
-  border-radius: 4px;
+  border-radius: 5px;
   background: var(--surface);
   display: inline-grid;
   place-items: center;
@@ -710,14 +710,15 @@
   flex-shrink: 0;
 }
 .cfg-chip.on {
-  background: color-mix(in oklab, var(--accent) 8%, var(--surface));
-  border-color: color-mix(in oklab, var(--accent) 40%, var(--border));
+  background: color-mix(in oklab, var(--accent) 10%, var(--surface));
+  border-color: color-mix(in oklab, var(--accent) 55%, var(--border));
   color: var(--accent);
 }
 .cfg-chip.on .check {
   background: var(--accent);
   border-color: var(--accent);
-  color: var(--accent-text, white);
+  /* High-contrast checkmark — the white glyph reads clearly on the accent fill. */
+  color: #fff;
 }
 
 /* segmented control for theme/width */
@@ -1841,4 +1842,34 @@
   place-items: center;
   font-size: 26px;
   line-height: 1;
+}
+
+/* ── Embed snippet "coming soon" language tabs (React / npm) ──────────────────
+   These packages aren't shipped yet, so their tabs carry a small "soon" badge
+   and render a playful placeholder instead of a snippet. */
+.snippet-box .head .lang.lang--soon {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.snippet-box .head .lang .lang-soon {
+  font: 600 8px var(--font-sans);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 1px 4px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 14%, transparent);
+  color: var(--accent);
+}
+
+/* Keep the live-preview compact inside the modal so the snippet below stays
+   reachable without a long scroll (the standalone /embed view is full-height). */
+.embed-preview-wrap .embed-comp {
+  min-height: 0;
+}
+.embed-preview-wrap .embed-code,
+.embed-preview-wrap .embed-tree,
+.embed-preview-wrap .embed-preview-doc {
+  max-height: 220px;
+  overflow: hidden;
 }

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -1235,7 +1235,9 @@
   padding: 12px 14px;
   font: 12px/1.6 var(--font-mono);
   color: var(--text);
-  overflow-x: auto;
+  /* Wrap the iframe snippet instead of scrolling horizontally. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 .snippet-box pre .tag {
   color: var(--code-keyword);
@@ -1500,12 +1502,19 @@
   font-size: 11.5px;
 }
 
-/* Gated permission card — same shape as others, dashed border (color handled by tone) */
+/* Gated permission card — clearly visible dashed border in the write tone so the
+   "locked Pro option" reads at a glance (the faint --border was barely visible). */
 .perm-card.gated {
   border-style: dashed;
+  border-width: 1.5px;
+  border-color: color-mix(in oklab, var(--amber-500) 60%, var(--border));
+}
+.perm-card.gated:hover {
+  border-color: color-mix(in oklab, var(--amber-500) 80%, var(--border));
 }
 .perm-card.gated.active {
   border-style: solid;
+  border-color: var(--amber-500);
 }
 
 /* ============================================================

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -1,0 +1,1667 @@
+/* ── Share modal v3 — share-* class system ───────────────────────────────────
+   Faithful port of the v3 Share modal (share-v3.css / share-v3.jsx). People ·
+   Link · Embed · Export PDF tabs, plan-gating (Pro badges, upgrade banners,
+   locked sections), and a fake-host embed preview. Token-driven via --mk-* so
+   light/dark flip for free — no per-theme overrides.
+
+   Token map (prototype → real):
+     accent       → --mk-pri          accent-soft → --mk-pri-50
+     accent-text  → #fff              surface     → --mk-bg
+     surface-2    → --mk-bg2          border      → --mk-bd
+     text         → --mk-fg           text-dim    → --mk-fg2
+     text-mute    → --mk-fg3          (faintest)  → --mk-fg4
+     green-500    → --mk-success      amber-500   → --mk-warning
+     red-500      → --mk-error        sky/blue    → --mk-info
+   Permission-card tones: read→info · output→success · write→warning · full→error
+   (their *-bd variants drive the soft borders).
+
+   The prototype also referenced helper tokens absent from the --mk-* set; they
+   are resolved locally on .share-shell / .share-overlay so the cascade reaches
+   every descendant: --border-strong (matches the editor topbar derivation),
+   --font-sans / --font-serif / --font-mono, the syntax --code-* set, and the
+   embed glyph --indigo-* pair.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.share-shell,
+.share-overlay {
+  --accent: var(--mk-pri);
+  --accent-soft: var(--mk-pri-50);
+  --accent-text: #fff;
+  --surface: var(--mk-bg);
+  --surface-2: var(--mk-bg2);
+  --border: var(--mk-bd);
+  --border-strong: color-mix(in oklab, var(--mk-bd) 45%, var(--mk-fg4));
+  --text: var(--mk-fg);
+  --text-dim: var(--mk-fg2);
+  --text-mute: var(--mk-fg3);
+
+  --green-500: var(--mk-success);
+  --amber-500: var(--mk-warning);
+  --red-500: var(--mk-error);
+  --sky-500: var(--mk-info);
+
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-serif: "Instrument Serif", "Times New Roman", serif;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+
+  --code-keyword: var(--mk-info);
+  --code-string: var(--mk-success);
+  --code-heading: var(--mk-pri);
+  --code-fn: var(--mk-warning);
+  --code-comment: var(--mk-fg3);
+
+  --indigo-500: var(--mk-pri);
+  --indigo-600: var(--mk-pri-h);
+}
+
+/* ---------- modal shell ---------- */
+.share-shell {
+  width: 100%;
+  max-width: 760px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 32px 64px -16px rgba(0, 0, 0, 0.28), 0 1px 0 rgba(0, 0, 0, 0.04);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+}
+.share-overlay {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in oklab, #0b1020 55%, transparent);
+  backdrop-filter: blur(2px);
+  display: grid;
+  place-items: center;
+  padding: 40px;
+  z-index: 50;
+}
+.share-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 18px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.share-head .ttl {
+  font: 600 16px var(--font-sans);
+  color: var(--text);
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.share-head .ttl .proj {
+  font: 600 14px var(--font-mono);
+  color: var(--text-dim);
+}
+.share-head .sub {
+  font: 12.5px var(--font-sans);
+  color: var(--text-mute);
+}
+.share-head .x {
+  margin-left: auto;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--text-mute);
+}
+.share-head .x:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+/* tab strip */
+.share-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+.share-tabs .tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 11px 14px 12px;
+  font: 500 13px var(--font-sans);
+  color: var(--text-mute);
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  margin-bottom: -1px;
+}
+.share-tabs .tab:hover {
+  color: var(--text-dim);
+}
+.share-tabs .tab.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+.share-tabs .tab .badge {
+  font: 500 10.5px var(--font-mono);
+  padding: 1px 5px;
+  background: var(--surface-2);
+  border-radius: 999px;
+  color: var(--text-mute);
+}
+.share-tabs .tab.active .badge {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+/* body */
+.share-body {
+  padding: 18px 20px 20px;
+  overflow-y: auto;
+  background: var(--surface);
+  flex: 1;
+  min-height: 0;
+}
+.share-section {
+  margin-top: 18px;
+}
+.share-section:first-child {
+  margin-top: 0;
+}
+.share-section .label {
+  font: 500 10.5px var(--font-sans);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin-bottom: 8px;
+}
+.share-section .sub-label {
+  font: 12px var(--font-sans);
+  color: var(--text-mute);
+  margin-top: 4px;
+}
+
+/* ---------- people tab ---------- */
+.invite-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+}
+.invite-row .field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  height: 36px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.invite-row .field input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  font: 13px var(--font-sans);
+  color: var(--text);
+  min-width: 0;
+}
+.invite-row .field input::placeholder {
+  color: var(--text-mute);
+}
+.invite-row .field svg {
+  color: var(--text-mute);
+}
+.invite-row .field .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 4px 2px 7px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  font: 12px var(--font-sans);
+  color: var(--text);
+}
+.invite-row .field .chip .x {
+  width: 16px;
+  height: 16px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  border-radius: 3px;
+  color: var(--text-mute);
+}
+.invite-row .field .chip .x:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+/* role select dropdown look */
+.role-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 36px;
+  padding: 0 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font: 500 12.5px var(--font-sans);
+  color: var(--text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.role-select:hover {
+  background: var(--surface);
+  border-color: var(--border-strong);
+}
+.role-select svg {
+  color: var(--text-mute);
+}
+.role-select.small {
+  height: 26px;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
+/* people list */
+.people-list {
+  display: grid;
+  gap: 2px;
+}
+.person-row {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px;
+  border-radius: 8px;
+}
+.person-row:hover {
+  background: var(--surface-2);
+}
+.person-row .av {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font: 600 11px var(--font-sans);
+  color: white;
+}
+.person-row .meta {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+.person-row .n {
+  font: 500 13px var(--font-sans);
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.person-row .n .you {
+  font: 500 10px var(--font-sans);
+  padding: 1px 5px;
+  background: var(--surface-2);
+  color: var(--text-mute);
+  border-radius: 999px;
+  letter-spacing: 0.02em;
+}
+.person-row .e {
+  font: 12px var(--font-mono);
+  color: var(--text-mute);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.person-row .pending {
+  font: 500 11px var(--font-sans);
+  color: var(--amber-500);
+  padding: 1px 6px;
+  background: color-mix(in oklab, var(--amber-500) 12%, transparent);
+  border-radius: 999px;
+}
+
+/* default access ribbon */
+.default-access {
+  margin-top: 14px;
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  display: grid;
+  grid-template-columns: 26px 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+.default-access .ic {
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text-dim);
+}
+.default-access .body {
+  display: grid;
+  gap: 1px;
+}
+.default-access .h {
+  font: 500 13px var(--font-sans);
+  color: var(--text);
+}
+.default-access .d {
+  font: 12px var(--font-sans);
+  color: var(--text-mute);
+}
+
+/* ---------- link tab ---------- */
+.link-box {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: stretch;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  overflow: hidden;
+}
+.link-box .url {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  min-height: 38px;
+  font: 12.5px var(--font-mono);
+  color: var(--text);
+  overflow: hidden;
+}
+.link-box .url svg {
+  color: var(--text-mute);
+  flex-shrink: 0;
+}
+.link-box .url .path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.link-box .url .path .host {
+  color: var(--text-mute);
+}
+.link-box .url .path .slug {
+  color: var(--text);
+}
+.link-box .url .path .token {
+  color: var(--accent);
+}
+.link-box .copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 14px;
+  background: var(--surface);
+  border: 0;
+  border-left: 1px solid var(--border);
+  font: 500 12.5px var(--font-sans);
+  color: var(--text);
+  cursor: pointer;
+}
+.link-box .copy:hover {
+  background: var(--surface-2);
+}
+.link-box .copy.copied {
+  color: var(--green-500);
+}
+
+/* permission cards */
+.perm-cards {
+  display: grid;
+  gap: 10px;
+}
+.perm-card {
+  display: grid;
+  grid-template-columns: 36px 1fr 20px;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+  align-items: start;
+  transition: background 0.12s, border-color 0.12s;
+}
+.perm-card:hover {
+  background: var(--surface-2);
+}
+.perm-card .ic {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-2);
+  border-radius: 8px;
+  color: var(--text-dim);
+}
+.perm-card .body .h {
+  font: 600 13px var(--font-sans);
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.perm-card .body .h .badge {
+  font: 500 10px var(--font-mono);
+  padding: 1px 5px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-mute);
+}
+.perm-card .body .d {
+  font: 12.5px/1.45 var(--font-sans);
+  color: var(--text-mute);
+  margin-top: 2px;
+}
+.perm-card .radio {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border-strong);
+  background: var(--surface);
+  position: relative;
+  margin-top: 2px;
+}
+.perm-card.active {
+  background: color-mix(in oklab, var(--accent) 6%, var(--surface));
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 14%, transparent);
+}
+.perm-card.active .ic {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.perm-card.active .radio {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+.perm-card.active .radio::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  background: var(--accent-text, white);
+}
+
+/* file scope expand (under "write specific files") */
+.scope-files {
+  margin-top: 8px;
+  margin-left: 48px;
+  padding: 10px 12px;
+  background: var(--surface-2);
+  border: 1px dashed var(--border-strong);
+  border-radius: 8px;
+}
+.scope-files .ttl {
+  font: 500 11px var(--font-sans);
+  color: var(--text-mute);
+  margin-bottom: 6px;
+}
+.scope-files .files {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.scope-files .f {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 4px 3px 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font: 500 12px var(--font-mono);
+  color: var(--text);
+}
+.scope-files .f .x {
+  width: 14px;
+  height: 14px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 3px;
+  color: var(--text-mute);
+  cursor: pointer;
+}
+.scope-files .f .x:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.scope-files .add {
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  color: var(--text-mute);
+  padding: 3px 8px;
+  border-radius: 6px;
+  font: 500 12px var(--font-sans);
+  cursor: pointer;
+}
+.scope-files .add:hover {
+  color: var(--text);
+  border-color: var(--text-mute);
+}
+
+/* toggle rows for advanced */
+.toggle-row {
+  display: grid;
+  grid-template-columns: 1fr 32px;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+.toggle-row:first-of-type {
+  border-top: 0;
+}
+.toggle-row .meta {
+  display: grid;
+  gap: 1px;
+}
+.toggle-row .h {
+  font: 500 13px var(--font-sans);
+  color: var(--text);
+}
+.toggle-row .d {
+  font: 12px var(--font-sans);
+  color: var(--text-mute);
+}
+.toggle-row .switch {
+  width: 32px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--border-strong);
+  position: relative;
+  cursor: pointer;
+  transition: background 0.16s;
+}
+.toggle-row .switch::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  background: var(--surface);
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+  transition: transform 0.16s;
+}
+.toggle-row.on .switch {
+  background: var(--accent);
+}
+.toggle-row.on .switch::after {
+  transform: translateX(14px);
+}
+
+/* link stats */
+.link-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-top: 12px;
+}
+.link-stats .stat {
+  padding: 10px 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.link-stats .stat .v {
+  font: 600 18px var(--font-sans);
+  color: var(--text);
+}
+.link-stats .stat .l {
+  font: 11.5px var(--font-sans);
+  color: var(--text-mute);
+}
+
+/* ---------- embed tab — controls on top, preview full-width below ---------- */
+.embed-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.cfg-group {
+  display: grid;
+  gap: 6px;
+  align-content: start;
+  padding: 11px 14px;
+  border-right: 1px solid var(--border);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.cfg-group:last-child {
+  border-right: 0;
+}
+.cfg-group.grow {
+  flex-grow: 2;
+}
+.cfg-group .lbl {
+  font: 500 10px var(--font-sans);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.cfg-group .row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  align-items: center;
+}
+
+/* clickable chip toggles for embed components */
+.cfg-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 10px 0 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font: 500 12.5px var(--font-sans);
+  user-select: none;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.cfg-chip:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.cfg-chip .check {
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--surface);
+  display: inline-grid;
+  place-items: center;
+  color: transparent;
+  flex-shrink: 0;
+}
+.cfg-chip.on {
+  background: color-mix(in oklab, var(--accent) 8%, var(--surface));
+  border-color: color-mix(in oklab, var(--accent) 40%, var(--border));
+  color: var(--accent);
+}
+.cfg-chip.on .check {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-text, white);
+}
+
+/* segmented control for theme/width */
+.cfg-seg {
+  display: inline-flex;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 3px;
+  gap: 2px;
+  height: 28px;
+}
+.cfg-seg .opt {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 0 11px;
+  border-radius: 5px;
+  font: 500 12px var(--font-sans);
+  color: var(--text-mute);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.cfg-seg .opt:hover {
+  color: var(--text-dim);
+}
+.cfg-seg .opt.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* embed preview — full width, prominent */
+.embed-preview-wrap {
+  margin-top: 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0;
+  overflow: hidden;
+  position: relative;
+}
+.embed-preview-wrap .preview-tag {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  z-index: 2;
+  font: 500 10px var(--font-sans);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  background: color-mix(in oklab, var(--surface) 80%, transparent);
+  border: 1px solid var(--border);
+  padding: 3px 7px;
+  border-radius: 999px;
+  backdrop-filter: blur(6px);
+}
+
+/* width frame — visualizes selected embed width inside the host */
+.embed-width-frame {
+  margin: 0 auto;
+  transition: max-width 0.24s ease;
+}
+
+/* sandbox indicator pill in embed top bar */
+.embed-bar .sandbox-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font: 500 10px var(--font-sans);
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--accent);
+  border-radius: 999px;
+  text-transform: uppercase;
+}
+.embed-bar .sandbox-pill .pulse {
+  width: 5px;
+  height: 5px;
+  background: var(--accent);
+  border-radius: 50%;
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent) 60%, transparent);
+  animation: sandbox-pulse 1.6s ease-out infinite;
+}
+@keyframes sandbox-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent) 60%, transparent);
+  }
+  70% {
+    box-shadow: 0 0 0 5px color-mix(in oklab, var(--accent) 0%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent) 0%, transparent);
+  }
+}
+
+/* edited line + caret inside embed code */
+.embed-code .ln-edited {
+  background: color-mix(in oklab, var(--amber-500) 12%, transparent);
+  box-shadow: inset 2px 0 0 var(--amber-500);
+  margin: 0 -10px;
+  padding: 0 10px;
+}
+.embed-code .ec-caret {
+  display: inline-block;
+  width: 1.5px;
+  height: 1em;
+  background: var(--accent);
+  vertical-align: text-bottom;
+  margin: 0 -0.5px;
+  animation: caret-blink 1.05s steps(1) infinite;
+}
+
+/* edited-line marker in preview pane */
+.embed-preview-doc .edited-bit {
+  background: color-mix(in oklab, var(--amber-500) 18%, transparent);
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
+/* contextual "appear on edit" hint pill in footer */
+.embed-foot .edit-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 4px 3px 9px;
+  background: var(--surface);
+  border: 1px solid color-mix(in oklab, var(--amber-500) 45%, var(--border));
+  border-radius: 999px;
+  font: 500 10.5px var(--font-sans);
+  color: var(--text-dim);
+  animation: cta-slide-up 0.32s ease-out;
+}
+.embed-foot .edit-cta .dot {
+  width: 6px;
+  height: 6px;
+  background: var(--amber-500);
+  border-radius: 50%;
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--amber-500) 22%, transparent);
+}
+.embed-foot .edit-cta .go {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  background: var(--accent);
+  color: var(--accent-text);
+  border: 0;
+  border-radius: 999px;
+  font: 600 10.5px var(--font-sans);
+  cursor: pointer;
+}
+.embed-foot .edit-cta .go:hover {
+  filter: brightness(1.08);
+}
+@keyframes cta-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* CTA-mode picker styled like segmented but with descriptions in chip labels */
+.cta-mode-row {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+/* fake host page wrapping the embed */
+.host-page {
+  background: var(--surface);
+  padding: 24px 22px 20px;
+  position: relative;
+}
+.host-page .host-chrome {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: -24px -22px 18px;
+  padding: 8px 12px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+  font: 12px var(--font-mono);
+  color: var(--text-mute);
+}
+.host-page .host-chrome .dots {
+  display: flex;
+  gap: 5px;
+}
+.host-page .host-chrome .dots i {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--border-strong);
+  display: block;
+}
+.host-page .host-chrome .url {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 8px;
+  color: var(--text-dim);
+  font: 11px var(--font-mono);
+}
+.host-page h1 {
+  font: 600 18px var(--font-sans);
+  color: var(--text);
+  margin: 0 0 6px;
+}
+.host-page p {
+  font: 13px/1.5 var(--font-sans);
+  color: var(--text-mute);
+  margin: 0 0 14px;
+}
+.host-page p strong {
+  color: var(--text-dim);
+}
+
+/* embed component itself */
+.embed-comp {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--surface);
+  display: grid;
+  grid-template-columns: 130px 1fr 1fr;
+  grid-template-rows: auto 1fr auto;
+  font: 12px var(--font-sans);
+  min-height: 280px;
+}
+.embed-comp .embed-bar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+  font: 500 11px var(--font-mono);
+  color: var(--text-dim);
+}
+.embed-comp .embed-bar .t-glyph {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, var(--indigo-500), var(--indigo-600));
+  color: white;
+  display: grid;
+  place-items: center;
+  font: 700 9px var(--font-sans);
+}
+.embed-comp .embed-bar .slug {
+  color: var(--text);
+}
+.embed-comp .embed-bar .spacer {
+  flex: 1;
+}
+.embed-comp .embed-bar a {
+  font: 500 10.5px var(--font-sans);
+  color: var(--text-mute);
+  cursor: pointer;
+  text-decoration: none;
+}
+.embed-comp .embed-bar a:hover {
+  color: var(--text);
+}
+.embed-comp .embed-bar .open {
+  background: var(--accent);
+  color: var(--accent-text);
+  padding: 3px 7px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+.embed-comp .embed-tree {
+  background: var(--surface-2);
+  border-right: 1px solid var(--border);
+  padding: 8px 6px;
+  font: 11px var(--font-mono);
+  color: var(--text-dim);
+  overflow: hidden;
+}
+.embed-comp .embed-tree .node {
+  padding: 2px 6px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.embed-comp .embed-tree .node.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.embed-comp .embed-tree .node.dir {
+  color: var(--text-mute);
+}
+.embed-comp .embed-tree .node.nest {
+  padding-left: 14px;
+}
+.embed-comp .embed-code {
+  padding: 8px 10px;
+  font: 11px/1.55 var(--font-mono);
+  color: var(--text);
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+  background: var(--surface);
+}
+.embed-comp .embed-code .ln {
+  color: var(--text-mute);
+  padding-right: 6px;
+}
+.embed-comp .embed-code .k {
+  color: var(--code-keyword);
+}
+.embed-comp .embed-code .s {
+  color: var(--code-string);
+}
+.embed-comp .embed-code .h {
+  color: var(--code-heading);
+  font-weight: 600;
+}
+.embed-comp .embed-preview-doc {
+  background: var(--surface-2);
+  padding: 12px 14px;
+  font: 11px/1.45 var(--font-serif);
+  color: var(--text);
+  overflow: hidden;
+}
+.embed-comp .embed-preview-doc h1 {
+  font: 600 13px var(--font-serif);
+  margin: 0 0 4px;
+  color: var(--text);
+}
+.embed-comp .embed-preview-doc .meta {
+  font: 9.5px var(--font-mono);
+  color: var(--text-mute);
+  margin-bottom: 8px;
+}
+.embed-comp .embed-preview-doc h2 {
+  font: 600 11.5px var(--font-serif);
+  margin: 8px 0 3px;
+  color: var(--text);
+}
+.embed-comp .embed-preview-doc p {
+  margin: 0 0 5px;
+  color: var(--text-dim);
+}
+.embed-comp .embed-foot {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--surface-2);
+  border-top: 1px solid var(--border);
+  font: 10.5px var(--font-sans);
+  color: var(--text-mute);
+}
+.embed-comp .embed-foot .powered {
+  color: var(--text-mute);
+}
+.embed-comp .embed-foot .spacer {
+  flex: 1;
+}
+.embed-comp .embed-foot .btn {
+  font: 500 10.5px var(--font-sans);
+  padding: 3px 7px;
+  border-radius: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+}
+.embed-comp .embed-foot .btn.primary {
+  background: var(--accent);
+  color: var(--accent-text);
+  border-color: transparent;
+}
+
+/* embed config panel */
+.embed-config {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+.embed-config .cfg-label {
+  font: 500 11px var(--font-sans);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.embed-config .seg-group {
+  display: flex;
+  gap: 3px;
+  padding: 3px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+}
+.embed-config .seg-group .seg {
+  flex: 1;
+  padding: 5px 8px;
+  text-align: center;
+  font: 500 12px var(--font-sans);
+  color: var(--text-mute);
+  border-radius: 5px;
+  cursor: pointer;
+}
+.embed-config .seg-group .seg.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+.embed-config .cfg-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font: 13px var(--font-sans);
+  color: var(--text);
+}
+.embed-config .cfg-toggle .switch {
+  width: 30px;
+  height: 17px;
+  border-radius: 999px;
+  background: var(--border-strong);
+  position: relative;
+  cursor: pointer;
+  transition: background 0.16s;
+  flex-shrink: 0;
+}
+.embed-config .cfg-toggle .switch::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 13px;
+  height: 13px;
+  background: var(--surface);
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+  transition: transform 0.16s;
+}
+.embed-config .cfg-toggle.on .switch {
+  background: var(--accent);
+}
+.embed-config .cfg-toggle.on .switch::after {
+  transform: translateX(13px);
+}
+
+/* code snippet box */
+.snippet-box {
+  margin-top: 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.snippet-box .head {
+  display: flex;
+  align-items: center;
+  padding: 6px 8px 6px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  font: 500 11px var(--font-sans);
+  color: var(--text-mute);
+}
+.snippet-box .head .langs {
+  display: flex;
+  gap: 1px;
+}
+.snippet-box .head .lang {
+  font: 500 11px var(--font-mono);
+  padding: 3px 7px;
+  border-radius: 5px;
+  color: var(--text-mute);
+  cursor: pointer;
+}
+.snippet-box .head .lang.active {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.snippet-box .head .copy {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  font: 500 11.5px var(--font-sans);
+  color: var(--text-dim);
+  cursor: pointer;
+}
+.snippet-box .head .copy:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.snippet-box pre {
+  margin: 0;
+  padding: 12px 14px;
+  font: 12px/1.6 var(--font-mono);
+  color: var(--text);
+  overflow-x: auto;
+}
+.snippet-box pre .tag {
+  color: var(--code-keyword);
+}
+.snippet-box pre .attr {
+  color: var(--code-fn);
+}
+.snippet-box pre .str {
+  color: var(--code-string);
+}
+.snippet-box pre .com {
+  color: var(--code-comment);
+  font-style: italic;
+}
+
+/* ---------- export / PDF tab ---------- */
+.export-hero {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+  background: linear-gradient(135deg, color-mix(in oklab, var(--accent) 5%, var(--surface)) 0%, var(--surface) 70%);
+  border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--border));
+  border-radius: 12px;
+}
+.export-hero .file-thumb {
+  width: 76px;
+  height: 96px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  font: 600 11px var(--font-mono);
+  color: var(--text-mute);
+  position: relative;
+  box-shadow: 0 8px 16px -8px rgba(0, 0, 0, 0.18);
+}
+.export-hero .file-thumb::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 16px;
+  height: 16px;
+  background: var(--surface-2);
+  border-left: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+.export-hero .file-thumb .lines {
+  position: absolute;
+  inset: 26px 12px auto;
+  display: grid;
+  gap: 4px;
+}
+.export-hero .file-thumb .lines i {
+  display: block;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--border-strong);
+}
+.export-hero .file-thumb .lines i:nth-child(2) {
+  width: 70%;
+}
+.export-hero .file-thumb .lines i:nth-child(4) {
+  width: 60%;
+}
+.export-hero .file-thumb .ext {
+  position: absolute;
+  bottom: 6px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font: 700 10px var(--font-mono);
+  letter-spacing: 0.08em;
+  color: var(--accent);
+}
+.export-hero .info .name {
+  font: 600 14px var(--font-mono);
+  color: var(--text);
+}
+.export-hero .info .meta {
+  font: 12px var(--font-sans);
+  color: var(--text-mute);
+  margin-top: 3px;
+}
+.export-hero .info .meta b {
+  color: var(--text-dim);
+  font-weight: 500;
+}
+.export-hero .info .meta .dot {
+  margin: 0 6px;
+  color: var(--text-mute);
+  opacity: 0.6;
+}
+.export-hero .actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.export-hero .actions .primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: var(--accent);
+  color: var(--accent-text);
+  border: 0;
+  border-radius: 8px;
+  font: 600 13px var(--font-sans);
+  cursor: pointer;
+  justify-content: center;
+}
+.export-hero .actions .secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  border-radius: 7px;
+  font: 500 12px var(--font-sans);
+  cursor: pointer;
+  justify-content: center;
+}
+
+/* divider with label "or" */
+.or-sep {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 18px 0 14px;
+  font: 500 11px var(--font-sans);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.or-sep::before,
+.or-sep::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* ---------- footer ---------- */
+.share-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  background: var(--surface-2);
+  border-top: 1px solid var(--border);
+  font: 12px var(--font-sans);
+  color: var(--text-mute);
+}
+.share-foot .learn {
+  color: var(--accent);
+  text-decoration: none;
+  cursor: pointer;
+}
+.share-foot .learn:hover {
+  text-decoration: underline;
+}
+.share-foot .spacer {
+  flex: 1;
+}
+.share-foot .done {
+  padding: 6px 14px;
+  background: var(--text);
+  color: var(--surface);
+  border: 0;
+  border-radius: 7px;
+  font: 600 12.5px var(--font-sans);
+  cursor: pointer;
+}
+.share-foot .done:hover {
+  filter: brightness(1.1);
+}
+
+/* ============================================================
+   Plan gating — restrained, matches existing badge/banner styles
+   ============================================================ */
+.pro-badge {
+  display: inline-flex;
+  align-items: center;
+  font: 500 9.5px var(--font-mono);
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: 999px;
+  text-transform: uppercase;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+.pro-badge.subtle {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+
+/* Upgrade banner — clean, no gradients */
+.upgrade-banner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 14px;
+  background: var(--accent-soft);
+  border: 1px solid color-mix(in oklab, var(--accent) 22%, transparent);
+  border-radius: 10px;
+}
+.upgrade-banner.compact {
+  padding: 8px 12px;
+}
+.upgrade-banner .ic {
+  width: 28px;
+  height: 28px;
+  background: var(--surface);
+  border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border));
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+}
+.upgrade-banner.compact .ic {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+}
+.upgrade-banner .meta .h {
+  font: 600 13px var(--font-sans);
+  color: var(--text);
+}
+.upgrade-banner .meta .d {
+  font: 12px/1.4 var(--font-sans);
+  color: var(--text-dim);
+  margin-top: 1px;
+}
+.upgrade-banner .cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  background: var(--accent);
+  color: var(--accent-text, white);
+  border: 0;
+  border-radius: 7px;
+  font: 600 12px var(--font-sans);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.upgrade-banner .cta:hover {
+  filter: brightness(1.08);
+}
+.upgrade-banner.compact .cta {
+  padding: 5px 10px;
+  font-size: 11.5px;
+}
+
+/* Gated permission card — same shape as others, dashed border (color handled by tone) */
+.perm-card.gated {
+  border-style: dashed;
+}
+.perm-card.gated.active {
+  border-style: solid;
+}
+
+/* ============================================================
+   Permission card tones — subtle visual grouping
+   Each permission gets its own hue: read=info, output=success,
+   write=warning, full=error. Resting state shows only via icon
+   container; active state lights the whole card in tone.
+   ============================================================ */
+.perm-card.tone-read .ic {
+  background: color-mix(in oklab, var(--sky-500) 14%, transparent);
+  color: var(--sky-500);
+}
+.perm-card.tone-read:hover .ic {
+  background: color-mix(in oklab, var(--sky-500) 18%, transparent);
+}
+.perm-card.tone-read.active {
+  background: color-mix(in oklab, var(--sky-500) 6%, var(--surface));
+  border-color: color-mix(in oklab, var(--sky-500) 50%, var(--border));
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--sky-500) 28%, transparent);
+}
+.perm-card.tone-read.active .ic {
+  background: color-mix(in oklab, var(--sky-500) 18%, transparent);
+  color: var(--sky-500);
+}
+.perm-card.tone-read.active .radio {
+  background: var(--sky-500);
+  border-color: var(--sky-500);
+}
+
+.perm-card.tone-output .ic {
+  background: color-mix(in oklab, var(--green-500) 14%, transparent);
+  color: var(--green-500);
+}
+.perm-card.tone-output:hover .ic {
+  background: color-mix(in oklab, var(--green-500) 18%, transparent);
+}
+.perm-card.tone-output.active {
+  background: color-mix(in oklab, var(--green-500) 6%, var(--surface));
+  border-color: color-mix(in oklab, var(--green-500) 50%, var(--border));
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--green-500) 28%, transparent);
+}
+.perm-card.tone-output.active .ic {
+  background: color-mix(in oklab, var(--green-500) 20%, transparent);
+}
+.perm-card.tone-output.active .radio {
+  background: var(--green-500);
+  border-color: var(--green-500);
+}
+
+.perm-card.tone-write .ic {
+  background: color-mix(in oklab, var(--amber-500) 14%, transparent);
+  color: var(--amber-500);
+}
+.perm-card.tone-write:hover .ic {
+  background: color-mix(in oklab, var(--amber-500) 18%, transparent);
+}
+.perm-card.tone-write.active {
+  background: color-mix(in oklab, var(--amber-500) 6%, var(--surface));
+  border-color: color-mix(in oklab, var(--amber-500) 52%, var(--border));
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--amber-500) 30%, transparent);
+}
+.perm-card.tone-write.active .ic {
+  background: color-mix(in oklab, var(--amber-500) 20%, transparent);
+}
+.perm-card.tone-write.active .radio {
+  background: var(--amber-500);
+  border-color: var(--amber-500);
+}
+
+.perm-card.tone-full .ic {
+  background: color-mix(in oklab, var(--red-500) 12%, transparent);
+  color: var(--red-500);
+}
+.perm-card.tone-full:hover .ic {
+  background: color-mix(in oklab, var(--red-500) 16%, transparent);
+}
+.perm-card.tone-full.active {
+  background: color-mix(in oklab, var(--red-500) 5%, var(--surface));
+  border-color: color-mix(in oklab, var(--red-500) 48%, var(--border));
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--red-500) 28%, transparent);
+}
+.perm-card.tone-full.active .ic {
+  background: color-mix(in oklab, var(--red-500) 18%, transparent);
+}
+.perm-card.tone-full.active .radio {
+  background: var(--red-500);
+  border-color: var(--red-500);
+}
+
+/* Locked section: dim + corner unlock pill */
+.locked-section {
+  position: relative;
+}
+.locked-section > .locked-content {
+  opacity: 0.5;
+  pointer-events: none;
+}
+.locked-section .lock-shield {
+  position: absolute;
+  top: -2px;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  background: var(--surface);
+  border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border));
+  border-radius: 999px;
+  font: 500 11px var(--font-sans);
+  color: var(--accent);
+  cursor: pointer;
+  z-index: 2;
+}
+.locked-section .lock-shield:hover {
+  background: var(--accent);
+  color: var(--accent-text, white);
+  border-color: var(--accent);
+}
+
+/* Stats blurred for free plan */
+.link-stats.locked-stats .stat .v {
+  filter: blur(7px);
+  user-select: none;
+  color: var(--text-mute);
+}
+.link-stats.locked-stats .stat .l {
+  color: var(--text-mute);
+}
+
+/* Locked chip (used in embed components row) */
+.cfg-chip.locked {
+  cursor: not-allowed;
+  background: var(--surface);
+  border-style: dashed;
+  color: var(--text-mute);
+}
+.cfg-chip.locked .check {
+  background: transparent;
+  border-color: var(--border-strong);
+  color: var(--accent);
+}
+.cfg-chip.locked:hover {
+  color: var(--text-dim);
+  border-color: var(--border-strong);
+}
+
+/* Locked option in segmented control */
+.cfg-seg .opt.locked {
+  color: var(--text-mute);
+  cursor: not-allowed;
+  opacity: 0.85;
+}
+.cfg-seg .opt.locked:hover {
+  color: var(--text-mute);
+}
+.cfg-seg .opt.locked .pro-badge {
+  font-size: 8.5px;
+  padding: 1px 4px;
+  margin-left: 4px;
+}

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -23,7 +23,8 @@
    ─────────────────────────────────────────────────────────────────────────── */
 
 .share-shell,
-.share-overlay {
+.share-overlay,
+.share-public {
   --accent: var(--mk-pri);
   --accent-soft: var(--mk-pri-50);
   --accent-text: #fff;
@@ -1664,4 +1665,171 @@
   font-size: 8.5px;
   padding: 1px 4px;
   margin-left: 4px;
+}
+
+/* ── Public share / embed view (/p/:slug, /embed/:token) ─────────────────────
+   Reuses the v3 embed chrome (.embed-comp / .embed-bar / .embed-foot / .t-glyph)
+   defined above, but the body holds the REAL read-only CodeMirror + WASM preview
+   sized to fill the page: a centered framed card on /p/:slug, full-bleed in an
+   iframe (/embed/:token). Token-driven, so light/dark flip for free. */
+.share-public {
+  min-height: 100dvh;
+  background: var(--surface-2);
+  color: var(--text);
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  font-family: var(--font-sans);
+}
+
+/* /p/:slug — centered, framed card */
+.share-public .embed-comp {
+  width: 100%;
+  max-width: 1180px;
+  height: min(86dvh, 920px);
+  min-height: 0;
+  grid-template-columns: 1fr; /* output-only: preview spans full width */
+  box-shadow: var(--mk-sh-lg);
+}
+.share-public .embed-comp.embed-comp--split {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); /* read/full: source | preview */
+}
+
+/* /embed/:token — flush, full-viewport, no outer chrome */
+.share-public--embed {
+  padding: 0;
+}
+.share-public--embed .embed-comp {
+  max-width: none;
+  height: 100dvh;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* top-bar identity + read-only pill */
+.share-public .embed-bar .slug {
+  min-width: 0;
+  font-weight: 600;
+}
+.share-public .embed-bar .file {
+  min-width: 0;
+  color: var(--text-mute);
+}
+.share-public .embed-bar .ro-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font: 600 10px var(--font-sans);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+/* real source + preview panes fill the middle (1fr) grid row */
+.share-public .embed-source,
+.share-public .embed-preview {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.share-public .embed-source {
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+}
+.share-public .embed-preview {
+  background: var(--surface-2);
+}
+.share-public .embed-source > #editor-container,
+.share-public .embed-source .cm-editor {
+  width: 100%;
+  height: 100%;
+}
+.share-public .embed-preview > .ts-preview__scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+.share-public .ts-preview__placeholder {
+  margin: auto;
+  text-align: center;
+  color: var(--text-mute);
+  display: grid;
+  place-items: center;
+  gap: 8px;
+}
+.share-public .ts-preview__placeholder-ic {
+  color: var(--mk-fg4);
+}
+
+/* footer CTA — single "Open in Typster ↗" */
+.share-public .embed-foot .powered {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.share-public .embed-foot__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font: 600 11px var(--font-sans);
+  padding: 4px 11px;
+  border-radius: 6px;
+  background: var(--accent);
+  color: var(--accent-text);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: filter 0.15s var(--mk-ease, ease);
+}
+.share-public .embed-foot__cta:hover {
+  filter: brightness(1.07);
+}
+
+/* invalid / expired link panel */
+.share-public--invalid {
+  place-items: center;
+}
+.share-public__panel {
+  max-width: 380px;
+  text-align: center;
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  padding: 32px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: var(--mk-sh-md);
+}
+.share-public__panel h1 {
+  font: 600 18px var(--font-sans);
+  color: var(--text);
+  margin: 4px 0 0;
+}
+.share-public__panel p {
+  font-size: 13px;
+  color: var(--text-mute);
+  margin: 0 0 8px;
+}
+.t-glyph--lg {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--indigo-500), var(--indigo-600));
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 26px;
+  line-height: 1;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -9,6 +9,7 @@
 @import "./_typster_ui.css";
 @import "./_editor_topbar.css";
 @import "./_editor_v3.css";
+@import "./_share.css";
 @source "../css";
 @source "../js";
 @source "../../lib/typster_web";

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -54,6 +54,40 @@ test.describe('Product UI redesign', () => {
     await expect(page.locator('#preview-container')).toBeVisible()
   })
 
+  test('redesigned embed view + clickable-but-locked Pro write card', async ({ page }) => {
+    test.setTimeout(120_000)
+    await createProjectAndOpenEditor(page, 'embed-look')
+    await addMainFile(page)
+
+    await page.locator('.ts-tb__share').click()
+    const modal = page.locator('.share-shell')
+    await expect(modal).toBeVisible({ timeout: 5000 })
+
+    // Pro write-scope card is clickable but NOT usable: clicking activates it
+    // and reveals the upsell inline — it never selects a real write scope.
+    const writeCard = modal.locator('.perm-card.tone-write')
+    await expect(writeCard).not.toHaveClass(/\bactive\b/)
+    await writeCard.click()
+    await expect(writeCard).toHaveClass(/\bactive\b/)
+    await expect(writeCard.locator('.upgrade-banner')).toBeVisible()
+
+    // Pull the link token and open the cross-origin-framable embed view.
+    const path = (await modal.locator('.link-box .path').textContent()).trim()
+    const token = path.match(/key=([\w-]+)/)[1]
+    await page.goto(`/embed/${token}`)
+
+    // Redesigned embed chrome: identity bar, read-only pill, real read-only
+    // source + live preview, and the single footer CTA.
+    await expect(page.locator('.share-public--embed .embed-comp')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.embed-bar .slug')).toContainText('embed-look')
+    await expect(page.locator('.ro-pill')).toBeVisible()
+    await expect(page.locator('.embed-source #editor-container .cm-content')).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page.locator('#preview-container')).toBeVisible()
+    await expect(page.locator('.embed-foot__cta')).toBeVisible()
+  })
+
   test('autocomplete suggests local #let and imported symbols', async ({ page }) => {
     await createProjectAndOpenEditor(page, 'LocalImport E2E')
     await addMainFile(page)

--- a/assets/e2e/redesign.spec.mjs
+++ b/assets/e2e/redesign.spec.mjs
@@ -25,6 +25,35 @@ async function addMainFile(page) {
 }
 
 test.describe('Product UI redesign', () => {
+  test('share modal: real link, invite, and a public read-only view', async ({ page }) => {
+    test.setTimeout(120_000)
+    await createProjectAndOpenEditor(page, 'quarterly-report')
+    await addMainFile(page)
+
+    await page.locator('.ts-tb__share').click()
+    const modal = page.locator('.share-shell')
+    await expect(modal).toBeVisible({ timeout: 5000 })
+
+    // A real, copyable link with a token.
+    const url = (await modal.locator('.link-box .path').textContent()).trim()
+    expect(url).toMatch(/\/p\/quarterly-report\?key=.+/)
+
+    // Pro features are gated.
+    await expect(modal.locator('.perm-card.tone-write.gated .pro-badge')).toBeVisible()
+    await expect(modal.locator('.locked-section .lock-shield')).toBeVisible()
+
+    // Invite a collaborator → they appear in the access list.
+    await modal.locator('.share-tabs .tab').filter({ hasText: 'People' }).click()
+    await modal.locator('input[name="invite[email]"]').fill('newperson@studio.io')
+    await modal.locator('button[type="submit"]').filter({ hasText: 'Send invite' }).click()
+    await expect(modal.locator('.people-list')).toContainText('newperson@studio.io')
+
+    // The link opens a public, read-only view that compiles client-side.
+    await page.goto(url)
+    await expect(page.locator('.share-public')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('#preview-container')).toBeVisible()
+  })
+
   test('autocomplete suggests local #let and imported symbols', async ({ page }) => {
     await createProjectAndOpenEditor(page, 'LocalImport E2E')
     await addMainFile(page)

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -50,6 +50,7 @@ const liveSocket = new LiveSocket("/live", Socket, {
     Palette: Hooks.Palette,
     SlashFocus: Hooks.SlashFocus,
     LucideIcons: Hooks.LucideIcons,
+    Clipboard: Hooks.Clipboard,
     CompileDelay: Hooks.CompileDelay,
     FileTreeDnD: Hooks.FileTreeDnD
   },

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,6 +27,7 @@ import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/typster"
 import topbar from "../vendor/topbar"
 import * as Hooks from "./hooks"
+import { bootEmbed } from "./embed_boot"
 
 // Tag the document with the OS family so shortcut hints can show ⌘ on Apple
 // platforms and Ctrl everywhere else (CSS toggles `.ts-mac` / `.ts-other`).
@@ -61,8 +62,13 @@ topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
 window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
 window.addEventListener("phx:page-loading-stop", () => { topbar.hide(); mkIcons(); })
 
-// connect if there are any LiveViews on the page
-liveSocket.connect()
+// The embed page (/embed/:token) is framed cross-site, where its SameSite=Lax
+// session cookie is blocked — a LiveView socket would never join and the client
+// would reload-loop. Boot it standalone (read-only editor + WASM preview, no
+// socket). Every other page connects LiveView normally.
+if (!bootEmbed()) {
+  liveSocket.connect()
+}
 
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -473,17 +473,25 @@ export function initEditor(container, initialContent, socket, fileId, options = 
     }
   })
 
+  // Editing aids (lint, v3 assists, autocomplete) are skipped in read-only mode
+  // — e.g. a shared/embedded view: just highlighting on a frozen, uneditable doc.
+  const editingExtensions = options.readonly
+    ? [EditorState.readOnly.of(true), EditorView.editable.of(false)]
+    : [
+        lintGutter(),
+        ...editorV3Extensions,
+        autocompletion(
+          language === "typst"
+            ? { override: [(ctx) => typstCompletionSource(ctx, options.project)] }
+            : {}
+        )
+      ]
+
   const state = EditorState.create({
     doc: initialContent || "",
     extensions: [
       basicSetup,
-      lintGutter(),
-      ...editorV3Extensions,
-      autocompletion(
-        language === "typst"
-          ? { override: [(ctx) => typstCompletionSource(ctx, options.project)] }
-          : {}
-      ),
+      ...editingExtensions,
       themeCompartment.of(getThemeExtension()),
       languageCompartment.of(getLanguageExtension(language)),
       ...(language === "typst" ? [typstCloseBrackets, ...typst()] : []),
@@ -500,7 +508,7 @@ export function initEditor(container, initialContent, socket, fileId, options = 
     registerTypstView(editor)
   }
 
-  if (initialContent && language === "typst") {
+  if (initialContent && language === "typst" && !options.readonly) {
     compileTypst(initialContent, options.project || {})
   }
 

--- a/assets/js/embed_boot.js
+++ b/assets/js/embed_boot.js
@@ -1,0 +1,65 @@
+// Standalone bootstrap for the public embed page (/embed/:token).
+//
+// The embed is framed on third-party sites, where the SameSite=Lax session
+// cookie is blocked — so a LiveView socket can never establish and the client
+// would reload-loop. Instead the embed page renders statically and we boot the
+// read-only editor + WASM preview here, directly, with NO socket. Everything it
+// needs (content, language, project sources, theme) is in the DOM dataset.
+
+import { initEditor } from "./editor"
+import { initTypstWorker, compileTypst } from "./typst_worker"
+
+function parseJsonDataset(value, fallback) {
+  if (!value) return fallback
+  try {
+    return JSON.parse(value)
+  } catch (_error) {
+    return fallback
+  }
+}
+
+function editorOptions(el) {
+  return {
+    language: el.dataset.language || "typst",
+    readonly: el.dataset.readonly === "true",
+    project: {
+      sources: parseJsonDataset(el.dataset.projectSources, []),
+      assets: parseJsonDataset(el.dataset.projectAssets, []),
+    },
+  }
+}
+
+// A no-op stand-in for a LiveView hook: the embed has no server to push to, so
+// outline/cursor/compile-stat callbacks simply go nowhere. Rendering (CodeMirror
+// DOM, the compiled SVG) is all client-side and does not need the socket.
+const NOOP_HOOK = { pushEvent() {}, pushEventTo() {}, handleEvent() {}, el: null }
+
+// Returns true when it booted an embed page (so the caller skips liveSocket).
+export function bootEmbed() {
+  if (!document.getElementById("typster-embed")) return false
+
+  const ec = document.getElementById("editor-container")
+  let content = ""
+  let project = { sources: [], assets: [] }
+  let language = "typst"
+
+  if (ec) {
+    content = ec.dataset.content || ""
+    language = ec.dataset.language || "typst"
+    const options = { ...editorOptions(ec), onCursor() {}, onOutline() {} }
+    project = options.project
+    initEditor(ec, content, NOOP_HOOK, ec.dataset.fileId || null, options)
+  }
+
+  // initTypstWorker reads its target from `hook.el`, so the stub must carry the
+  // real preview element (a null `el` would silently drop every rendered frame).
+  const previewEl = document.getElementById("preview-container")
+  if (previewEl) {
+    initTypstWorker({ ...NOOP_HOOK, el: previewEl })
+    if (content && language === "typst") {
+      setTimeout(() => compileTypst(content, project), 100)
+    }
+  }
+
+  return true
+}

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -17,6 +17,7 @@ function parseJsonDataset(value, fallback) {
 function editorOptions(element) {
   return {
     language: element.dataset.language || "typst",
+    readonly: element.dataset.readonly === "true",
     project: {
       sources: parseJsonDataset(element.dataset.projectSources, []),
       assets: parseJsonDataset(element.dataset.projectAssets, [])
@@ -377,6 +378,22 @@ export const PreviewZoom = {
 export const LucideIcons = {
   mounted() { window.mkIcons?.(this.el) },
   updated() { window.mkIcons?.(this.el) }
+}
+
+// Copy `data-clipboard` to the clipboard on click; flashes `.copied` briefly.
+export const Clipboard = {
+  mounted() {
+    this.handler = () => {
+      const text = this.el.dataset.clipboard || ""
+      if (navigator.clipboard) navigator.clipboard.writeText(text).catch(() => {})
+      this.el.classList.add("copied")
+      setTimeout(() => this.el.classList.remove("copied"), 1200)
+    }
+    this.el.addEventListener("click", this.handler)
+  },
+  destroyed() {
+    this.el.removeEventListener("click", this.handler)
+  }
 }
 
 // Persist the auto-recompile debounce (read by editor.js' compileDelay()).

--- a/lib/typster/assets.ex
+++ b/lib/typster/assets.ex
@@ -5,13 +5,16 @@ defmodule Typster.Assets do
 
   import Ecto.Query, warn: false
   alias Typster.Accounts.Scope
-  alias Typster.Repo
   alias Typster.Assets.Asset
+  alias Typster.Repo
+  alias Typster.Sharing.Collaborator
 
   def get_asset!(%Scope{user: user}, id) do
     from(a in Asset,
       join: p in assoc(a, :project),
-      where: a.id == ^id and p.user_id == ^user.id
+      left_join: c in Collaborator,
+      on: c.project_id == p.id and c.user_id == ^user.id and c.status == :accepted,
+      where: a.id == ^id and (p.user_id == ^user.id or not is_nil(c.id))
     )
     |> Repo.one!()
   end
@@ -19,13 +22,15 @@ defmodule Typster.Assets do
   def get_asset(%Scope{user: user}, id) do
     from(a in Asset,
       join: p in assoc(a, :project),
-      where: a.id == ^id and p.user_id == ^user.id
+      left_join: c in Collaborator,
+      on: c.project_id == p.id and c.user_id == ^user.id and c.status == :accepted,
+      where: a.id == ^id and (p.user_id == ^user.id or not is_nil(c.id))
     )
     |> Repo.one()
   end
 
   def upload_asset(%Scope{} = scope, project_id, object_key, attrs) do
-    _project = Typster.Projects.get_project!(scope, project_id)
+    _project = Typster.Projects.get_editable_project!(scope, project_id)
 
     %Asset{project_id: project_id, inserted_at: DateTime.utc_now(:second)}
     |> Asset.changeset(
@@ -77,7 +82,7 @@ defmodule Typster.Assets do
   end
 
   def list_assets(%Scope{} = scope, project_id) do
-    _project = Typster.Projects.get_project!(scope, project_id)
+    _project = Typster.Projects.get_editable_project!(scope, project_id)
 
     from(a in Asset,
       where: a.project_id == ^project_id,

--- a/lib/typster/files.ex
+++ b/lib/typster/files.ex
@@ -5,8 +5,9 @@ defmodule Typster.Files do
 
   import Ecto.Query, warn: false
   alias Typster.Accounts.Scope
-  alias Typster.Repo
   alias Typster.Projects.File
+  alias Typster.Repo
+  alias Typster.Sharing.Collaborator
 
   @editable_extensions ~w(.typ .bib .md .yaml .yml .tex .latex .sty .cls .csv .tsv)
   @asset_extensions ~w(.pdf .png .jpg .jpeg .svg .webp .ttf .otf .woff .woff2)
@@ -14,7 +15,9 @@ defmodule Typster.Files do
   def get_file!(%Scope{user: user}, id) do
     from(f in File,
       join: p in assoc(f, :project),
-      where: f.id == ^id and p.user_id == ^user.id
+      left_join: c in Collaborator,
+      on: c.project_id == p.id and c.user_id == ^user.id and c.status == :accepted,
+      where: f.id == ^id and (p.user_id == ^user.id or not is_nil(c.id))
     )
     |> Repo.one!()
   end
@@ -22,13 +25,15 @@ defmodule Typster.Files do
   def get_file(%Scope{user: user}, id) do
     from(f in File,
       join: p in assoc(f, :project),
-      where: f.id == ^id and p.user_id == ^user.id
+      left_join: c in Collaborator,
+      on: c.project_id == p.id and c.user_id == ^user.id and c.status == :accepted,
+      where: f.id == ^id and (p.user_id == ^user.id or not is_nil(c.id))
     )
     |> Repo.one()
   end
 
   def create_file(%Scope{} = scope, project_id, attrs \\ %{}) do
-    _project = Typster.Projects.get_project!(scope, project_id)
+    _project = Typster.Projects.get_editable_project!(scope, project_id)
 
     %File{project_id: project_id}
     |> File.changeset(attrs)
@@ -65,7 +70,7 @@ defmodule Typster.Files do
   end
 
   def get_file_tree(%Scope{} = scope, project_id) do
-    _project = Typster.Projects.get_project!(scope, project_id)
+    _project = Typster.Projects.get_editable_project!(scope, project_id)
 
     from(f in File,
       where: f.project_id == ^project_id,

--- a/lib/typster/projects.ex
+++ b/lib/typster/projects.ex
@@ -7,20 +7,30 @@ defmodule Typster.Projects do
   alias Typster.Accounts.Scope
   alias Typster.Repo
   alias Typster.Projects.Project
+  alias Typster.Sharing.Collaborator
 
   def list_projects(%Scope{user: user}) do
-    from(p in Project, where: p.user_id == ^user.id, order_by: [desc: p.inserted_at])
+    from(p in Project,
+      left_join: c in Collaborator,
+      on: c.project_id == p.id and c.user_id == ^user.id and c.status == :accepted,
+      where: p.user_id == ^user.id or not is_nil(c.id),
+      distinct: true,
+      order_by: [desc: p.inserted_at]
+    )
     |> Repo.all()
   end
 
   @doc """
-  Returns a map of `%{project_id => file_count}` for the scope's projects.
+  Returns a map of `%{project_id => file_count}` for every project the scope
+  can reach — owned or shared as an accepted collaborator.
   """
   def file_counts(%Scope{user: user}) do
     from(f in Typster.Projects.File,
       join: p in Project,
       on: f.project_id == p.id,
-      where: p.user_id == ^user.id,
+      left_join: c in Collaborator,
+      on: c.project_id == p.id and c.user_id == ^user.id and c.status == :accepted,
+      where: p.user_id == ^user.id or not is_nil(c.id),
       group_by: f.project_id,
       select: {f.project_id, count(f.id)}
     )
@@ -37,6 +47,36 @@ defmodule Typster.Projects do
     from(p in Project, where: p.id == ^id and p.user_id == ^user.id)
     |> Repo.one()
   end
+
+  @doc """
+  Like `get_project!/2` but also grants access to accepted collaborators, not
+  just the owner. Use this for **content** access (opening the editor, reading
+  and writing files/assets). Project lifecycle (update/delete) and all sharing
+  management stay owner-only via `get_project!/2`.
+  """
+  def get_editable_project!(%Scope{user: user}, id) do
+    editable_query(user, id) |> Repo.one!()
+  end
+
+  @doc "Non-raising variant of `get_editable_project!/2`."
+  def get_editable_project(%Scope{user: user}, id) do
+    editable_query(user, id) |> Repo.one()
+  end
+
+  defp editable_query(user, id) do
+    from(p in Project,
+      left_join: c in Collaborator,
+      on: c.project_id == p.id and c.user_id == ^user.id and c.status == :accepted,
+      where: p.id == ^id and (p.user_id == ^user.id or not is_nil(c.id))
+    )
+  end
+
+  @doc """
+  Returns true when the scope's user owns the project, false for collaborators
+  or strangers. Drives owner-only UI affordances (sharing management, delete).
+  """
+  def owner?(%Scope{user: %{id: user_id}}, %Project{user_id: user_id}), do: true
+  def owner?(_scope, _project), do: false
 
   def create_project(%Scope{user: user}, attrs \\ %{}) do
     %Project{user_id: user.id}

--- a/lib/typster/projects/project.ex
+++ b/lib/typster/projects/project.ex
@@ -6,6 +6,8 @@ defmodule Typster.Projects.Project do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
+  @type t :: %__MODULE__{}
+
   schema "projects" do
     field :name, :string
     belongs_to :user, Typster.Accounts.User

--- a/lib/typster/sharing.ex
+++ b/lib/typster/sharing.ex
@@ -162,6 +162,42 @@ defmodule Typster.Sharing do
     Collaborator.changeset(collaborator, attrs)
   end
 
+  @doc """
+  PUBLIC (bearer): accepts a pending invite for the authenticated user.
+
+  The invite `id` is the bearer credential — the invitee is not the project
+  owner, so authorization is the unguessable id itself, not project ownership.
+  Links the collaborator row to the current user and marks it `:accepted`.
+
+  Idempotent: re-accepting an already-accepted invite is a no-op success.
+  Returns `{:ok, collaborator}` with the project preloaded, or
+  `{:error, :not_found}` when the id is malformed or no invite exists.
+  """
+  def accept_invite(%Scope{user: %{id: user_id}}, invite_id) when is_binary(invite_id) do
+    case fetch_collaborator(invite_id) do
+      nil ->
+        {:error, :not_found}
+
+      %Collaborator{} = collaborator ->
+        collaborator
+        |> Collaborator.accept_changeset(user_id)
+        |> Repo.update()
+        |> case do
+          {:ok, accepted} -> {:ok, Repo.preload(accepted, :project)}
+          {:error, _changeset} = error -> error
+        end
+    end
+  end
+
+  def accept_invite(_scope, _invite_id), do: {:error, :not_found}
+
+  defp fetch_collaborator(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, uuid} -> Repo.get(Collaborator, uuid)
+      :error -> nil
+    end
+  end
+
   ## Internal
 
   defp deliver_invite_quietly(%Collaborator{} = collaborator, project) do

--- a/lib/typster/sharing.ex
+++ b/lib/typster/sharing.ex
@@ -1,0 +1,175 @@
+defmodule Typster.Sharing do
+  @moduledoc """
+  The Sharing context: public share links and project collaborators.
+
+  Owner-management functions take a `%Scope{}` first and authorize against the
+  project owner via `Projects.get_project!/2` (which raises for projects the
+  scope's user does not own). Public token resolution does **not** take a scope.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Typster.Accounts.Scope
+  alias Typster.Projects
+  alias Typster.Repo
+  alias Typster.Sharing.Collaborator
+  alias Typster.Sharing.Notifier
+  alias Typster.Sharing.ShareLink
+
+  ## Share links
+
+  @doc """
+  Returns the project's share link, creating one with a fresh token and the
+  default `:read` scope if none exists yet. Authorizes via the project owner.
+  """
+  def get_or_create_link(%Scope{} = scope, project_id) do
+    project = Projects.get_project!(scope, project_id)
+
+    case Repo.get_by(ShareLink, project_id: project.id) do
+      nil ->
+        %ShareLink{project_id: project.id, token: ShareLink.gen_token(), scope: :read}
+        |> Repo.insert!()
+
+      %ShareLink{} = link ->
+        link
+    end
+  end
+
+  @doc """
+  Updates an existing link's `:scope` and/or `:allow_download`. Authorizes the
+  link's project against the scope owner before updating.
+  """
+  def update_link(%Scope{} = scope, %ShareLink{} = link, attrs) do
+    _project = Projects.get_project!(scope, link.project_id)
+
+    link
+    |> ShareLink.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Rotates the link's token, invalidating the previous one. Authorizes via owner.
+  """
+  def rotate_link(%Scope{} = scope, %ShareLink{} = link) do
+    _project = Projects.get_project!(scope, link.project_id)
+
+    link
+    |> Ecto.Changeset.change(token: ShareLink.gen_token())
+    |> Repo.update()
+  end
+
+  @doc """
+  PUBLIC: resolves a share link by its token, preloading the project.
+
+  Returns `nil` for a blank or unknown token. Takes no scope by design.
+  """
+  def get_link_by_token(token) when is_binary(token) do
+    case String.trim(token) do
+      "" ->
+        nil
+
+      trimmed ->
+        ShareLink
+        |> where([l], l.token == ^trimmed)
+        |> preload(:project)
+        |> Repo.one()
+    end
+  end
+
+  def get_link_by_token(_token), do: nil
+
+  @doc """
+  Returns a changeset for a share link, for use in forms.
+  """
+  def change_link(%ShareLink{} = link, attrs \\ %{}) do
+    ShareLink.changeset(link, attrs)
+  end
+
+  @doc """
+  PUBLIC: the source files of a share link's project, path-ordered.
+
+  Takes no scope — the link itself is the authorization. Used to render the
+  read-only shared/embedded view (and feed the client-side Typst compiler).
+  """
+  def files_for_link(%ShareLink{project_id: project_id}) do
+    Typster.Projects.File
+    |> where([f], f.project_id == ^project_id)
+    |> order_by([f], asc: f.path)
+    |> Repo.all()
+  end
+
+  ## Collaborators
+
+  @doc """
+  Lists a project's collaborators, oldest first. Authorizes via the owner.
+  """
+  def list_collaborators(%Scope{} = scope, project_id) do
+    project = Projects.get_project!(scope, project_id)
+
+    Collaborator
+    |> where([c], c.project_id == ^project.id)
+    |> order_by([c], asc: c.inserted_at)
+    |> Repo.all()
+  end
+
+  @doc """
+  Invites a collaborator by email with the given role (default `:viewer`).
+
+  Inserts a `:pending` collaborator, then delivers an invite email. Delivery
+  failures are swallowed so a transient mailer error never fails the invite.
+  """
+  def invite_collaborator(%Scope{} = scope, project_id, email, role \\ :viewer) do
+    project = Projects.get_project!(scope, project_id)
+
+    result =
+      %Collaborator{project_id: project.id, status: :pending}
+      |> Collaborator.changeset(%{email: email, role: role})
+      |> Repo.insert()
+
+    case result do
+      {:ok, collaborator} ->
+        deliver_invite_quietly(collaborator, project)
+        {:ok, collaborator}
+
+      {:error, _changeset} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Updates a collaborator's role. Authorizes via the collaborator's project.
+  """
+  def update_collaborator_role(%Scope{} = scope, %Collaborator{} = collaborator, role) do
+    _project = Projects.get_project!(scope, collaborator.project_id)
+
+    collaborator
+    |> Collaborator.changeset(%{role: role})
+    |> Repo.update()
+  end
+
+  @doc """
+  Removes a collaborator. Authorizes via the collaborator's project.
+  """
+  def remove_collaborator(%Scope{} = scope, %Collaborator{} = collaborator) do
+    _project = Projects.get_project!(scope, collaborator.project_id)
+    Repo.delete(collaborator)
+  end
+
+  @doc """
+  Returns a changeset for a collaborator, for use in forms.
+  """
+  def change_collaborator(%Collaborator{} = collaborator, attrs \\ %{}) do
+    Collaborator.changeset(collaborator, attrs)
+  end
+
+  ## Internal
+
+  defp deliver_invite_quietly(%Collaborator{} = collaborator, project) do
+    url = "#{TypsterWeb.Endpoint.url()}/invites/#{collaborator.id}"
+    Notifier.deliver_collaborator_invite(collaborator.email, project.name, url)
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+end

--- a/lib/typster/sharing/collaborator.ex
+++ b/lib/typster/sharing/collaborator.ex
@@ -52,4 +52,14 @@ defmodule Typster.Sharing.Collaborator do
       message: "is already a collaborator on this project"
     )
   end
+
+  @doc """
+  Changeset that links a pending invite to a user account and marks it accepted.
+
+  `user_id` and `status` are set programmatically here (never via user params),
+  which is why they are excluded from `changeset/2`'s `cast/3`.
+  """
+  def accept_changeset(collaborator, user_id) do
+    change(collaborator, user_id: user_id, status: :accepted)
+  end
 end

--- a/lib/typster/sharing/collaborator.ex
+++ b/lib/typster/sharing/collaborator.ex
@@ -1,0 +1,55 @@
+defmodule Typster.Sharing.Collaborator do
+  @moduledoc """
+  A collaborator invited to a project by email.
+
+  `project_id` and `status` are set programmatically; only `email` and `role`
+  are user-editable. `user_id` is linked when the invitee has an account.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{
+          id: binary() | nil,
+          email: String.t() | nil,
+          role: :owner | :editor | :viewer,
+          status: :pending | :accepted,
+          project_id: binary() | nil,
+          user_id: binary() | nil,
+          project: Typster.Projects.Project.t() | Ecto.Association.NotLoaded.t() | nil,
+          user: Typster.Accounts.User.t() | Ecto.Association.NotLoaded.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  schema "collaborators" do
+    field :email, :string
+    field :role, Ecto.Enum, values: [:owner, :editor, :viewer], default: :viewer
+    field :status, Ecto.Enum, values: [:pending, :accepted], default: :pending
+    belongs_to :project, Typster.Projects.Project
+    belongs_to :user, Typster.Accounts.User
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Changeset for inviting or editing a collaborator.
+
+  `project_id`, `status`, and `user_id` are set programmatically and excluded
+  from `cast/3`.
+  """
+  def changeset(collaborator, attrs) do
+    collaborator
+    |> cast(attrs, [:email, :role])
+    |> validate_required([:email])
+    |> validate_format(:email, ~r/^[^@,;\s]+@[^@,;\s]+$/,
+      message: "must have the @ sign and no spaces"
+    )
+    |> validate_length(:email, max: 160)
+    |> unique_constraint([:project_id, :email],
+      name: :collaborators_project_id_email_index,
+      message: "is already a collaborator on this project"
+    )
+  end
+end

--- a/lib/typster/sharing/notifier.ex
+++ b/lib/typster/sharing/notifier.ex
@@ -1,0 +1,47 @@
+defmodule Typster.Sharing.Notifier do
+  @moduledoc """
+  Outbound email notifications for project sharing and collaboration invites.
+  """
+
+  import Swoosh.Email
+
+  alias Typster.Mailer
+
+  # Delivers the email using the application mailer.
+  defp deliver(recipient, subject, body) do
+    email =
+      new()
+      |> to(recipient)
+      |> from({"Typster", "contact@example.com"})
+      |> subject(subject)
+      |> text_body(body)
+
+    with {:ok, _metadata} <- Mailer.deliver(email) do
+      {:ok, email}
+    end
+  end
+
+  @doc """
+  Deliver a collaboration invite to the given email for the named project.
+
+  The `url` is a placeholder link the invitee can follow to accept.
+  """
+  def deliver_collaborator_invite(email, project_name, url) do
+    deliver(email, "You've been invited to collaborate on #{project_name}", """
+
+    ==============================
+
+    Hi #{email},
+
+    You've been invited to collaborate on the project "#{project_name}".
+
+    Accept the invitation by visiting the URL below:
+
+    #{url}
+
+    If you weren't expecting this invitation, please ignore this email.
+
+    ==============================
+    """)
+  end
+end

--- a/lib/typster/sharing/share_link.ex
+++ b/lib/typster/sharing/share_link.ex
@@ -1,0 +1,64 @@
+defmodule Typster.Sharing.ShareLink do
+  @moduledoc """
+  A public share link for a project.
+
+  One link exists per project. The `token` and `project_id` are set
+  programmatically (never cast from user params); only `scope` and
+  `allow_download` are user-editable.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{
+          id: binary() | nil,
+          token: String.t() | nil,
+          scope: :read | :output | :full,
+          allow_download: boolean(),
+          project_id: binary() | nil,
+          project: Typster.Projects.Project.t() | Ecto.Association.NotLoaded.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  schema "share_links" do
+    field :token, :string
+    field :scope, Ecto.Enum, values: [:read, :output, :full], default: :read
+    field :allow_download, :boolean, default: true
+    belongs_to :project, Typster.Projects.Project
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Changeset for user-editable link settings.
+
+  `token` and `project_id` are intentionally excluded from `cast/3` and must be
+  set programmatically by the context.
+  """
+  def changeset(share_link, attrs) do
+    share_link
+    |> cast(attrs, [:scope, :allow_download])
+    |> validate_required([:scope, :allow_download])
+  end
+
+  @doc """
+  Returns a fresh url-safe token formatted as three dashed 4-character groups,
+  e.g. `"k3f9-7m2x-w8q1"`.
+  """
+  def gen_token, do: do_gen_token()
+
+  defp do_gen_token do
+    :crypto.strong_rand_bytes(9)
+    |> Base.url_encode64(padding: false)
+    |> binary_part(0, 12)
+    |> String.downcase()
+    |> String.replace(["-", "_"], "x")
+    |> group_in_fours()
+  end
+
+  defp group_in_fours(<<a::binary-size(4), b::binary-size(4), c::binary-size(4)>>) do
+    "#{a}-#{b}-#{c}"
+  end
+end

--- a/lib/typster_web/controllers/invite_controller.ex
+++ b/lib/typster_web/controllers/invite_controller.ex
@@ -1,0 +1,27 @@
+defmodule TypsterWeb.InviteController do
+  @moduledoc """
+  Accepts a collaboration invite delivered by email at `/invites/:id`.
+
+  The route lives behind `:require_authenticated_user`, so an unregistered
+  invitee is bounced to log-in/registration first (the plug stashes this path
+  as `:user_return_to`) and lands back here authenticated, where the invite is
+  linked to their freshly created account.
+  """
+  use TypsterWeb, :controller
+
+  alias Typster.Sharing
+
+  def show(conn, %{"id" => id}) do
+    case Sharing.accept_invite(conn.assigns.current_scope, id) do
+      {:ok, collaborator} ->
+        conn
+        |> put_flash(:info, gettext("share.invite.accepted"))
+        |> redirect(to: ~p"/projects/#{collaborator.project_id}/edit")
+
+      {:error, :not_found} ->
+        conn
+        |> put_flash(:error, gettext("share.invite.invalid"))
+        |> redirect(to: ~p"/projects")
+    end
+  end
+end

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -64,6 +64,8 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:share_tab, "link")
      |> assign(:share_link, nil)
      |> assign(:share_write_preview, false)
+     |> assign(:embed_cfg, default_embed_cfg())
+     |> assign(:embed_lang, "iframe")
      |> assign(:share_collaborators, [])
      |> assign(:invite_form, to_form(%{"email" => "", "role" => "editor"}, as: :invite))
      |> stream(:outline, [])
@@ -242,6 +244,8 @@ defmodule TypsterWeb.EditorLive.Index do
      socket
      |> load_share()
      |> assign(:share_write_preview, false)
+     |> assign(:embed_cfg, default_embed_cfg())
+     |> assign(:embed_lang, "iframe")
      |> assign(:show_share, true)}
   end
 
@@ -298,6 +302,44 @@ defmodule TypsterWeb.EditorLive.Index do
       nil -> {:noreply, socket}
       link -> {:noreply, update_share_link(socket, %{allow_download: !link.allow_download})}
     end
+  end
+
+  # ── Embed tab configurator ──────────────────────────────────────────────────
+  # Toggle a boolean component chip. `editable`/`unbranded` are Pro-only; clicks
+  # are ignored on Free (the chip renders locked with a PRO badge).
+  @impl true
+  def handle_event("embed_toggle", %{"key" => key}, socket)
+      when key in ~w(tree preview editable unbranded) do
+    pro? = Features.pro?(socket.assigns.current_scope)
+    locked? = key in ~w(editable unbranded) and not pro?
+
+    cfg =
+      if locked? do
+        socket.assigns.embed_cfg
+      else
+        Map.update!(socket.assigns.embed_cfg, String.to_existing_atom(key), &(!&1))
+      end
+
+    {:noreply, assign(socket, :embed_cfg, cfg)}
+  end
+
+  # Pick a value in a segmented control (Save CTA / Theme / Width). The `on-edit`
+  # Save-CTA mode is Pro-only.
+  def handle_event("embed_set", %{"key" => key, "val" => val}, socket)
+      when key in ~w(cta theme width) do
+    pro? = Features.pro?(socket.assigns.current_scope)
+    locked? = key == "cta" and val == "on-edit" and not pro?
+
+    cfg =
+      if locked?,
+        do: socket.assigns.embed_cfg,
+        else: Map.put(socket.assigns.embed_cfg, String.to_existing_atom(key), val)
+
+    {:noreply, assign(socket, :embed_cfg, cfg)}
+  end
+
+  def handle_event("embed_lang", %{"lang" => lang}, socket) when lang in ~w(iframe react npm) do
+    {:noreply, assign(socket, :embed_lang, lang)}
   end
 
   @impl true
@@ -1032,13 +1074,52 @@ defmodule TypsterWeb.EditorLive.Index do
   defp collab_status(%{status: :pending}), do: gettext("share.people.invite_sent")
   defp collab_status(%{role: role}), do: role_label(role)
 
-  defp embed_iframe(%{token: token}) do
-    src = url(~p"/embed/#{token}")
+  # Default embed configurator state (mirrors the v3 EmbedTab prototype).
+  defp default_embed_cfg do
+    %{
+      tree: true,
+      preview: true,
+      editable: false,
+      unbranded: false,
+      cta: "always",
+      theme: "auto",
+      width: "responsive"
+    }
+  end
 
+  # Build the embed URL with the configurator's options encoded as query params.
+  defp embed_src(%{token: token}, entry, cfg) do
+    query =
+      [
+        entry && "file=#{entry.path}",
+        "theme=#{cfg.theme}",
+        !cfg.tree && "tree=0",
+        !cfg.preview && "preview=0",
+        cfg.editable && "editable=1"
+      ]
+      |> Enum.filter(& &1)
+      |> Enum.join("&")
+
+    "#{url(~p"/embed/#{token}")}?#{query}"
+  end
+
+  defp embed_src(_link, _entry, _cfg), do: ""
+
+  defp embed_width_value(%{width: "responsive"}), do: "100%"
+  defp embed_width_value(%{width: w}), do: w
+
+  # The copyable snippet for the active language tab. The React and npm packages
+  # aren't shipped yet, so those tabs show a playful "coming soon" placeholder
+  # instead of a snippet that wouldn't work.
+  defp embed_snippet(_link, _entry, _cfg, lang) when lang in ~w(react npm) do
+    gettext("share.embed.coming_soon")
+  end
+
+  defp embed_snippet(link, entry, cfg, _iframe) do
     """
     <iframe
-      src="#{src}"
-      width="100%"
+      src="#{embed_src(link, entry, cfg)}"
+      width="#{embed_width_value(cfg)}"
       height="540"
       loading="lazy"
       allow="clipboard-write"
@@ -1046,7 +1127,23 @@ defmodule TypsterWeb.EditorLive.Index do
     """
   end
 
-  defp embed_iframe(_link), do: ""
+  # CSS grid columns for the live-preview comp, honoring the tree/preview toggles.
+  defp embed_preview_cols(cfg) do
+    tree = if cfg.tree, do: "130px ", else: ""
+    prev = if cfg.preview, do: " 1fr", else: ""
+    "grid-template-columns: #{tree}1fr#{prev};"
+  end
+
+  # First `n` source lines of the entry file, for the read-only preview pane.
+  defp embed_preview_lines(%{content: content}, n) when is_binary(content) do
+    content
+    |> String.split("\n")
+    |> Enum.take(n)
+    |> Enum.with_index(1)
+    |> Enum.map(fn {text, i} -> {i, text} end)
+  end
+
+  defp embed_preview_lines(_entry, _n), do: [{1, ""}]
 
   # ── Share modal function components ─────────────────────────────────────────
   attr :scope, :string, required: true
@@ -1103,6 +1200,117 @@ defmodule TypsterWeb.EditorLive.Index do
         <div :if={@sub} class="d">{@sub}</div>
       </div>
       <div class="switch"></div>
+    </div>
+    """
+  end
+
+  attr :key, :string, required: true
+  attr :label, :string, required: true
+  attr :on, :boolean, default: false
+  attr :locked, :boolean, default: false
+
+  # A toggle chip in the embed Components group. Locked chips are Pro-gated.
+  defp cfg_chip(assigns) do
+    ~H"""
+    <div
+      class={["cfg-chip", (@on and !@locked) && "on", @locked && "locked"]}
+      phx-click="embed_toggle"
+      phx-value-key={@key}
+    >
+      <span class="check">
+        <.icon :if={@locked} name="hero-lock-closed" class="size-3" />
+        <.icon :if={!@locked and @on} name="hero-check-solid" class="size-3.5" />
+      </span>
+      {@label}<span :if={@locked} class="pro-badge">PRO</span>
+    </div>
+    """
+  end
+
+  attr :key, :string, required: true
+  attr :value, :string, required: true
+  attr :opts, :list, required: true
+
+  # A segmented control (Save CTA / Theme / Width). Options may be Pro-locked.
+  defp cfg_seg(assigns) do
+    ~H"""
+    <div class="cfg-seg">
+      <div
+        :for={o <- @opts}
+        class={["opt", (@value == o.v and !o[:locked]) && "active", o[:locked] && "locked"]}
+        phx-click="embed_set"
+        phx-value-key={@key}
+        phx-value-val={o.v}
+      >
+        {o.label}<span :if={o[:locked]} class="pro-badge">PRO</span>
+      </div>
+    </div>
+    """
+  end
+
+  attr :cfg, :map, required: true
+  attr :project, :map, required: true
+  attr :entry, :map, default: nil
+  attr :sources, :list, default: []
+  attr :pro, :boolean, default: false
+
+  # The "Live preview" — a representative embed rendered inside a fake host page,
+  # driven by the configurator (tree/preview/editable/unbranded/theme/width).
+  defp embed_preview(assigns) do
+    assigns =
+      assign(assigns, :sandbox?, assigns.cfg.editable and assigns.pro)
+      |> assign(:branded?, !(assigns.cfg.unbranded and assigns.pro))
+
+    ~H"""
+    <div class="host-page" data-theme={if(@cfg.theme in ~w(light dark), do: @cfg.theme)}>
+      <div class="host-chrome">
+        <div class="dots"><i></i><i></i><i></i></div>
+        <span class="url">{gettext("share.embed.host_example")}</span>
+      </div>
+
+      <div class="embed-comp" style={embed_preview_cols(@cfg)}>
+        <div class="embed-bar">
+          <span class="t-glyph ts-serif">T</span>
+          <span class="slug">{@project.name}</span>
+          <span :if={@entry} style="color: var(--text-mute)">· {@entry.path}</span>
+          <span class="spacer"></span>
+          <span :if={@sandbox?} class="sandbox-pill">
+            <span class="pulse"></span>{gettext("share.embed.sandbox")}
+          </span>
+          <span :if={!@sandbox?} style="font: 500 10.5px var(--font-sans); color: var(--text-mute)">
+            {gettext("share.embed.readonly")}
+          </span>
+        </div>
+
+        <div :if={@cfg.tree} class="embed-tree">
+          <div class="node dir">▾ {@project.name}</div>
+          <div
+            :for={src <- Enum.take(@sources, 5)}
+            class={["node", "nest", @entry && src.path == @entry.path && "active"]}
+          >
+            {src.path}
+          </div>
+        </div>
+
+        <div class="embed-code">
+          <div :for={{n, text} <- embed_preview_lines(@entry, 11)}>
+            <span class="ln">{n}</span>{text}
+          </div>
+        </div>
+
+        <div :if={@cfg.preview} class="embed-preview-doc">
+          <h1>{@project.name}</h1>
+          <div class="meta">{gettext("share.embed.sample_meta")}</div>
+          <p>{gettext("share.embed.sample_body")}</p>
+        </div>
+
+        <div class="embed-foot">
+          <span :if={@branded?} class="powered">
+            {gettext("share.public.powered_by")} <strong style="color: var(--text)">Typster</strong>
+          </span>
+          <span class="spacer"></span>
+          <span class="btn primary">{gettext("share.public.open_in_typster")} ↗</span>
+        </div>
+      </div>
     </div>
     """
   end

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -1127,24 +1127,6 @@ defmodule TypsterWeb.EditorLive.Index do
     """
   end
 
-  # CSS grid columns for the live-preview comp, honoring the tree/preview toggles.
-  defp embed_preview_cols(cfg) do
-    tree = if cfg.tree, do: "130px ", else: ""
-    prev = if cfg.preview, do: " 1fr", else: ""
-    "grid-template-columns: #{tree}1fr#{prev};"
-  end
-
-  # First `n` source lines of the entry file, for the read-only preview pane.
-  defp embed_preview_lines(%{content: content}, n) when is_binary(content) do
-    content
-    |> String.split("\n")
-    |> Enum.take(n)
-    |> Enum.with_index(1)
-    |> Enum.map(fn {text, i} -> {i, text} end)
-  end
-
-  defp embed_preview_lines(_entry, _n), do: [{1, ""}]
-
   # ── Share modal function components ─────────────────────────────────────────
   attr :scope, :string, required: true
   attr :tone, :string, required: true
@@ -1242,74 +1224,6 @@ defmodule TypsterWeb.EditorLive.Index do
         phx-value-val={o.v}
       >
         {o.label}<span :if={o[:locked]} class="pro-badge">PRO</span>
-      </div>
-    </div>
-    """
-  end
-
-  attr :cfg, :map, required: true
-  attr :project, :map, required: true
-  attr :entry, :map, default: nil
-  attr :sources, :list, default: []
-  attr :pro, :boolean, default: false
-
-  # The "Live preview" — a representative embed rendered inside a fake host page,
-  # driven by the configurator (tree/preview/editable/unbranded/theme/width).
-  defp embed_preview(assigns) do
-    assigns =
-      assign(assigns, :sandbox?, assigns.cfg.editable and assigns.pro)
-      |> assign(:branded?, !(assigns.cfg.unbranded and assigns.pro))
-
-    ~H"""
-    <div class="host-page" data-theme={if(@cfg.theme in ~w(light dark), do: @cfg.theme)}>
-      <div class="host-chrome">
-        <div class="dots"><i></i><i></i><i></i></div>
-        <span class="url">{gettext("share.embed.host_example")}</span>
-      </div>
-
-      <div class="embed-comp" style={embed_preview_cols(@cfg)}>
-        <div class="embed-bar">
-          <span class="t-glyph ts-serif">T</span>
-          <span class="slug">{@project.name}</span>
-          <span :if={@entry} style="color: var(--text-mute)">· {@entry.path}</span>
-          <span class="spacer"></span>
-          <span :if={@sandbox?} class="sandbox-pill">
-            <span class="pulse"></span>{gettext("share.embed.sandbox")}
-          </span>
-          <span :if={!@sandbox?} style="font: 500 10.5px var(--font-sans); color: var(--text-mute)">
-            {gettext("share.embed.readonly")}
-          </span>
-        </div>
-
-        <div :if={@cfg.tree} class="embed-tree">
-          <div class="node dir">▾ {@project.name}</div>
-          <div
-            :for={src <- Enum.take(@sources, 5)}
-            class={["node", "nest", @entry && src.path == @entry.path && "active"]}
-          >
-            {src.path}
-          </div>
-        </div>
-
-        <div class="embed-code">
-          <div :for={{n, text} <- embed_preview_lines(@entry, 11)}>
-            <span class="ln">{n}</span>{text}
-          </div>
-        </div>
-
-        <div :if={@cfg.preview} class="embed-preview-doc">
-          <h1>{@project.name}</h1>
-          <div class="meta">{gettext("share.embed.sample_meta")}</div>
-          <p>{gettext("share.embed.sample_body")}</p>
-        </div>
-
-        <div class="embed-foot">
-          <span :if={@branded?} class="powered">
-            {gettext("share.public.powered_by")} <strong style="color: var(--text)">Typster</strong>
-          </span>
-          <span class="spacer"></span>
-          <span class="btn primary">{gettext("share.public.open_in_typster")} ↗</span>
-        </div>
       </div>
     </div>
     """

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -63,6 +63,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:show_share, false)
      |> assign(:share_tab, "link")
      |> assign(:share_link, nil)
+     |> assign(:share_write_preview, false)
      |> assign(:share_collaborators, [])
      |> assign(:invite_form, to_form(%{"email" => "", "role" => "editor"}, as: :invite))
      |> stream(:outline, [])
@@ -233,7 +234,11 @@ defmodule TypsterWeb.EditorLive.Index do
 
   @impl true
   def handle_event("open_share", _params, %{assigns: %{owner?: true}} = socket) do
-    {:noreply, socket |> load_share() |> assign(:show_share, true)}
+    {:noreply,
+     socket
+     |> load_share()
+     |> assign(:share_write_preview, false)
+     |> assign(:show_share, true)}
   end
 
   # Sharing is managed by the owner only; collaborators can edit but not invite.
@@ -253,7 +258,17 @@ defmodule TypsterWeb.EditorLive.Index do
   @impl true
   def handle_event("share_scope", %{"scope" => scope}, socket)
       when scope in ~w(read output full) do
-    {:noreply, update_share_link(socket, %{scope: scope})}
+    {:noreply,
+     socket
+     |> assign(:share_write_preview, false)
+     |> update_share_link(%{scope: scope})}
+  end
+
+  # Pro "per-file write scope". The card is clickable so visitors can preview the
+  # capability, but on Free it only reveals the upsell — it never changes the
+  # link's real scope (which stays read/output/full). Pro swaps in the file picker.
+  def handle_event("share_scope", %{"scope" => "write"}, socket) do
+    {:noreply, assign(socket, :share_write_preview, true)}
   end
 
   def handle_event("share_scope", _params, socket), do: {:noreply, socket}

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -103,6 +103,10 @@ defmodule TypsterWeb.EditorLive.Index do
      assign(socket, :collaborators, present_collaborators(scope, socket.assigns.project.id))}
   end
 
+  # Ignore stray process messages (e.g. the Swoosh test adapter's {:email, _}
+  # delivered to this process when an invite is sent) so they never crash the LV.
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
   @impl true
   def handle_event("save_started", _params, socket) do
     {:noreply, assign(socket, :save_status, "saving")}
@@ -1031,7 +1035,15 @@ defmodule TypsterWeb.EditorLive.Index do
   defp embed_iframe(%{token: token}) do
     src = url(~p"/embed/#{token}")
 
-    ~s(<iframe src="#{src}" width="100%" height="540" loading="lazy" allow="clipboard-write"></iframe>)
+    """
+    <iframe
+      src="#{src}"
+      width="100%"
+      height="540"
+      loading="lazy"
+      allow="clipboard-write"
+    ></iframe>\
+    """
   end
 
   defp embed_iframe(_link), do: ""

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -2,10 +2,15 @@ defmodule TypsterWeb.EditorLive.Index do
   use TypsterWeb, :live_view
 
   alias Typster.Assets
+  alias Typster.Features
   alias Typster.Files
   alias Typster.Projects
   alias Typster.Revisions
+  alias Typster.Sharing
   alias Typster.Templates
+
+  # Stable avatar colours for the share People list (hashed from the email).
+  @collab_palette ~w(#6366f1 #8b5cf6 #0ea5e9 #10b981 #f43f5e #f59e0b)
 
   @impl true
   def mount(%{"id" => project_id}, _session, socket) do
@@ -54,6 +59,11 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:collapsed_dirs, MapSet.new())
      |> assign(:show_palette, false)
      |> assign(:palette_query, "")
+     |> assign(:show_share, false)
+     |> assign(:share_tab, "link")
+     |> assign(:share_link, nil)
+     |> assign(:share_collaborators, [])
+     |> assign(:invite_form, to_form(%{"email" => "", "role" => "editor"}, as: :invite))
      |> stream(:outline, [])
      |> assign(:outline_count, 0)
      |> assign(:page_title, project.name)
@@ -218,6 +228,88 @@ defmodule TypsterWeb.EditorLive.Index do
   @impl true
   def handle_event("filter_palette", %{"value" => query}, socket) do
     {:noreply, assign(socket, :palette_query, query)}
+  end
+
+  @impl true
+  def handle_event("open_share", _params, socket) do
+    {:noreply, socket |> load_share() |> assign(:show_share, true)}
+  end
+
+  @impl true
+  def handle_event("close_share", _params, socket) do
+    {:noreply, assign(socket, :show_share, false)}
+  end
+
+  @impl true
+  def handle_event("share_tab", %{"tab" => tab}, socket)
+      when tab in ~w(people link embed export) do
+    {:noreply, assign(socket, :share_tab, tab)}
+  end
+
+  @impl true
+  def handle_event("share_scope", %{"scope" => scope}, socket)
+      when scope in ~w(read output full) do
+    {:noreply, update_share_link(socket, %{scope: scope})}
+  end
+
+  def handle_event("share_scope", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("share_rotate", _params, socket) do
+    scope = socket.assigns.current_scope
+
+    socket =
+      with link when not is_nil(link) <- socket.assigns.share_link,
+           {:ok, rotated} <- Sharing.rotate_link(scope, link) do
+        assign(socket, :share_link, rotated)
+      else
+        _ -> socket
+      end
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("share_toggle_download", _params, socket) do
+    case socket.assigns.share_link do
+      nil -> {:noreply, socket}
+      link -> {:noreply, update_share_link(socket, %{allow_download: !link.allow_download})}
+    end
+  end
+
+  @impl true
+  def handle_event("share_invite", %{"invite" => %{"email" => email, "role" => role}}, socket) do
+    scope = socket.assigns.current_scope
+    project = socket.assigns.project
+
+    case Sharing.invite_collaborator(scope, project.id, email, invite_role(role)) do
+      {:ok, _collaborator} ->
+        {:noreply,
+         socket
+         |> assign(:share_collaborators, Sharing.list_collaborators(scope, project.id))
+         |> assign(:invite_form, to_form(%{"email" => "", "role" => "editor"}, as: :invite))
+         |> put_flash(:info, gettext("share.flash.invited", email: email))}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, gettext("share.flash.invite_failed"))}
+    end
+  end
+
+  @impl true
+  def handle_event("share_remove_collab", %{"id" => id}, socket) do
+    scope = socket.assigns.current_scope
+    project = socket.assigns.project
+
+    socket =
+      with collab when not is_nil(collab) <-
+             Enum.find(socket.assigns.share_collaborators, &(&1.id == id)),
+           {:ok, _} <- Sharing.remove_collaborator(scope, collab) do
+        assign(socket, :share_collaborators, Sharing.list_collaborators(scope, project.id))
+      else
+        _ -> socket
+      end
+
+    {:noreply, socket}
   end
 
   @impl true
@@ -845,6 +937,143 @@ defmodule TypsterWeb.EditorLive.Index do
 
   defp email_local_parts(email) do
     email |> String.split("@") |> List.first() |> String.split(~r/[._-]/, trim: true)
+  end
+
+  # ── Share modal helpers ─────────────────────────────────────────────────────
+  defp load_share(socket) do
+    scope = socket.assigns.current_scope
+    project = socket.assigns.project
+
+    socket
+    |> assign(:share_link, Sharing.get_or_create_link(scope, project.id))
+    |> assign(:share_collaborators, Sharing.list_collaborators(scope, project.id))
+  end
+
+  defp update_share_link(socket, attrs) do
+    scope = socket.assigns.current_scope
+
+    with link when not is_nil(link) <- socket.assigns.share_link,
+         {:ok, updated} <- Sharing.update_link(scope, link, attrs) do
+      assign(socket, :share_link, updated)
+    else
+      _ -> socket
+    end
+  end
+
+  defp invite_role("owner"), do: :owner
+  defp invite_role("viewer"), do: :viewer
+  defp invite_role(_), do: :editor
+
+  # Full public share URL for the project's link (for display + copy).
+  defp share_url(project, %{token: token}), do: url(~p"/p/#{share_slug(project)}?#{[key: token]}")
+  defp share_url(_project, _link), do: "#"
+
+  defp share_slug(%{name: name}) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
+    |> case do
+      "" -> "project"
+      slug -> slug
+    end
+  end
+
+  # Role label + avatar colour for the People list.
+  defp collab_initials(%{email: email}), do: email |> initials_from(2)
+  defp collab_color(%{email: email}), do: Enum.at(@collab_palette, :erlang.phash2(email, 6))
+
+  defp initials_from(email, take) do
+    email
+    |> String.split("@")
+    |> List.first()
+    |> String.split(~r/[._-]+/, trim: true)
+    |> Enum.map(&String.first/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.take(take)
+    |> Enum.map_join("", &String.upcase/1)
+    |> case do
+      "" -> "?"
+      s -> s
+    end
+  end
+
+  defp plan_label(scope) do
+    if Features.pro?(scope), do: gettext("share.plan.pro"), else: gettext("share.plan.free")
+  end
+
+  defp role_label(:owner), do: gettext("share.role.owner")
+  defp role_label(:viewer), do: gettext("share.role.viewer")
+  defp role_label(_), do: gettext("share.role.editor")
+
+  defp collab_status(%{status: :pending}), do: gettext("share.people.invite_sent")
+  defp collab_status(%{role: role}), do: role_label(role)
+
+  defp embed_iframe(%{token: token}) do
+    src = url(~p"/embed/#{token}")
+
+    ~s(<iframe src="#{src}" width="100%" height="540" loading="lazy" allow="clipboard-write"></iframe>)
+  end
+
+  defp embed_iframe(_link), do: ""
+
+  # ── Share modal function components ─────────────────────────────────────────
+  attr :scope, :string, required: true
+  attr :tone, :string, required: true
+  attr :active, :boolean, default: false
+  attr :icon, :string, required: true
+  attr :badge, :string, default: nil
+  attr :title, :string, required: true
+  attr :desc, :string, required: true
+
+  defp perm_card(assigns) do
+    ~H"""
+    <div
+      class={["perm-card", "tone-#{@tone}", @active && "active"]}
+      phx-click="share_scope"
+      phx-value-scope={@scope}
+    >
+      <div class="ic"><.icon name={@icon} class="size-4" /></div>
+      <div class="body">
+        <div class="h">{@title}<span :if={@badge} class="badge">{@badge}</span></div>
+        <div class="d">{@desc}</div>
+      </div>
+      <div class="radio"></div>
+    </div>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :desc, :string, default: nil
+  attr :compact, :boolean, default: false
+
+  defp upgrade_banner(assigns) do
+    ~H"""
+    <div class={["upgrade-banner", @compact && "compact"]}>
+      <div class="ic"><.icon name="hero-sparkles" class="size-4" /></div>
+      <div class="meta">
+        <div class="h">{@title}</div>
+        <div :if={@desc} class="d">{@desc}</div>
+      </div>
+      <button type="button" class="cta">{gettext("share.upgrade.cta")}</button>
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :sub, :string, default: nil
+  attr :on, :boolean, default: false
+
+  defp toggle_row(assigns) do
+    ~H"""
+    <div class={["toggle-row", @on && "on"]}>
+      <div class="meta">
+        <div class="h">{@label}</div>
+        <div :if={@sub} class="d">{@sub}</div>
+      </div>
+      <div class="switch"></div>
+    </div>
+    """
   end
 
   # Append a file id to the open-tabs list (keeping order, no duplicates).

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -15,7 +15,7 @@ defmodule TypsterWeb.EditorLive.Index do
   @impl true
   def mount(%{"id" => project_id}, _session, socket) do
     scope = socket.assigns.current_scope
-    project = Projects.get_project!(scope, project_id)
+    project = Projects.get_editable_project!(scope, project_id)
     file_tree = Files.get_file_tree(scope, project_id)
     assets = Assets.list_assets(scope, project_id)
     main_file = initial_file(file_tree)
@@ -28,6 +28,7 @@ defmodule TypsterWeb.EditorLive.Index do
     {:ok,
      socket
      |> assign(:project, project)
+     |> assign(:owner?, Projects.owner?(scope, project))
      |> assign(:collaborators, present_collaborators(scope, project.id))
      |> assign(:file_tree, file_tree)
      |> assign(:assets, assets)
@@ -231,9 +232,12 @@ defmodule TypsterWeb.EditorLive.Index do
   end
 
   @impl true
-  def handle_event("open_share", _params, socket) do
+  def handle_event("open_share", _params, %{assigns: %{owner?: true}} = socket) do
     {:noreply, socket |> load_share() |> assign(:show_share, true)}
   end
+
+  # Sharing is managed by the owner only; collaborators can edit but not invite.
+  def handle_event("open_share", _params, socket), do: {:noreply, socket}
 
   @impl true
   def handle_event("close_share", _params, socket) do

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -1182,11 +1182,16 @@
                 title={gettext("share.perm.output")}
                 desc={gettext("share.perm.output_desc")}
               />
-              <div class={[
-                "perm-card",
-                "tone-write",
-                !Features.can?(@current_scope, :share_write_scoped) && "gated"
-              ]}>
+              <div
+                class={[
+                  "perm-card",
+                  "tone-write",
+                  !Features.can?(@current_scope, :share_write_scoped) && "gated",
+                  @share_write_preview && "active"
+                ]}
+                phx-click="share_scope"
+                phx-value-scope="write"
+              >
                 <div class="ic">
                   <.icon
                     name={
@@ -1210,7 +1215,9 @@
                   </div>
                   <div class="d">{gettext("share.perm.write_desc")}</div>
                   <div
-                    :if={!Features.can?(@current_scope, :share_write_scoped)}
+                    :if={
+                      @share_write_preview && !Features.can?(@current_scope, :share_write_scoped)
+                    }
                     style="margin-top: 10px;"
                   >
                     <.upgrade_banner

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -64,6 +64,7 @@
       </button>
 
       <button
+        :if={@owner?}
         type="button"
         class="ts-btn ts-btn--ghost ts-btn--sm ts-tb__share"
         phx-click="open_share"

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -1344,7 +1344,7 @@
                 <.icon name="hero-clipboard-document" class="size-3" /> {gettext("common.copy")}
               </button>
             </div>
-            <pre phx-no-curly-interpolation>{embed_iframe(@share_link)}</pre>
+            <pre>{embed_iframe(@share_link)}</pre>
           </div>
         </div>
 

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -66,8 +66,8 @@
       <button
         type="button"
         class="ts-btn ts-btn--ghost ts-btn--sm ts-tb__share"
-        disabled
-        title={gettext("editor.share_soon")}
+        phx-click="open_share"
+        title={gettext("editor.share")}
       >
         <i data-lucide="upload" aria-hidden="true"></i> {gettext("editor.share")}
       </button>
@@ -996,6 +996,393 @@
         >
           <.icon name="hero-table-cells" class="size-4" />
           <span>{gettext("editor.palette.table")}</span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <%!-- Share modal --%>
+  <div
+    :if={@show_share}
+    class="share-overlay"
+    phx-click="close_share"
+    phx-window-keydown="close_share"
+    phx-key="Escape"
+  >
+    <div class="share-shell" id="share-modal" phx-click="">
+      <div class="share-head">
+        <div>
+          <div class="ttl">
+            {gettext("share.title")} <span class="proj">{@project.name}</span>
+          </div>
+          <div class="sub">{gettext("share.subtitle")}</div>
+        </div>
+        <div style="display: flex; align-items: center; gap: 8px; margin-left: auto;">
+          <span class="pro-badge subtle">{plan_label(@current_scope)}</span>
+          <button
+            type="button"
+            class="x"
+            phx-click="close_share"
+            aria-label={gettext("common.close")}
+          >
+            <.icon name="hero-x-mark" class="size-4" />
+          </button>
+        </div>
+      </div>
+
+      <div class="share-tabs">
+        <button
+          :for={
+            {id, label} <- [
+              {"people", gettext("share.tab.people")},
+              {"link", gettext("share.tab.link")},
+              {"embed", gettext("share.tab.embed")},
+              {"export", gettext("share.tab.export")}
+            ]
+          }
+          type="button"
+          class={["tab", @share_tab == id && "active"]}
+          phx-click="share_tab"
+          phx-value-tab={id}
+        >
+          {label}
+          <span :if={id == "people" and @share_collaborators != []} class="badge">
+            {length(@share_collaborators)}
+          </span>
+        </button>
+      </div>
+
+      <div class="share-body">
+        <%!-- People --%>
+        <div :if={@share_tab == "people"}>
+          <div class="share-section">
+            <div class="label">{gettext("share.people.invite")}</div>
+            <.form
+              for={@invite_form}
+              id="invite-form"
+              phx-submit="share_invite"
+              class="invite-row"
+            >
+              <div class="field">
+                <.icon name="hero-at-symbol" class="size-3.5" />
+                <input
+                  name="invite[email]"
+                  type="email"
+                  value={@invite_form[:email].value}
+                  placeholder={gettext("share.people.add_placeholder")}
+                  autocomplete="off"
+                  required
+                />
+              </div>
+              <select name="invite[role]" class="role-select">
+                <option value="editor">{gettext("share.role.editor")}</option>
+                <option value="viewer">{gettext("share.role.viewer")}</option>
+              </select>
+              <button type="submit" class="ts-btn ts-btn--primary" style="height: 36px;">
+                <.icon name="hero-paper-airplane" class="size-3" /> {gettext("share.people.send")}
+              </button>
+            </.form>
+            <div class="sub-label">{gettext("share.people.invite_hint")}</div>
+          </div>
+
+          <div class="share-section">
+            <div class="label">
+              {gettext("share.people.with_access")} ({length(@share_collaborators) + 1})
+            </div>
+            <div class="people-list">
+              <div class="person-row">
+                <div class="av" style="background: var(--mk-pri);">
+                  {user_initials(@current_scope)}
+                </div>
+                <div class="meta">
+                  <div class="n">
+                    {user_display_name(@current_scope)}
+                    <span class="you">{gettext("share.people.you")}</span>
+                  </div>
+                  <div :if={@current_scope && @current_scope.user} class="e">
+                    {@current_scope.user.email}
+                  </div>
+                </div>
+                <div class="role-select small">{gettext("share.role.owner")}</div>
+              </div>
+              <div :for={c <- @share_collaborators} class="person-row">
+                <div class="av" style={"background: #{collab_color(c)}"}>
+                  {collab_initials(c)}
+                </div>
+                <div class="meta">
+                  <div class="n">{c.email}</div>
+                  <div class="e">{collab_status(c)}</div>
+                </div>
+                <span :if={c.status == :pending} class="pending">
+                  {gettext("share.people.pending")}
+                </span>
+                <button
+                  type="button"
+                  class="role-select small"
+                  phx-click="share_remove_collab"
+                  phx-value-id={c.id}
+                  aria-label={gettext("share.people.remove")}
+                >
+                  <.icon name="hero-trash" class="size-3" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <%!-- Link --%>
+        <div :if={@share_tab == "link"}>
+          <div class="share-section">
+            <div class="label">{gettext("share.link.label")}</div>
+            <div class="link-box">
+              <div class="url">
+                <.icon name="hero-link" class="size-3.5" />
+                <span class="path">{share_url(@project, @share_link)}</span>
+              </div>
+              <button
+                type="button"
+                class="copy"
+                id="share-copy-link"
+                phx-hook="Clipboard"
+                data-clipboard={share_url(@project, @share_link)}
+              >
+                <.icon name="hero-clipboard-document" class="size-3" /> {gettext("common.copy")}
+              </button>
+            </div>
+            <div class="sub-label">
+              {gettext("share.link.rotate_hint")}
+              <button
+                type="button"
+                class="ts-btn ts-btn--ghost ts-btn--sm"
+                phx-click="share_rotate"
+              >
+                <.icon name="hero-arrow-path" class="size-3" /> {gettext("share.link.rotate")}
+              </button>
+            </div>
+          </div>
+
+          <div class="share-section">
+            <div class="label">{gettext("share.link.perm_label")}</div>
+            <div class="perm-cards">
+              <.perm_card
+                scope="read"
+                tone="read"
+                active={@share_link && @share_link.scope == :read}
+                icon="hero-eye"
+                title={gettext("share.perm.read")}
+                desc={gettext("share.perm.read_desc")}
+              />
+              <.perm_card
+                scope="output"
+                tone="output"
+                active={@share_link && @share_link.scope == :output}
+                icon="hero-play"
+                badge={gettext("share.perm.pdf_only")}
+                title={gettext("share.perm.output")}
+                desc={gettext("share.perm.output_desc")}
+              />
+              <div class={[
+                "perm-card",
+                "tone-write",
+                !Features.can?(@current_scope, :share_write_scoped) && "gated"
+              ]}>
+                <div class="ic">
+                  <.icon
+                    name={
+                      if(Features.can?(@current_scope, :share_write_scoped),
+                        do: "hero-pencil-square",
+                        else: "hero-lock-closed"
+                      )
+                    }
+                    class="size-4"
+                  />
+                </div>
+                <div class="body">
+                  <div class="h">
+                    {gettext("share.perm.write")}
+                    <span
+                      :if={!Features.can?(@current_scope, :share_write_scoped)}
+                      class="pro-badge"
+                    >
+                      PRO
+                    </span>
+                  </div>
+                  <div class="d">{gettext("share.perm.write_desc")}</div>
+                  <div
+                    :if={!Features.can?(@current_scope, :share_write_scoped)}
+                    style="margin-top: 10px;"
+                  >
+                    <.upgrade_banner
+                      compact
+                      title={gettext("share.upgrade.write_title")}
+                      desc={gettext("share.upgrade.write_desc")}
+                    />
+                  </div>
+                </div>
+                <div class="radio"></div>
+              </div>
+              <.perm_card
+                scope="full"
+                tone="full"
+                active={@share_link && @share_link.scope == :full}
+                icon="hero-bolt"
+                badge={gettext("share.perm.careful")}
+                title={gettext("share.perm.full")}
+                desc={gettext("share.perm.full_desc")}
+              />
+            </div>
+          </div>
+
+          <div class="share-section">
+            <div class="label">{gettext("share.link.advanced")}</div>
+            <div
+              class={["toggle-row", @share_link && @share_link.allow_download && "on"]}
+              phx-click="share_toggle_download"
+            >
+              <div class="meta">
+                <div class="h">{gettext("share.adv.download")}</div>
+                <div class="d">{gettext("share.adv.download_sub")}</div>
+              </div>
+              <div class="switch"></div>
+            </div>
+            <div :if={!Features.can?(@current_scope, :share_advanced_link)} class="locked-section">
+              <button type="button" class="lock-shield">
+                <.icon name="hero-lock-closed" class="size-3" /> {gettext("share.upgrade.unlock")}
+              </button>
+              <div class="locked-content">
+                <.toggle_row
+                  label={gettext("share.adv.signin")}
+                  sub={gettext("share.adv.signin_sub")}
+                  on
+                />
+                <.toggle_row
+                  label={gettext("share.adv.expires")}
+                  sub={gettext("share.adv.expires_sub")}
+                />
+                <.toggle_row
+                  label={gettext("share.adv.password")}
+                  sub={gettext("share.adv.password_sub")}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div class="share-section">
+            <div class="label">{gettext("share.link.activity")}</div>
+            <div class={[
+              "link-stats",
+              !Features.can?(@current_scope, :share_link_analytics) && "locked-stats"
+            ]}>
+              <div class="stat">
+                <div class="v">—</div>
+                <div class="l">{gettext("share.stats.opens")}</div>
+              </div>
+              <div class="stat">
+                <div class="v">—</div>
+                <div class="l">{gettext("share.stats.editors")}</div>
+              </div>
+              <div class="stat">
+                <div class="v">—</div>
+                <div class="l">{gettext("share.stats.created")}</div>
+              </div>
+            </div>
+            <div
+              :if={!Features.can?(@current_scope, :share_link_analytics)}
+              style="margin-top: 10px;"
+            >
+              <.upgrade_banner
+                compact
+                title={gettext("share.upgrade.stats_title")}
+                desc={gettext("share.upgrade.stats_desc")}
+              />
+            </div>
+          </div>
+        </div>
+
+        <%!-- Embed --%>
+        <div :if={@share_tab == "embed"}>
+          <div :if={!Features.pro?(@current_scope)} class="share-section">
+            <.upgrade_banner
+              compact
+              title={gettext("share.embed.free_title")}
+              desc={gettext("share.embed.free_desc")}
+            />
+          </div>
+          <div class="share-section">
+            <div class="embed-controls">
+              <div class="cfg-group grow">
+                <div class="lbl">{gettext("share.embed.components")}</div>
+                <div class="row">
+                  <div class="cfg-chip on">
+                    <span class="check"><.icon name="hero-check" class="size-3" /></span>
+                    {gettext("share.embed.file_tree")}
+                  </div>
+                  <div class="cfg-chip on">
+                    <span class="check"><.icon name="hero-check" class="size-3" /></span>
+                    {gettext("share.embed.preview")}
+                  </div>
+                  <div class="cfg-chip locked">
+                    <span class="check"><.icon name="hero-lock-closed" class="size-3" /></span>
+                    {gettext("share.embed.editable")}<span class="pro-badge">PRO</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="snippet-box">
+            <div class="head">
+              <div class="langs">
+                <div class="lang active">iframe</div>
+              </div>
+              <button
+                type="button"
+                class="copy"
+                id="embed-copy"
+                phx-hook="Clipboard"
+                data-clipboard={embed_iframe(@share_link)}
+              >
+                <.icon name="hero-clipboard-document" class="size-3" /> {gettext("common.copy")}
+              </button>
+            </div>
+            <pre phx-no-curly-interpolation>{embed_iframe(@share_link)}</pre>
+          </div>
+        </div>
+
+        <%!-- Export --%>
+        <div :if={@share_tab == "export"}>
+          <div class="share-section">
+            <div class="label">{gettext("share.export.label")}</div>
+            <div class="export-hero">
+              <div class="file-thumb">
+                <div class="lines"><i></i><i></i><i></i><i></i><i></i></div>
+                <div class="ext">PDF</div>
+              </div>
+              <div class="info">
+                <div class="name">{share_slug(@project)}.pdf</div>
+                <div class="meta">{gettext("share.export.meta")}</div>
+              </div>
+              <div class="actions">
+                <button
+                  type="button"
+                  class="primary"
+                  phx-click={JS.dispatch("phx:editor-command", detail: %{cmd: "download"})}
+                >
+                  <.icon name="hero-arrow-down-tray" class="size-3.5" /> {gettext(
+                    "share.export.download"
+                  )}
+                </button>
+              </div>
+            </div>
+            <div class="sub-label">{gettext("share.export.hint")}</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="share-foot">
+        <a class="learn">{gettext("share.learn")}</a>
+        <span class="spacer"></span>
+        <button type="button" class="done" phx-click="close_share">
+          {gettext("common.done")}
         </button>
       </div>
     </div>

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -1316,43 +1316,129 @@
               desc={gettext("share.embed.free_desc")}
             />
           </div>
-          <div class="share-section">
-            <div class="embed-controls">
-              <div class="cfg-group grow">
-                <div class="lbl">{gettext("share.embed.components")}</div>
-                <div class="row">
-                  <div class="cfg-chip on">
-                    <span class="check"><.icon name="hero-check" class="size-3" /></span>
-                    {gettext("share.embed.file_tree")}
-                  </div>
-                  <div class="cfg-chip on">
-                    <span class="check"><.icon name="hero-check" class="size-3" /></span>
-                    {gettext("share.embed.preview")}
-                  </div>
-                  <div class="cfg-chip locked">
-                    <span class="check"><.icon name="hero-lock-closed" class="size-3" /></span>
-                    {gettext("share.embed.editable")}<span class="pro-badge">PRO</span>
-                  </div>
-                </div>
+
+          <% pro? = Features.pro?(@current_scope) %>
+
+          <div class="embed-controls">
+            <div class="cfg-group grow">
+              <div class="lbl">{gettext("share.embed.components")}</div>
+              <div class="row">
+                <.cfg_chip
+                  key="tree"
+                  label={gettext("share.embed.file_tree")}
+                  on={@embed_cfg.tree}
+                />
+                <.cfg_chip
+                  key="preview"
+                  label={gettext("share.embed.preview")}
+                  on={@embed_cfg.preview}
+                />
+                <.cfg_chip
+                  key="editable"
+                  label={gettext("share.embed.editable")}
+                  on={@embed_cfg.editable}
+                  locked={!pro?}
+                />
+                <.cfg_chip
+                  key="unbranded"
+                  label={gettext("share.embed.hide_footer")}
+                  on={@embed_cfg.unbranded}
+                  locked={!pro?}
+                />
+              </div>
+            </div>
+            <div class="cfg-group">
+              <div class="lbl">{gettext("share.embed.save_cta")}</div>
+              <div class="row">
+                <.cfg_seg
+                  key="cta"
+                  value={@embed_cfg.cta}
+                  opts={[
+                    %{v: "always", label: gettext("share.embed.cta_always")},
+                    %{v: "on-edit", label: gettext("share.embed.cta_onedit"), locked: !pro?},
+                    %{v: "never", label: gettext("share.embed.cta_hidden")}
+                  ]}
+                />
+              </div>
+            </div>
+            <div class="cfg-group">
+              <div class="lbl">{gettext("share.embed.theme")}</div>
+              <div class="row">
+                <.cfg_seg
+                  key="theme"
+                  value={@embed_cfg.theme}
+                  opts={[
+                    %{v: "auto", label: gettext("share.embed.theme_auto")},
+                    %{v: "light", label: gettext("share.embed.theme_light")},
+                    %{v: "dark", label: gettext("share.embed.theme_dark")}
+                  ]}
+                />
+              </div>
+            </div>
+            <div class="cfg-group">
+              <div class="lbl">{gettext("share.embed.width")}</div>
+              <div class="row">
+                <.cfg_seg
+                  key="width"
+                  value={@embed_cfg.width}
+                  opts={[
+                    %{v: "responsive", label: "100%"},
+                    %{v: "640", label: "640"},
+                    %{v: "800", label: "800"}
+                  ]}
+                />
               </div>
             </div>
           </div>
+
+          <div class="embed-preview-wrap">
+            <span class="preview-tag">{gettext("share.embed.live_preview")}</span>
+            <div
+              class="embed-width-frame"
+              style={"max-width: #{if(@embed_cfg.width == "responsive", do: "none", else: @embed_cfg.width <> "px")}"}
+            >
+              <.embed_preview
+                cfg={@embed_cfg}
+                project={@project}
+                entry={@current_file}
+                sources={@project_sources}
+                pro={pro?}
+              />
+            </div>
+          </div>
+
           <div class="snippet-box">
             <div class="head">
               <div class="langs">
-                <div class="lang active">iframe</div>
+                <div
+                  :for={lang <- ~w(iframe react npm)}
+                  class={[
+                    "lang",
+                    @embed_lang == lang && "active",
+                    lang != "iframe" && "lang--soon"
+                  ]}
+                  phx-click="embed_lang"
+                  phx-value-lang={lang}
+                >
+                  {if(lang == "react", do: "React", else: lang)}<span
+                    :if={lang != "iframe"}
+                    class="lang-soon"
+                  >soon</span>
+                </div>
               </div>
               <button
                 type="button"
                 class="copy"
                 id="embed-copy"
                 phx-hook="Clipboard"
-                data-clipboard={embed_iframe(@share_link)}
+                data-clipboard={
+                  embed_snippet(@share_link, @current_file, @embed_cfg, @embed_lang)
+                }
               >
                 <.icon name="hero-clipboard-document" class="size-3" /> {gettext("common.copy")}
               </button>
             </div>
-            <pre>{embed_iframe(@share_link)}</pre>
+            <pre>{embed_snippet(@share_link, @current_file, @embed_cfg, @embed_lang)}</pre>
           </div>
         </div>
 

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -1397,13 +1397,16 @@
               class="embed-width-frame"
               style={"max-width: #{if(@embed_cfg.width == "responsive", do: "none", else: @embed_cfg.width <> "px")}"}
             >
-              <.embed_preview
-                cfg={@embed_cfg}
-                project={@project}
-                entry={@current_file}
-                sources={@project_sources}
-                pro={pro?}
-              />
+              <%!-- A real, live iframe of the embed: real highlight, real compiled
+                    PDF and real theme — exactly what visitors will see. --%>
+              <iframe
+                class="embed-live-frame"
+                src={embed_src(@share_link, @current_file, @embed_cfg)}
+                title={gettext("share.embed.live_preview")}
+                loading="lazy"
+                allow="clipboard-write"
+              >
+              </iframe>
             </div>
           </div>
 

--- a/lib/typster_web/live/project_live/show.ex
+++ b/lib/typster_web/live/project_live/show.ex
@@ -8,7 +8,7 @@ defmodule TypsterWeb.ProjectLive.Show do
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     scope = socket.assigns.current_scope
-    project = Projects.get_project!(scope, id)
+    project = Projects.get_editable_project!(scope, id)
     file_tree = Files.get_file_tree(scope, id)
     assets = Assets.list_assets(scope, id)
 
@@ -24,7 +24,7 @@ defmodule TypsterWeb.ProjectLive.Show do
     {:noreply,
      socket
      |> assign(:page_title, socket.assigns.project.name)
-     |> assign(:project, Projects.get_project!(socket.assigns.current_scope, id))}
+     |> assign(:project, Projects.get_editable_project!(socket.assigns.current_scope, id))}
   end
 
   @impl true

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -45,9 +45,9 @@ defmodule TypsterWeb.SharedProjectLive do
   @impl true
   def render(%{link: nil} = assigns) do
     ~H"""
-    <div class="mk-body share-public share-public--invalid">
+    <div class="mk-body share-public share-public--invalid" data-theme-scope>
       <div class="share-public__panel">
-        <div class="ts-emptystate__tile ts-serif">T</div>
+        <div class="t-glyph t-glyph--lg ts-serif">T</div>
         <h1>{gettext("share.public.invalid_title")}</h1>
         <p>{gettext("share.public.invalid_sub")}</p>
         <a href={~p"/"} class="ts-btn ts-btn--primary ts-btn--sm">{gettext("share.public.home")}</a>
@@ -59,36 +59,34 @@ defmodule TypsterWeb.SharedProjectLive do
   def render(assigns) do
     ~H"""
     <div class={["mk-body", "share-public", @embed? && "share-public--embed"]} data-theme-scope>
-      <header class="share-public__bar">
-        <span class="ts-tb__proj-glyph ts-serif">T</span>
-        <span class="share-public__name truncate">{@project.name}</span>
-        <span :if={@entry} class="share-public__file">· {@entry.path}</span>
-        <span class="share-public__pill">{scope_label(@scope_kind)}</span>
-        <div class="ts-spacer" />
-        <.link navigate={~p"/projects/#{@project.id}/edit"} class="ts-btn ts-btn--primary ts-btn--sm">
-          {gettext("share.public.open_in_typster")}
-        </.link>
-      </header>
+      <div class={["embed-comp", show_source?(@scope_kind) && "embed-comp--split"]}>
+        <div class="embed-bar">
+          <span class="t-glyph ts-serif">T</span>
+          <span class="slug truncate">{@project.name}</span>
+          <span :if={@entry} class="file truncate">· {@entry.path}</span>
+          <span class="spacer"></span>
+          <span class="ro-pill">
+            <.icon name="hero-eye" class="size-3" /> {scope_label(@scope_kind)}
+          </span>
+        </div>
 
-      <div class={["share-public__body", show_source?(@scope_kind) && "with-source"]}>
-        <section :if={show_source?(@scope_kind)} class="share-public__source">
+        <section :if={show_source?(@scope_kind)} class="embed-source">
           <div
             id="editor-container"
             phx-hook="CodeMirror"
             phx-update="ignore"
             data-content={@content}
-            data-file-id=""
+            data-file-id={@entry && @entry.id}
             data-readonly="true"
             data-language={@language}
             data-project-sources={Jason.encode!(@project_sources)}
             data-project-assets="[]"
-            class="ts-source__editor"
           >
           </div>
         </section>
 
-        <section class="share-public__preview">
-          <div :if={!show_source?(@scope_kind)} class="share-public__hidden-src" hidden>
+        <section class="embed-preview">
+          <div :if={!show_source?(@scope_kind)} class="embed-hidden-src" hidden>
             <div
               id="editor-container"
               phx-hook="CodeMirror"
@@ -109,11 +107,21 @@ defmodule TypsterWeb.SharedProjectLive do
             class="ts-preview__scroll"
           >
             <div id="preview-placeholder" class="ts-preview__placeholder">
-              <span style="color: var(--mk-fg4);"><.icon name="hero-eye" class="size-8" /></span>
+              <span class="ts-preview__placeholder-ic"><.icon name="hero-eye" class="size-8" /></span>
               <p>{gettext("editor.preview_placeholder")}</p>
             </div>
           </div>
         </section>
+
+        <div class="embed-foot">
+          <span class="powered">
+            {gettext("share.public.powered_by")} <strong class="ts-serif">Typster</strong>
+          </span>
+          <span class="spacer"></span>
+          <.link navigate={~p"/projects/#{@project.id}/edit"} class="embed-foot__cta">
+            {gettext("share.public.open_in_typster")} <span aria-hidden="true">↗</span>
+          </.link>
+        </div>
       </div>
     </div>
     """

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -119,6 +119,14 @@ defmodule TypsterWeb.SharedProjectLive do
     """
   end
 
+  # The public/embed view reuses the editor's client hooks (CodeMirror, Preview),
+  # which push compile/outline/save events back to the LiveView. This view is
+  # read-only and compiles entirely client-side, so there is no server state to
+  # update — we accept and ignore them. Without this clause, the first
+  # `update_preview` push would crash the LiveView (undefined handle_event/3).
+  @impl true
+  def handle_event(_event, _params, socket), do: {:noreply, socket}
+
   # ── helpers ──────────────────────────────────────────────────────────────
   defp show_source?(:output), do: false
   defp show_source?(_), do: true

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -1,0 +1,146 @@
+defmodule TypsterWeb.SharedProjectLive do
+  @moduledoc """
+  Public, read-only view of a project shared via a link (`/p/:slug?key=…`) or
+  embedded (`/embed/:token`). No authentication: the link token is the
+  authorization. The document is compiled client-side in the visitor's browser
+  (the same WASM worker the editor uses), so nothing is rendered server-side.
+
+  Link `scope` decides what is shown:
+
+    * `:read` / `:full` — the entry source (read-only) plus the live preview
+    * `:output`         — the compiled preview only (source hidden)
+  """
+  use TypsterWeb, :live_view
+
+  alias Typster.Files
+  alias Typster.Sharing
+
+  @impl true
+  def mount(params, _session, socket) do
+    token = params["token"] || params["key"]
+
+    case Sharing.get_link_by_token(token) do
+      nil ->
+        {:ok,
+         assign(socket, link: nil, project: nil, page_title: gettext("share.public.invalid"))}
+
+      link ->
+        files = Sharing.files_for_link(link)
+        entry = entry_file(files)
+
+        {:ok,
+         socket
+         |> assign(:link, link)
+         |> assign(:project, link.project)
+         |> assign(:scope_kind, link.scope)
+         |> assign(:embed?, socket.assigns.live_action == :embed)
+         |> assign(:entry, entry)
+         |> assign(:content, (entry && entry.content) || "")
+         |> assign(:language, entry_language(entry))
+         |> assign(:project_sources, project_sources(files))
+         |> assign(:page_title, link.project.name)}
+    end
+  end
+
+  @impl true
+  def render(%{link: nil} = assigns) do
+    ~H"""
+    <div class="mk-body share-public share-public--invalid">
+      <div class="share-public__panel">
+        <div class="ts-emptystate__tile ts-serif">T</div>
+        <h1>{gettext("share.public.invalid_title")}</h1>
+        <p>{gettext("share.public.invalid_sub")}</p>
+        <a href={~p"/"} class="ts-btn ts-btn--primary ts-btn--sm">{gettext("share.public.home")}</a>
+      </div>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class={["mk-body", "share-public", @embed? && "share-public--embed"]} data-theme-scope>
+      <header class="share-public__bar">
+        <span class="ts-tb__proj-glyph ts-serif">T</span>
+        <span class="share-public__name truncate">{@project.name}</span>
+        <span :if={@entry} class="share-public__file">· {@entry.path}</span>
+        <span class="share-public__pill">{scope_label(@scope_kind)}</span>
+        <div class="ts-spacer" />
+        <.link navigate={~p"/projects/#{@project.id}/edit"} class="ts-btn ts-btn--primary ts-btn--sm">
+          {gettext("share.public.open_in_typster")}
+        </.link>
+      </header>
+
+      <div class={["share-public__body", show_source?(@scope_kind) && "with-source"]}>
+        <section :if={show_source?(@scope_kind)} class="share-public__source">
+          <div
+            id="editor-container"
+            phx-hook="CodeMirror"
+            phx-update="ignore"
+            data-content={@content}
+            data-file-id=""
+            data-readonly="true"
+            data-language={@language}
+            data-project-sources={Jason.encode!(@project_sources)}
+            data-project-assets="[]"
+            class="ts-source__editor"
+          >
+          </div>
+        </section>
+
+        <section class="share-public__preview">
+          <div :if={!show_source?(@scope_kind)} class="share-public__hidden-src" hidden>
+            <div
+              id="editor-container"
+              phx-hook="CodeMirror"
+              phx-update="ignore"
+              data-content={@content}
+              data-file-id=""
+              data-readonly="true"
+              data-language={@language}
+              data-project-sources={Jason.encode!(@project_sources)}
+              data-project-assets="[]"
+            >
+            </div>
+          </div>
+          <div
+            id="preview-container"
+            phx-hook="Preview"
+            phx-update="ignore"
+            class="ts-preview__scroll"
+          >
+            <div id="preview-placeholder" class="ts-preview__placeholder">
+              <span style="color: var(--mk-fg4);"><.icon name="hero-eye" class="size-8" /></span>
+              <p>{gettext("editor.preview_placeholder")}</p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    """
+  end
+
+  # ── helpers ──────────────────────────────────────────────────────────────
+  defp show_source?(:output), do: false
+  defp show_source?(_), do: true
+
+  defp scope_label(:output), do: gettext("share.scope.output")
+  defp scope_label(:full), do: gettext("share.scope.full")
+  defp scope_label(_), do: gettext("share.scope.read")
+
+  defp entry_file(files) do
+    Enum.find(files, &(&1.path == "main.typ")) ||
+      Enum.find(files, &(Files.editor_language(&1.path) == "typst")) ||
+      List.first(files)
+  end
+
+  defp entry_language(nil), do: "typst"
+  defp entry_language(%{path: path}), do: Files.editor_language(path)
+
+  defp project_sources(files) do
+    files
+    |> Enum.filter(&Files.editable_file?/1)
+    |> Enum.map(fn f ->
+      %{path: f.path, content: f.content || "", language: Files.editor_language(f.path)}
+    end)
+  end
+end

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -26,7 +26,7 @@ defmodule TypsterWeb.SharedProjectLive do
 
       link ->
         files = Sharing.files_for_link(link)
-        entry = entry_file(files)
+        entry = pick_entry(files, params["file"])
 
         {:ok,
          socket
@@ -34,12 +34,25 @@ defmodule TypsterWeb.SharedProjectLive do
          |> assign(:project, link.project)
          |> assign(:scope_kind, link.scope)
          |> assign(:embed?, socket.assigns.live_action == :embed)
+         |> assign(:embed_theme, embed_theme(params["theme"]))
+         |> assign(:show_preview?, params["preview"] != "0")
          |> assign(:entry, entry)
          |> assign(:content, (entry && entry.content) || "")
          |> assign(:language, entry_language(entry))
          |> assign(:project_sources, project_sources(files))
          |> assign(:page_title, link.project.name)}
     end
+  end
+
+  # The embed honors `?theme=light|dark` (anything else inherits the host theme).
+  defp embed_theme(theme) when theme in ~w(light dark), do: theme
+  defp embed_theme(_), do: nil
+
+  # `?file=path` selects which file the embed opens to; otherwise auto-pick.
+  defp pick_entry(files, nil), do: entry_file(files)
+
+  defp pick_entry(files, path) do
+    Enum.find(files, &(&1.path == path)) || entry_file(files)
   end
 
   @impl true
@@ -58,8 +71,16 @@ defmodule TypsterWeb.SharedProjectLive do
 
   def render(assigns) do
     ~H"""
-    <div class={["mk-body", "share-public", @embed? && "share-public--embed"]} data-theme-scope>
-      <div class={["embed-comp", show_source?(@scope_kind) && "embed-comp--split"]}>
+    <div
+      class={["mk-body", "share-public", @embed? && "share-public--embed"]}
+      id={if(@embed?, do: "typster-embed")}
+      data-theme={@embed_theme}
+      data-theme-scope
+    >
+      <div class={[
+        "embed-comp",
+        (show_source?(@scope_kind) and @show_preview?) && "embed-comp--split"
+      ]}>
         <div class="embed-bar">
           <span class="t-glyph ts-serif">T</span>
           <span class="slug truncate">{@project.name}</span>
@@ -85,7 +106,7 @@ defmodule TypsterWeb.SharedProjectLive do
           </div>
         </section>
 
-        <section class="embed-preview">
+        <section :if={@show_preview?} class="embed-preview">
           <div :if={!show_source?(@scope_kind)} class="embed-hidden-src" hidden>
             <div
               id="editor-container"
@@ -119,7 +140,7 @@ defmodule TypsterWeb.SharedProjectLive do
           </span>
           <span class="spacer"></span>
           <.link navigate={~p"/projects/#{@project.id}/edit"} class="embed-foot__cta">
-            {gettext("share.public.open_in_typster")} <span aria-hidden="true">↗</span>
+            {gettext("share.public.open_in_typster")}
           </.link>
         </div>
       </div>

--- a/lib/typster_web/router.ex
+++ b/lib/typster_web/router.ex
@@ -107,6 +107,11 @@ defmodule TypsterWeb.Router do
     end
 
     post "/users/update-password", UserSessionController, :update_password
+
+    # Collaboration invite acceptance. Behind :require_authenticated_user so an
+    # unregistered invitee is sent to log-in/registration first, then returned
+    # here (via :user_return_to) to link the invite to their account.
+    get "/invites/:id", InviteController, :show
   end
 
   scope "/", TypsterWeb do

--- a/lib/typster_web/router.ex
+++ b/lib/typster_web/router.ex
@@ -9,13 +9,11 @@ defmodule TypsterWeb.Router do
     conn
   end
 
-  # Default browser hardening, but with `frame-ancestors *` so the embed can be
-  # iframed from any origin. `put_secure_browser_headers/2` merges the given map
-  # over its secure defaults, so only the CSP directive changes.
-  defp put_embeddable_browser_headers(conn, _opts) do
-    put_secure_browser_headers(conn, %{
-      "content-security-policy" => "base-uri 'self'; frame-ancestors *"
-    })
+  # The embed is meant to be iframed by any origin, so relax just the CSP
+  # `frame-ancestors` directive that `put_secure_browser_headers` pins to 'self'.
+  # All other secure browser headers (set by that plug above) stay in place.
+  defp allow_cross_origin_framing(conn, _opts) do
+    put_resp_header(conn, "content-security-policy", "base-uri 'self'; frame-ancestors *")
   end
 
   pipeline :browser do
@@ -39,7 +37,8 @@ defmodule TypsterWeb.Router do
     plug :fetch_live_flash
     plug :put_root_layout, html: {TypsterWeb.Layouts, :root}
     plug :protect_from_forgery
-    plug :put_embeddable_browser_headers
+    plug :put_secure_browser_headers
+    plug :allow_cross_origin_framing
     plug :fetch_current_scope_for_user
     plug :set_locale
   end

--- a/lib/typster_web/router.ex
+++ b/lib/typster_web/router.ex
@@ -120,6 +120,10 @@ defmodule TypsterWeb.Router do
       live "/users/register", UserLive.Registration, :new
       live "/users/log-in", UserLive.Login, :new
       live "/users/log-in/:token", UserLive.Confirmation, :new
+
+      # Public, read-only shared/embedded project views (the link token authorizes).
+      live "/p/:slug", SharedProjectLive, :show
+      live "/embed/:token", SharedProjectLive, :embed
     end
 
     post "/users/log-in", UserSessionController, :create

--- a/lib/typster_web/router.ex
+++ b/lib/typster_web/router.ex
@@ -9,6 +9,15 @@ defmodule TypsterWeb.Router do
     conn
   end
 
+  # Default browser hardening, but with `frame-ancestors *` so the embed can be
+  # iframed from any origin. `put_secure_browser_headers/2` merges the given map
+  # over its secure defaults, so only the CSP directive changes.
+  defp put_embeddable_browser_headers(conn, _opts) do
+    put_secure_browser_headers(conn, %{
+      "content-security-policy" => "base-uri 'self'; frame-ancestors *"
+    })
+  end
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -16,6 +25,21 @@ defmodule TypsterWeb.Router do
     plug :put_root_layout, html: {TypsterWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug :fetch_current_scope_for_user
+    plug :set_locale
+  end
+
+  # Like `:browser`, but allows the response to be framed by any origin —
+  # embedding `/embed/:token` on third-party sites is its entire purpose. The
+  # default `put_secure_browser_headers` pins `frame-ancestors 'self'`, which
+  # blocks cross-origin iframes; we override just that directive here.
+  pipeline :embeddable do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {TypsterWeb.Layouts, :root}
+    plug :protect_from_forgery
+    plug :put_embeddable_browser_headers
     plug :fetch_current_scope_for_user
     plug :set_locale
   end
@@ -126,12 +150,25 @@ defmodule TypsterWeb.Router do
       live "/users/log-in", UserLive.Login, :new
       live "/users/log-in/:token", UserLive.Confirmation, :new
 
-      # Public, read-only shared/embedded project views (the link token authorizes).
+      # Public, read-only shared project view (the link token authorizes).
       live "/p/:slug", SharedProjectLive, :show
-      live "/embed/:token", SharedProjectLive, :embed
     end
 
     post "/users/log-in", UserSessionController, :create
     delete "/users/log-out", UserSessionController, :delete
+  end
+
+  # The embed view is identical to the shared view but framable cross-origin, so
+  # it gets the `:embeddable` pipeline and its own `live_session`.
+  scope "/", TypsterWeb do
+    pipe_through [:embeddable]
+
+    live_session :embed,
+      on_mount: [
+        {TypsterWeb.RestoreLocale, :default},
+        {TypsterWeb.UserAuth, :mount_current_scope}
+      ] do
+      live "/embed/:token", SharedProjectLive, :embed
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -86,16 +86,16 @@ defmodule Typster.MixProject do
   end
 
   # Closed-source "Pro" modules live in the private `typster-pro` repo, mounted
-  # here as a git submodule at `pro/` and consumed as a path dependency — but
-  # ONLY when present. A plain public clone (or CI without access) leaves `pro/`
-  # empty, so the dependency is never declared and the open-core build compiles
-  # cleanly under `--warning-as-errors`. Path deps never enter `mix.lock`, so
-  # `deps.unlock --unused` in `precommit` has nothing to strip. The host
-  # dispatches to `Typster.Pro.*` at runtime via `Code.ensure_loaded?/1`
+  # here as a git submodule at `vendor/pro/` and consumed as a path dependency —
+  # but ONLY when present. A plain public clone (or CI without access) leaves
+  # `vendor/pro/` empty, so the dependency is never declared and the open-core
+  # build compiles cleanly under `--warning-as-errors`. Path deps never enter
+  # `mix.lock`, so `deps.unlock --unused` in `precommit` has nothing to strip.
+  # The host dispatches to `Typster.Pro.*` at runtime via `Code.ensure_loaded?/1`
   # (see `Typster.Features`), never at compile time.
   defp pro_deps do
-    if File.exists?("pro/mix.exs") do
-      [{:typster_pro, path: "pro"}]
+    if File.exists?("vendor/pro/mix.exs") do
+      [{:typster_pro, path: "vendor/pro"}]
     else
       []
     end

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Typster.MixProject do
   def application do
     [
       mod: {Typster.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :crypto]
     ]
   end
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -156,29 +156,29 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:639
+#: lib/typster_web/live/editor_live/index.ex:700
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:697
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:340
+#: lib/typster_web/live/editor_live/index.ex:401
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:670
+#: lib/typster_web/live/editor_live/index.ex:731
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:497
-#: lib/typster_web/live/editor_live/index.ex:521
-#: lib/typster_web/live/editor_live/index.ex:813
+#: lib/typster_web/live/editor_live/index.ex:558
+#: lib/typster_web/live/editor_live/index.ex:582
+#: lib/typster_web/live/editor_live/index.ex:874
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:732
-#: lib/typster_web/live/shared_project_live.ex:106
+#: lib/typster_web/live/shared_project_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:747
+#: lib/typster_web/live/editor_live/index.ex:808
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:745
+#: lib/typster_web/live/editor_live/index.ex:806
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:746
+#: lib/typster_web/live/editor_live/index.ex:807
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -2037,9 +2037,9 @@ msgstr ""
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:462
-#: lib/typster_web/live/editor_live/index.ex:508
-#: lib/typster_web/live/editor_live/index.ex:669
+#: lib/typster_web/live/editor_live/index.ex:523
+#: lib/typster_web/live/editor_live/index.ex:569
+#: lib/typster_web/live/editor_live/index.ex:730
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,12 +2049,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:606
+#: lib/typster_web/live/editor_live/index.ex:667
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:575
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:763
+#: lib/typster_web/live/editor_live/index.ex:824
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2145,12 +2145,12 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:814
+#: lib/typster_web/live/editor_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1158
+#: lib/typster_web/live/editor_live/index.ex:1393
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1160
+#: lib/typster_web/live/editor_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1164
+#: lib/typster_web/live/editor_live/index.ex:1399
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2222,12 +2222,12 @@ msgstr ""
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:868
+#: lib/typster_web/live/editor_live/index.ex:929
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:855
+#: lib/typster_web/live/editor_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:940
+#: lib/typster_web/live/editor_live/index.ex:1001
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
@@ -2298,127 +2298,127 @@ msgid "common.close"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1345
+#: lib/typster_web/live/editor_live/index.html.heex:1428
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1386
+#: lib/typster_web/live/editor_live/index.html.heex:1469
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1244
+#: lib/typster_web/live/editor_live/index.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1245
+#: lib/typster_web/live/editor_live/index.html.heex:1252
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1260
+#: lib/typster_web/live/editor_live/index.html.heex:1267
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1261
+#: lib/typster_web/live/editor_live/index.html.heex:1268
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1265
+#: lib/typster_web/live/editor_live/index.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1255
+#: lib/typster_web/live/editor_live/index.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1256
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1324
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1334
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1319
+#: lib/typster_web/live/editor_live/index.html.heex:1326
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1309
+#: lib/typster_web/live/editor_live/index.html.heex:1316
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1315
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1323
+#: lib/typster_web/live/editor_live/index.html.heex:1329
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1454
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1377
+#: lib/typster_web/live/editor_live/index.html.heex:1460
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1355
+#: lib/typster_web/live/editor_live/index.html.heex:1438
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1363
+#: lib/typster_web/live/editor_live/index.html.heex:1446
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:298
+#: lib/typster_web/live/editor_live/index.ex:359
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:295
+#: lib/typster_web/live/editor_live/index.ex:356
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1383
+#: lib/typster_web/live/editor_live/index.html.heex:1466
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1272
+#: lib/typster_web/live/editor_live/index.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr ""
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "share.people.invite_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1013
+#: lib/typster_web/live/editor_live/index.ex:1074
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr ""
@@ -2488,17 +2488,17 @@ msgstr ""
 msgid "share.people.you"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1230
+#: lib/typster_web/live/editor_live/index.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1231
+#: lib/typster_web/live/editor_live/index.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1232
+#: lib/typster_web/live/editor_live/index.html.heex:1239
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr ""
@@ -2528,22 +2528,22 @@ msgstr ""
 msgid "share.perm.read_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1203
+#: lib/typster_web/live/editor_live/index.html.heex:1208
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1211
+#: lib/typster_web/live/editor_live/index.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr ""
@@ -2568,55 +2568,56 @@ msgstr ""
 msgid "share.public.invalid_title"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:117
+#: lib/typster_web/live/editor_live/index.ex:1311
+#: lib/typster_web/live/shared_project_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1011
+#: lib/typster_web/live/editor_live/index.ex:1072
 #: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.ex:1070
 #: lib/typster_web/live/editor_live/index.html.heex:1107
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1010
+#: lib/typster_web/live/editor_live/index.ex:1071
 #: lib/typster_web/live/editor_live/index.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:138
+#: lib/typster_web/live/shared_project_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:137
+#: lib/typster_web/live/shared_project_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:139
+#: lib/typster_web/live/shared_project_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1287
+#: lib/typster_web/live/editor_live/index.html.heex:1294
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1290
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr ""
@@ -2651,32 +2652,32 @@ msgstr ""
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1062
+#: lib/typster_web/live/editor_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1297
+#: lib/typster_web/live/editor_live/index.html.heex:1304
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1296
+#: lib/typster_web/live/editor_live/index.html.heex:1303
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1219
+#: lib/typster_web/live/editor_live/index.html.heex:1226
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1225
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr ""
@@ -2691,7 +2692,93 @@ msgstr ""
 msgid "share.invite.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:113
+#: lib/typster_web/live/editor_live/index.ex:1308
+#: lib/typster_web/live/shared_project_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1353
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_always"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1355
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_hidden"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1354
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_onedit"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1340
+#, elixir-autogen, elixir-format
+msgid "share.embed.hide_footer"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1267
+#, elixir-autogen, elixir-format
+msgid "share.embed.host_example"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1391
+#, elixir-autogen, elixir-format
+msgid "share.embed.live_preview"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1280
+#, elixir-autogen, elixir-format
+msgid "share.embed.readonly"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1303
+#, elixir-autogen, elixir-format
+msgid "share.embed.sample_body"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1302
+#, elixir-autogen, elixir-format
+msgid "share.embed.sample_meta"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1277
+#, elixir-autogen, elixir-format
+msgid "share.embed.sandbox"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1347
+#, elixir-autogen, elixir-format
+msgid "share.embed.save_cta"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1361
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1367
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_auto"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1369
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_dark"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1368
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_light"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1375
+#, elixir-autogen, elixir-format
+msgid "share.embed.width"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1115
+#, elixir-autogen, elixir-format
+msgid "share.embed.coming_soon"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2292,108 +2292,108 @@ msgstr ""
 msgid "editor.status.compile_times"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1022
+#: lib/typster_web/live/editor_live/index.html.heex:1026
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1133
-#: lib/typster_web/live/editor_live/index.html.heex:1303
+#: lib/typster_web/live/editor_live/index.html.heex:1149
+#: lib/typster_web/live/editor_live/index.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1341
+#: lib/typster_web/live/editor_live/index.html.heex:1385
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1217
+#: lib/typster_web/live/editor_live/index.html.heex:1243
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1259
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1227
+#: lib/typster_web/live/editor_live/index.html.heex:1254
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1227
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1275
+#: lib/typster_web/live/editor_live/index.html.heex:1314
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1287
+#: lib/typster_web/live/editor_live/index.html.heex:1326
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1318
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1269
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1268
+#: lib/typster_web/live/editor_live/index.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1322
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1329
+#: lib/typster_web/live/editor_live/index.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1333
+#: lib/typster_web/live/editor_live/index.html.heex:1376
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1313
+#: lib/typster_web/live/editor_live/index.html.heex:1354
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1321
+#: lib/typster_web/live/editor_live/index.html.heex:1362
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr ""
@@ -2408,52 +2408,52 @@ msgstr ""
 msgid "share.flash.invited"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1339
+#: lib/typster_web/live/editor_live/index.html.heex:1382
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1235
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1211
+#: lib/typster_web/live/editor_live/index.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1120
+#: lib/typster_web/live/editor_live/index.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1145
+#: lib/typster_web/live/editor_live/index.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1139
+#: lib/typster_web/live/editor_live/index.html.heex:1159
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1137
+#: lib/typster_web/live/editor_live/index.html.heex:1153
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1062
+#: lib/typster_web/live/editor_live/index.html.heex:1072
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1054
+#: lib/typster_web/live/editor_live/index.html.heex:1059
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1075
+#: lib/typster_web/live/editor_live/index.html.heex:1085
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr ""
@@ -2463,77 +2463,77 @@ msgstr ""
 msgid "share.people.invite_sent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1102
+#: lib/typster_web/live/editor_live/index.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1108
+#: lib/typster_web/live/editor_live/index.html.heex:1124
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1072
+#: lib/typster_web/live/editor_live/index.html.heex:1082
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1080
+#: lib/typster_web/live/editor_live/index.html.heex:1090
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1088
+#: lib/typster_web/live/editor_live/index.html.heex:1100
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1203
+#: lib/typster_web/live/editor_live/index.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1204
+#: lib/typster_web/live/editor_live/index.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1205
+#: lib/typster_web/live/editor_live/index.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1161
+#: lib/typster_web/live/editor_live/index.html.heex:1181
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1162
+#: lib/typster_web/live/editor_live/index.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1180
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1152
+#: lib/typster_web/live/editor_live/index.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1202
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1187
+#: lib/typster_web/live/editor_live/index.html.heex:1210
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr ""
@@ -2574,19 +2574,19 @@ msgid "share.public.open_in_typster"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:1007
-#: lib/typster_web/live/editor_live/index.html.heex:1068
+#: lib/typster_web/live/editor_live/index.html.heex:1078
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:1005
-#: lib/typster_web/live/editor_live/index.html.heex:1094
+#: lib/typster_web/live/editor_live/index.html.heex:1106
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:1006
-#: lib/typster_web/live/editor_live/index.html.heex:1069
+#: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr ""
@@ -2606,17 +2606,17 @@ msgstr ""
 msgid "share.scope.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1246
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1242
+#: lib/typster_web/live/editor_live/index.html.heex:1278
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr ""
@@ -2626,22 +2626,22 @@ msgstr ""
 msgid "share.subtitle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1034
+#: lib/typster_web/live/editor_live/index.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1035
+#: lib/typster_web/live/editor_live/index.html.heex:1040
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1033
+#: lib/typster_web/live/editor_live/index.html.heex:1038
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1032
+#: lib/typster_web/live/editor_live/index.html.heex:1037
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr ""
@@ -2656,27 +2656,37 @@ msgstr ""
 msgid "share.upgrade.cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1257
+#: lib/typster_web/live/editor_live/index.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1256
+#: lib/typster_web/live/editor_live/index.html.heex:1295
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1224
+#: lib/typster_web/live/editor_live/index.html.heex:1250
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1192
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1191
+#: lib/typster_web/live/editor_live/index.html.heex:1217
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
+msgstr ""
+
+#: lib/typster_web/controllers/invite_controller.ex:18
+#, elixir-autogen, elixir-format
+msgid "share.invite.accepted"
+msgstr ""
+
+#: lib/typster_web/controllers/invite_controller.ex:23
+#, elixir-autogen, elixir-format
+msgid "share.invite.invalid"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -156,29 +156,29 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:635
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:540
+#: lib/typster_web/live/editor_live/index.ex:632
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:244
+#: lib/typster_web/live/editor_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:574
+#: lib/typster_web/live/editor_live/index.ex:666
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:401
-#: lib/typster_web/live/editor_live/index.ex:425
-#: lib/typster_web/live/editor_live/index.ex:717
+#: lib/typster_web/live/editor_live/index.ex:493
+#: lib/typster_web/live/editor_live/index.ex:517
+#: lib/typster_web/live/editor_live/index.ex:809
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -204,21 +204,22 @@ msgid "editor.preview"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:731
+#: lib/typster_web/live/shared_project_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:651
+#: lib/typster_web/live/editor_live/index.ex:743
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:649
+#: lib/typster_web/live/editor_live/index.ex:741
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:650
+#: lib/typster_web/live/editor_live/index.ex:742
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -650,14 +651,10 @@ msgstr ""
 msgid "editor.refresh"
 msgstr ""
 
+#: lib/typster_web/live/editor_live/index.html.heex:70
 #: lib/typster_web/live/editor_live/index.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "editor.share"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#, elixir-autogen, elixir-format
-msgid "editor.share_soon"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:690
@@ -2040,9 +2037,9 @@ msgstr ""
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:366
-#: lib/typster_web/live/editor_live/index.ex:412
-#: lib/typster_web/live/editor_live/index.ex:573
+#: lib/typster_web/live/editor_live/index.ex:458
+#: lib/typster_web/live/editor_live/index.ex:504
+#: lib/typster_web/live/editor_live/index.ex:665
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2052,12 +2049,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:479
+#: lib/typster_web/live/editor_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2122,7 +2119,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:667
+#: lib/typster_web/live/editor_live/index.ex:759
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2148,12 +2145,12 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:718
+#: lib/typster_web/live/editor_live/index.ex:810
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:925
+#: lib/typster_web/live/editor_live/index.ex:1154
 #: lib/typster_web/live/editor_live/index.html.heex:674
 #: lib/typster_web/live/editor_live/index.html.heex:882
 #, elixir-autogen, elixir-format
@@ -2162,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:927
+#: lib/typster_web/live/editor_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:931
+#: lib/typster_web/live/editor_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2225,12 +2222,12 @@ msgstr ""
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:772
+#: lib/typster_web/live/editor_live/index.ex:864
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:759
+#: lib/typster_web/live/editor_live/index.ex:851
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
@@ -2265,7 +2262,7 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:844
+#: lib/typster_web/live/editor_live/index.ex:936
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
@@ -2293,4 +2290,393 @@ msgstr ""
 #: lib/typster_web/live/editor_live/index.html.heex:854
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1022
+#, elixir-autogen, elixir-format
+msgid "common.close"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1133
+#: lib/typster_web/live/editor_live/index.html.heex:1303
+#, elixir-autogen, elixir-format
+msgid "common.copy"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1341
+#, elixir-autogen, elixir-format
+msgid "common.done"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1217
+#, elixir-autogen, elixir-format
+msgid "share.adv.download"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1218
+#, elixir-autogen, elixir-format
+msgid "share.adv.download_sub"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1228
+#, elixir-autogen, elixir-format
+msgid "share.adv.expires"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1228
+#, elixir-autogen, elixir-format
+msgid "share.adv.expires_sub"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1229
+#, elixir-autogen, elixir-format
+msgid "share.adv.password"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1229
+#, elixir-autogen, elixir-format
+msgid "share.adv.password_sub"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1227
+#, elixir-autogen, elixir-format
+msgid "share.adv.signin"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1227
+#, elixir-autogen, elixir-format
+msgid "share.adv.signin_sub"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1275
+#, elixir-autogen, elixir-format
+msgid "share.embed.components"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1287
+#, elixir-autogen, elixir-format
+msgid "share.embed.editable"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1279
+#, elixir-autogen, elixir-format
+msgid "share.embed.file_tree"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1269
+#, elixir-autogen, elixir-format
+msgid "share.embed.free_desc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1268
+#, elixir-autogen, elixir-format
+msgid "share.embed.free_title"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1283
+#, elixir-autogen, elixir-format
+msgid "share.embed.preview"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1329
+#, elixir-autogen, elixir-format
+msgid "share.export.download"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1333
+#, elixir-autogen, elixir-format
+msgid "share.export.hint"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1313
+#, elixir-autogen, elixir-format
+msgid "share.export.label"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1321
+#, elixir-autogen, elixir-format
+msgid "share.export.meta"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:294
+#, elixir-autogen, elixir-format
+msgid "share.flash.invite_failed"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:291
+#, elixir-autogen, elixir-format
+msgid "share.flash.invited"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1339
+#, elixir-autogen, elixir-format
+msgid "share.learn"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1235
+#, elixir-autogen, elixir-format
+msgid "share.link.activity"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1211
+#, elixir-autogen, elixir-format
+msgid "share.link.advanced"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1120
+#, elixir-autogen, elixir-format
+msgid "share.link.label"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1145
+#, elixir-autogen, elixir-format
+msgid "share.link.perm_label"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1139
+#, elixir-autogen, elixir-format
+msgid "share.link.rotate"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1137
+#, elixir-autogen, elixir-format
+msgid "share.link.rotate_hint"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1062
+#, elixir-autogen, elixir-format
+msgid "share.people.add_placeholder"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1054
+#, elixir-autogen, elixir-format
+msgid "share.people.invite"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1075
+#, elixir-autogen, elixir-format
+msgid "share.people.invite_hint"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1009
+#, elixir-autogen, elixir-format
+msgid "share.people.invite_sent"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1102
+#, elixir-autogen, elixir-format
+msgid "share.people.pending"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1108
+#, elixir-autogen, elixir-format
+msgid "share.people.remove"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1072
+#, elixir-autogen, elixir-format
+msgid "share.people.send"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1080
+#, elixir-autogen, elixir-format
+msgid "share.people.with_access"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1088
+#, elixir-autogen, elixir-format
+msgid "share.people.you"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1203
+#, elixir-autogen, elixir-format
+msgid "share.perm.careful"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1204
+#, elixir-autogen, elixir-format
+msgid "share.perm.full"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1205
+#, elixir-autogen, elixir-format
+msgid "share.perm.full_desc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1161
+#, elixir-autogen, elixir-format
+msgid "share.perm.output"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1162
+#, elixir-autogen, elixir-format
+msgid "share.perm.output_desc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1160
+#, elixir-autogen, elixir-format
+msgid "share.perm.pdf_only"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1152
+#, elixir-autogen, elixir-format
+msgid "share.perm.read"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1153
+#, elixir-autogen, elixir-format
+msgid "share.perm.read_desc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1182
+#, elixir-autogen, elixir-format
+msgid "share.perm.write"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1187
+#, elixir-autogen, elixir-format
+msgid "share.perm.write_desc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1002
+#, elixir-autogen, elixir-format
+msgid "share.plan.free"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1002
+#, elixir-autogen, elixir-format
+msgid "share.plan.pro"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:53
+#, elixir-autogen, elixir-format
+msgid "share.public.home"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:25
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:52
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid_sub"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:51
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid_title"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:69
+#, elixir-autogen, elixir-format
+msgid "share.public.open_in_typster"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1007
+#: lib/typster_web/live/editor_live/index.html.heex:1068
+#, elixir-autogen, elixir-format
+msgid "share.role.editor"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1005
+#: lib/typster_web/live/editor_live/index.html.heex:1094
+#, elixir-autogen, elixir-format
+msgid "share.role.owner"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.html.heex:1069
+#, elixir-autogen, elixir-format
+msgid "share.role.viewer"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "share.scope.full"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:126
+#, elixir-autogen, elixir-format
+msgid "share.scope.output"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:128
+#, elixir-autogen, elixir-format
+msgid "share.scope.read"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1250
+#, elixir-autogen, elixir-format
+msgid "share.stats.created"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1246
+#, elixir-autogen, elixir-format
+msgid "share.stats.editors"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1242
+#, elixir-autogen, elixir-format
+msgid "share.stats.opens"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1018
+#, elixir-autogen, elixir-format
+msgid "share.subtitle"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1034
+#, elixir-autogen, elixir-format
+msgid "share.tab.embed"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1035
+#, elixir-autogen, elixir-format
+msgid "share.tab.export"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1033
+#, elixir-autogen, elixir-format
+msgid "share.tab.link"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1032
+#, elixir-autogen, elixir-format
+msgid "share.tab.people"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1016
+#, elixir-autogen, elixir-format
+msgid "share.title"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:1058
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.cta"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1257
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.stats_desc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1256
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.stats_title"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1224
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.unlock"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1192
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.write_desc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1191
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.write_title"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -35,7 +35,7 @@ msgstr ""
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr ""
@@ -134,122 +134,122 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:407
+#: lib/typster_web/live/editor_live/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:109
+#: lib/typster_web/live/editor_live/index.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:715
 #: lib/typster_web/live/editor_live/index.html.heex:716
+#: lib/typster_web/live/editor_live/index.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:219
-#: lib/typster_web/live/editor_live/index.html.heex:292
+#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:635
+#: lib/typster_web/live/editor_live/index.ex:639
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:632
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:336
+#: lib/typster_web/live/editor_live/index.ex:340
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:666
+#: lib/typster_web/live/editor_live/index.ex:670
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:493
-#: lib/typster_web/live/editor_live/index.ex:517
-#: lib/typster_web/live/editor_live/index.ex:809
+#: lib/typster_web/live/editor_live/index.ex:497
+#: lib/typster_web/live/editor_live/index.ex:521
+#: lib/typster_web/live/editor_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:242
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:533
+#: lib/typster_web/live/editor_live/index.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:297
+#: lib/typster_web/live/editor_live/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:668
+#: lib/typster_web/live/editor_live/index.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:731
-#: lib/typster_web/live/shared_project_live.ex:113
+#: lib/typster_web/live/editor_live/index.html.heex:732
+#: lib/typster_web/live/shared_project_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:743
+#: lib/typster_web/live/editor_live/index.ex:747
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:741
+#: lib/typster_web/live/editor_live/index.ex:745
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:742
+#: lib/typster_web/live/editor_live/index.ex:746
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
-#: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:181
+#: lib/typster_web/live/editor_live/index.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:178
+#: lib/typster_web/live/editor_live/index.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:184
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:138
+#: lib/typster_web/live/editor_live/index.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr ""
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:189
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:192
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr ""
@@ -517,157 +517,157 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:99
-#: lib/typster_web/live/editor_live/index.html.heex:685
+#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:686
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:78
-#: lib/typster_web/live/editor_live/index.html.heex:681
+#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:682
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:212
 #: lib/typster_web/live/editor_live/index.html.heex:213
+#: lib/typster_web/live/editor_live/index.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
 #: lib/typster_web/live/editor_live/index.html.heex:543
+#: lib/typster_web/live/editor_live/index.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
 #: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:608
 #: lib/typster_web/live/editor_live/index.html.heex:609
+#: lib/typster_web/live/editor_live/index.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:551
 #: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:589
 #: lib/typster_web/live/editor_live/index.html.heex:590
+#: lib/typster_web/live/editor_live/index.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:570
 #: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:580
 #: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:582
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:598
 #: lib/typster_web/live/editor_live/index.html.heex:599
+#: lib/typster_web/live/editor_live/index.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:391
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:917
-#: lib/typster_web/live/editor_live/index.html.heex:925
-#: lib/typster_web/live/editor_live/index.html.heex:934
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:926
+#: lib/typster_web/live/editor_live/index.html.heex:935
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:969
-#: lib/typster_web/live/editor_live/index.html.heex:977
-#: lib/typster_web/live/editor_live/index.html.heex:986
+#: lib/typster_web/live/editor_live/index.html.heex:970
+#: lib/typster_web/live/editor_live/index.html.heex:978
+#: lib/typster_web/live/editor_live/index.html.heex:987
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:952
+#: lib/typster_web/live/editor_live/index.html.heex:953
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:975
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:909
+#: lib/typster_web/live/editor_live/index.html.heex:910
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:942
-#: lib/typster_web/live/editor_live/index.html.heex:948
+#: lib/typster_web/live/editor_live/index.html.heex:919
+#: lib/typster_web/live/editor_live/index.html.heex:943
+#: lib/typster_web/live/editor_live/index.html.heex:949
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:923
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:970
-#: lib/typster_web/live/editor_live/index.html.heex:989
-#: lib/typster_web/live/editor_live/index.html.heex:998
+#: lib/typster_web/live/editor_live/index.html.heex:971
+#: lib/typster_web/live/editor_live/index.html.heex:990
+#: lib/typster_web/live/editor_live/index.html.heex:999
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:707
+#: lib/typster_web/live/editor_live/index.html.heex:708
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:72
+#: lib/typster_web/live/editor_live/index.html.heex:71
+#: lib/typster_web/live/editor_live/index.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:690
+#: lib/typster_web/live/editor_live/index.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:699
+#: lib/typster_web/live/editor_live/index.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:695
+#: lib/typster_web/live/editor_live/index.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -827,38 +827,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:651
+#: lib/typster_web/live/editor_live/index.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:659
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:657
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:647
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:645
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:618
 #: lib/typster_web/live/editor_live/index.html.heex:619
+#: lib/typster_web/live/editor_live/index.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1986,17 +1986,17 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:225
+#: lib/typster_web/live/editor_live/index.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr ""
@@ -2006,40 +2006,40 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:337
+#: lib/typster_web/live/editor_live/index.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:458
-#: lib/typster_web/live/editor_live/index.ex:504
-#: lib/typster_web/live/editor_live/index.ex:665
+#: lib/typster_web/live/editor_live/index.ex:462
+#: lib/typster_web/live/editor_live/index.ex:508
+#: lib/typster_web/live/editor_live/index.ex:669
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,24 +2049,24 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:602
+#: lib/typster_web/live/editor_live/index.ex:606
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:571
+#: lib/typster_web/live/editor_live/index.ex:575
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:283
+#: lib/typster_web/live/editor_live/index.html.heex:284
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:474
 #: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
@@ -2082,7 +2082,7 @@ msgid "editor.tree.pin"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
@@ -2092,19 +2092,19 @@ msgstr ""
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:234
+#: lib/typster_web/live/editor_live/index.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr ""
@@ -2114,130 +2114,130 @@ msgstr ""
 msgid "editor.breadcrumb"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:759
+#: lib/typster_web/live/editor_live/index.ex:763
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:447
+#: lib/typster_web/live/editor_live/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:473
+#: lib/typster_web/live/editor_live/index.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:493
+#: lib/typster_web/live/editor_live/index.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:463
 #: lib/typster_web/live/editor_live/index.html.heex:464
+#: lib/typster_web/live/editor_live/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:810
+#: lib/typster_web/live/editor_live/index.ex:814
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1154
-#: lib/typster_web/live/editor_live/index.html.heex:674
-#: lib/typster_web/live/editor_live/index.html.heex:882
+#: lib/typster_web/live/editor_live/index.ex:1158
+#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1156
+#: lib/typster_web/live/editor_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1160
+#: lib/typster_web/live/editor_live/index.ex:1164
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:788
+#: lib/typster_web/live/editor_live/index.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:794
+#: lib/typster_web/live/editor_live/index.html.heex:795
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:770
+#: lib/typster_web/live/editor_live/index.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:884
+#: lib/typster_web/live/editor_live/index.html.heex:746
+#: lib/typster_web/live/editor_live/index.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:802
+#: lib/typster_web/live/editor_live/index.html.heex:803
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:815
+#: lib/typster_web/live/editor_live/index.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:754
+#: lib/typster_web/live/editor_live/index.html.heex:755
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:875
+#: lib/typster_web/live/editor_live/index.html.heex:876
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:776
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:773
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:864
+#: lib/typster_web/live/editor_live/index.ex:868
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:851
+#: lib/typster_web/live/editor_live/index.ex:855
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:159
+#: lib/typster_web/live/editor_live/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:175
+#: lib/typster_web/live/editor_live/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr ""
@@ -2247,12 +2247,12 @@ msgstr ""
 msgid "editor.topbar.back"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:120
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:87
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr ""
@@ -2262,12 +2262,12 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:936
+#: lib/typster_web/live/editor_live/index.ex:940
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:148
+#: lib/typster_web/live/editor_live/index.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr ""
@@ -2287,263 +2287,263 @@ msgstr ""
 msgid "editor.topbar.branch"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:854
+#: lib/typster_web/live/editor_live/index.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1026
+#: lib/typster_web/live/editor_live/index.html.heex:1027
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1149
-#: lib/typster_web/live/editor_live/index.html.heex:1344
+#: lib/typster_web/live/editor_live/index.html.heex:1150
+#: lib/typster_web/live/editor_live/index.html.heex:1345
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1385
+#: lib/typster_web/live/editor_live/index.html.heex:1386
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1243
+#: lib/typster_web/live/editor_live/index.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1244
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1259
+#: lib/typster_web/live/editor_live/index.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1260
+#: lib/typster_web/live/editor_live/index.html.heex:1261
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1265
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1254
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1255
+#: lib/typster_web/live/editor_live/index.html.heex:1256
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1314
+#: lib/typster_web/live/editor_live/index.html.heex:1315
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1326
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1318
+#: lib/typster_web/live/editor_live/index.html.heex:1319
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1307
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1322
+#: lib/typster_web/live/editor_live/index.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1371
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1376
+#: lib/typster_web/live/editor_live/index.html.heex:1377
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1354
+#: lib/typster_web/live/editor_live/index.html.heex:1355
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1362
+#: lib/typster_web/live/editor_live/index.html.heex:1363
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:294
+#: lib/typster_web/live/editor_live/index.ex:298
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:291
+#: lib/typster_web/live/editor_live/index.ex:295
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1382
+#: lib/typster_web/live/editor_live/index.html.heex:1383
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1271
+#: lib/typster_web/live/editor_live/index.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1136
+#: lib/typster_web/live/editor_live/index.html.heex:1137
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1165
+#: lib/typster_web/live/editor_live/index.html.heex:1166
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1159
+#: lib/typster_web/live/editor_live/index.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1154
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1072
+#: lib/typster_web/live/editor_live/index.html.heex:1073
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1059
+#: lib/typster_web/live/editor_live/index.html.heex:1060
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1085
+#: lib/typster_web/live/editor_live/index.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1117
+#: lib/typster_web/live/editor_live/index.html.heex:1118
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1124
+#: lib/typster_web/live/editor_live/index.html.heex:1125
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1082
+#: lib/typster_web/live/editor_live/index.html.heex:1083
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1090
+#: lib/typster_web/live/editor_live/index.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1100
+#: lib/typster_web/live/editor_live/index.html.heex:1101
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1230
+#: lib/typster_web/live/editor_live/index.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1231
+#: lib/typster_web/live/editor_live/index.html.heex:1232
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1183
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1180
+#: lib/typster_web/live/editor_live/index.html.heex:1181
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1172
+#: lib/typster_web/live/editor_live/index.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1173
+#: lib/typster_web/live/editor_live/index.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1202
+#: lib/typster_web/live/editor_live/index.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1210
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1002
+#: lib/typster_web/live/editor_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1002
+#: lib/typster_web/live/editor_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr ""
@@ -2568,115 +2568,115 @@ msgstr ""
 msgid "share.public.invalid_title"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:69
+#: lib/typster_web/live/shared_project_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1007
-#: lib/typster_web/live/editor_live/index.html.heex:1078
+#: lib/typster_web/live/editor_live/index.ex:1011
+#: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1005
-#: lib/typster_web/live/editor_live/index.html.heex:1106
+#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.html.heex:1107
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1006
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.ex:1010
+#: lib/typster_web/live/editor_live/index.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:127
+#: lib/typster_web/live/shared_project_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:126
+#: lib/typster_web/live/shared_project_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:128
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1286
+#: lib/typster_web/live/editor_live/index.html.heex:1287
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1282
+#: lib/typster_web/live/editor_live/index.html.heex:1283
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1278
+#: lib/typster_web/live/editor_live/index.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1018
+#: lib/typster_web/live/editor_live/index.html.heex:1019
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1039
+#: lib/typster_web/live/editor_live/index.html.heex:1040
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1040
+#: lib/typster_web/live/editor_live/index.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1038
+#: lib/typster_web/live/editor_live/index.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1037
+#: lib/typster_web/live/editor_live/index.html.heex:1038
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1016
+#: lib/typster_web/live/editor_live/index.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1058
+#: lib/typster_web/live/editor_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1296
+#: lib/typster_web/live/editor_live/index.html.heex:1297
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1295
+#: lib/typster_web/live/editor_live/index.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1217
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr ""
@@ -2689,4 +2689,9 @@ msgstr ""
 #: lib/typster_web/controllers/invite_controller.ex:23
 #, elixir-autogen, elixir-format
 msgid "share.invite.invalid"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:113
+#, elixir-autogen, elixir-format
+msgid "share.public.powered_by"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -204,7 +204,7 @@ msgid "editor.preview"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:732
-#: lib/typster_web/live/shared_project_live.ex:111
+#: lib/typster_web/live/shared_project_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
@@ -2150,7 +2150,7 @@ msgstr ""
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1393
+#: lib/typster_web/live/editor_live/index.ex:1308
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1395
+#: lib/typster_web/live/editor_live/index.ex:1310
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1399
+#: lib/typster_web/live/editor_live/index.ex:1314
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2298,12 +2298,12 @@ msgid "common.close"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1428
+#: lib/typster_web/live/editor_live/index.html.heex:1441
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1469
+#: lib/typster_web/live/editor_live/index.html.heex:1482
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr ""
@@ -2353,12 +2353,12 @@ msgstr ""
 msgid "share.embed.components"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1334
+#: lib/typster_web/live/editor_live/index.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1326
+#: lib/typster_web/live/editor_live/index.html.heex:1328
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr ""
@@ -2373,27 +2373,27 @@ msgstr ""
 msgid "share.embed.free_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1329
+#: lib/typster_web/live/editor_live/index.html.heex:1333
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1454
+#: lib/typster_web/live/editor_live/index.html.heex:1467
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1460
+#: lib/typster_web/live/editor_live/index.html.heex:1473
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1438
+#: lib/typster_web/live/editor_live/index.html.heex:1451
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1446
+#: lib/typster_web/live/editor_live/index.html.heex:1459
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr ""
@@ -2408,7 +2408,7 @@ msgstr ""
 msgid "share.flash.invited"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1466
+#: lib/typster_web/live/editor_live/index.html.heex:1479
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr ""
@@ -2548,7 +2548,7 @@ msgstr ""
 msgid "share.plan.pro"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:53
+#: lib/typster_web/live/shared_project_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr ""
@@ -2558,18 +2558,17 @@ msgstr ""
 msgid "share.public.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:52
+#: lib/typster_web/live/shared_project_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:51
+#: lib/typster_web/live/shared_project_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1311
-#: lib/typster_web/live/shared_project_live.ex:122
+#: lib/typster_web/live/shared_project_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr ""
@@ -2592,17 +2591,17 @@ msgstr ""
 msgid "share.role.viewer"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:143
+#: lib/typster_web/live/shared_project_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:142
+#: lib/typster_web/live/shared_project_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:144
+#: lib/typster_web/live/shared_project_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr ""
@@ -2652,7 +2651,7 @@ msgstr ""
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1186
+#: lib/typster_web/live/editor_live/index.ex:1169
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
@@ -2692,88 +2691,63 @@ msgstr ""
 msgid "share.invite.invalid"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1308
-#: lib/typster_web/live/shared_project_live.ex:118
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1353
+#: lib/typster_web/live/editor_live/index.html.heex:1357
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1355
+#: lib/typster_web/live/editor_live/index.html.heex:1359
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1354
+#: lib/typster_web/live/editor_live/index.html.heex:1358
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1267
-#, elixir-autogen, elixir-format
-msgid "share.embed.host_example"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:1391
+#: lib/typster_web/live/editor_live/index.html.heex:1395
+#: lib/typster_web/live/editor_live/index.html.heex:1405
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1280
-#, elixir-autogen, elixir-format
-msgid "share.embed.readonly"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.ex:1303
-#, elixir-autogen, elixir-format
-msgid "share.embed.sample_body"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.ex:1302
-#, elixir-autogen, elixir-format
-msgid "share.embed.sample_meta"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.ex:1277
-#, elixir-autogen, elixir-format
-msgid "share.embed.sandbox"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.html.heex:1347
+#: lib/typster_web/live/editor_live/index.html.heex:1351
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1361
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1367
+#: lib/typster_web/live/editor_live/index.html.heex:1371
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1369
+#: lib/typster_web/live/editor_live/index.html.heex:1373
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1368
+#: lib/typster_web/live/editor_live/index.html.heex:1372
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1375
+#: lib/typster_web/live/editor_live/index.html.heex:1379
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2292,108 +2292,108 @@ msgstr "Branch"
 msgid "editor.status.compile_times"
 msgstr "Compile times (last 12 runs)"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1022
+#: lib/typster_web/live/editor_live/index.html.heex:1026
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr "Close"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1133
-#: lib/typster_web/live/editor_live/index.html.heex:1303
+#: lib/typster_web/live/editor_live/index.html.heex:1149
+#: lib/typster_web/live/editor_live/index.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Copy"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1341
+#: lib/typster_web/live/editor_live/index.html.heex:1385
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Done"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1217
+#: lib/typster_web/live/editor_live/index.html.heex:1243
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Allow downloads"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Visitors can download the compiled PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1259
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Expires in 30 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Auto-revokes the link after the set period."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Password-protect"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Visitor must enter a passphrase before opening."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1227
+#: lib/typster_web/live/editor_live/index.html.heex:1254
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Require sign-in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1227
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Visitors must sign in with a Typster account."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1275
+#: lib/typster_web/live/editor_live/index.html.heex:1314
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Components"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1287
+#: lib/typster_web/live/editor_live/index.html.heex:1326
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Visitor can edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1318
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "File tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1269
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Visitors can read & open your project on any plan."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1268
+#: lib/typster_web/live/editor_live/index.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Embed is free — interactive sandbox is Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1322
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Compiled preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1329
+#: lib/typster_web/live/editor_live/index.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Download PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1333
+#: lib/typster_web/live/editor_live/index.html.heex:1376
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Exports the document compiled in your browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1313
+#: lib/typster_web/live/editor_live/index.html.heex:1354
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Last successful compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1321
+#: lib/typster_web/live/editor_live/index.html.heex:1362
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Includes embedded fonts. Re-export to refresh."
@@ -2408,52 +2408,52 @@ msgstr "Could not send that invite."
 msgid "share.flash.invited"
 msgstr "Invited %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1339
+#: lib/typster_web/live/editor_live/index.html.heex:1382
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "Learn about permissions →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1235
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Link activity"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1211
+#: lib/typster_web/live/editor_live/index.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Advanced"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1120
+#: lib/typster_web/live/editor_live/index.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr "Share link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1145
+#: lib/typster_web/live/editor_live/index.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr "Anyone with this link can…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1139
+#: lib/typster_web/live/editor_live/index.html.heex:1159
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr "Rotate key"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1137
+#: lib/typster_web/live/editor_live/index.html.heex:1153
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr "Rotating the key revokes the current link instantly."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1062
+#: lib/typster_web/live/editor_live/index.html.heex:1072
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr "Add by email…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1054
+#: lib/typster_web/live/editor_live/index.html.heex:1059
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr "Invite people"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1075
+#: lib/typster_web/live/editor_live/index.html.heex:1085
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
@@ -2463,77 +2463,77 @@ msgstr "Invitees get an email with a link and can edit after signing in."
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1102
+#: lib/typster_web/live/editor_live/index.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr "Pending"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1108
+#: lib/typster_web/live/editor_live/index.html.heex:1124
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr "Remove"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1072
+#: lib/typster_web/live/editor_live/index.html.heex:1082
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr "Send invite"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1080
+#: lib/typster_web/live/editor_live/index.html.heex:1090
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr "People with access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1088
+#: lib/typster_web/live/editor_live/index.html.heex:1100
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr "you"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1203
+#: lib/typster_web/live/editor_live/index.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "careful"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1204
+#: lib/typster_web/live/editor_live/index.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1205
+#: lib/typster_web/live/editor_live/index.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Read + write everything and manage the link. Same as Owner."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1161
+#: lib/typster_web/live/editor_live/index.html.heex:1181
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr "Compiled output only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1162
+#: lib/typster_web/live/editor_live/index.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr "Hides the source. Shows the latest successful compile."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1180
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr "PDF only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1152
+#: lib/typster_web/live/editor_live/index.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr "Read"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr "See realtime source and the rendered preview. No editing."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1202
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Write — specific files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1187
+#: lib/typster_web/live/editor_live/index.html.heex:1210
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
@@ -2574,19 +2574,19 @@ msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
 #: lib/typster_web/live/editor_live/index.ex:1007
-#: lib/typster_web/live/editor_live/index.html.heex:1068
+#: lib/typster_web/live/editor_live/index.html.heex:1078
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
 #: lib/typster_web/live/editor_live/index.ex:1005
-#: lib/typster_web/live/editor_live/index.html.heex:1094
+#: lib/typster_web/live/editor_live/index.html.heex:1106
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
 #: lib/typster_web/live/editor_live/index.ex:1006
-#: lib/typster_web/live/editor_live/index.html.heex:1069
+#: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Viewer"
@@ -2606,17 +2606,17 @@ msgstr "Compiled output"
 msgid "share.scope.read"
 msgstr "Read-only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Link created"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1246
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Active editors now"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1242
+#: lib/typster_web/live/editor_live/index.html.heex:1278
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Opens last 7 days"
@@ -2626,22 +2626,22 @@ msgstr "Opens last 7 days"
 msgid "share.subtitle"
 msgstr "Invite collaborators, share a link, embed the project, or download the PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1034
+#: lib/typster_web/live/editor_live/index.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr "Embed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1035
+#: lib/typster_web/live/editor_live/index.html.heex:1040
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr "Export PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1033
+#: lib/typster_web/live/editor_live/index.html.heex:1038
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1032
+#: lib/typster_web/live/editor_live/index.html.heex:1037
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr "People"
@@ -2656,27 +2656,37 @@ msgstr "Share"
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1257
+#: lib/typster_web/live/editor_live/index.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Real-time opens, active editors, and locations — with Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1256
+#: lib/typster_web/live/editor_live/index.html.heex:1295
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "See who opens your link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1224
+#: lib/typster_web/live/editor_live/index.html.heex:1250
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Unlock with Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1192
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Free links are read-only or fully editable. Upgrade to scope writes."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1191
+#: lib/typster_web/live/editor_live/index.html.heex:1217
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Per-file write access is Pro"
+
+#: lib/typster_web/controllers/invite_controller.ex:18
+#, elixir-autogen, elixir-format
+msgid "share.invite.accepted"
+msgstr "You're in — welcome to the project."
+
+#: lib/typster_web/controllers/invite_controller.ex:23
+#, elixir-autogen, elixir-format
+msgid "share.invite.invalid"
+msgstr "That invite link is invalid or has expired."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -204,7 +204,7 @@ msgid "editor.preview"
 msgstr "Preview"
 
 #: lib/typster_web/live/editor_live/index.html.heex:732
-#: lib/typster_web/live/shared_project_live.ex:111
+#: lib/typster_web/live/shared_project_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
@@ -2150,7 +2150,7 @@ msgstr "Start a file from this template"
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1393
+#: lib/typster_web/live/editor_live/index.ex:1308
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1395
+#: lib/typster_web/live/editor_live/index.ex:1310
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1399
+#: lib/typster_web/live/editor_live/index.ex:1314
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2298,12 +2298,12 @@ msgid "common.close"
 msgstr "Close"
 
 #: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1428
+#: lib/typster_web/live/editor_live/index.html.heex:1441
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Copy"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1469
+#: lib/typster_web/live/editor_live/index.html.heex:1482
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Done"
@@ -2353,12 +2353,12 @@ msgstr "Visitors must sign in with a Typster account."
 msgid "share.embed.components"
 msgstr "Components"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1334
+#: lib/typster_web/live/editor_live/index.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Visitor can edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1326
+#: lib/typster_web/live/editor_live/index.html.heex:1328
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "File tree"
@@ -2373,27 +2373,27 @@ msgstr "Visitors can read & open your project on any plan. Upgrade to let them e
 msgid "share.embed.free_title"
 msgstr "Embed is free — interactive sandbox is Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1329
+#: lib/typster_web/live/editor_live/index.html.heex:1333
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Compiled preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1454
+#: lib/typster_web/live/editor_live/index.html.heex:1467
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Download PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1460
+#: lib/typster_web/live/editor_live/index.html.heex:1473
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Exports the document compiled in your browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1438
+#: lib/typster_web/live/editor_live/index.html.heex:1451
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Last successful compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1446
+#: lib/typster_web/live/editor_live/index.html.heex:1459
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Includes embedded fonts. Re-export to refresh."
@@ -2408,7 +2408,7 @@ msgstr "Could not send that invite."
 msgid "share.flash.invited"
 msgstr "Invited %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1466
+#: lib/typster_web/live/editor_live/index.html.heex:1479
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "Learn about permissions →"
@@ -2548,7 +2548,7 @@ msgstr "Free"
 msgid "share.plan.pro"
 msgstr "Pro"
 
-#: lib/typster_web/live/shared_project_live.ex:53
+#: lib/typster_web/live/shared_project_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr "Go to Typster"
@@ -2558,18 +2558,17 @@ msgstr "Go to Typster"
 msgid "share.public.invalid"
 msgstr "Invalid link"
 
-#: lib/typster_web/live/shared_project_live.ex:52
+#: lib/typster_web/live/shared_project_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr "The share link may have been rotated or revoked."
 
-#: lib/typster_web/live/shared_project_live.ex:51
+#: lib/typster_web/live/shared_project_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr "This link isn't valid"
 
-#: lib/typster_web/live/editor_live/index.ex:1311
-#: lib/typster_web/live/shared_project_live.ex:122
+#: lib/typster_web/live/shared_project_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
@@ -2592,17 +2591,17 @@ msgstr "Owner"
 msgid "share.role.viewer"
 msgstr "Viewer"
 
-#: lib/typster_web/live/shared_project_live.ex:143
+#: lib/typster_web/live/shared_project_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/shared_project_live.ex:142
+#: lib/typster_web/live/shared_project_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Compiled output"
 
-#: lib/typster_web/live/shared_project_live.ex:144
+#: lib/typster_web/live/shared_project_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Read-only"
@@ -2652,7 +2651,7 @@ msgstr "People"
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1186
+#: lib/typster_web/live/editor_live/index.ex:1169
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
@@ -2692,88 +2691,63 @@ msgstr "You're in — welcome to the project."
 msgid "share.invite.invalid"
 msgstr "That invite link is invalid or has expired."
 
-#: lib/typster_web/live/editor_live/index.ex:1308
-#: lib/typster_web/live/shared_project_live.ex:118
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Powered by"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1353
+#: lib/typster_web/live/editor_live/index.html.heex:1357
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr "Always"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1355
+#: lib/typster_web/live/editor_live/index.html.heex:1359
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr "Hidden"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1354
+#: lib/typster_web/live/editor_live/index.html.heex:1358
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr "On edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr "Hide Typster footer"
 
-#: lib/typster_web/live/editor_live/index.ex:1267
-#, elixir-autogen, elixir-format
-msgid "share.embed.host_example"
-msgstr "yoursite.dev/embedded-report"
-
-#: lib/typster_web/live/editor_live/index.html.heex:1391
+#: lib/typster_web/live/editor_live/index.html.heex:1395
+#: lib/typster_web/live/editor_live/index.html.heex:1405
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr "Live preview"
 
-#: lib/typster_web/live/editor_live/index.ex:1280
-#, elixir-autogen, elixir-format
-msgid "share.embed.readonly"
-msgstr "Read-only"
-
-#: lib/typster_web/live/editor_live/index.ex:1303
-#, elixir-autogen, elixir-format
-msgid "share.embed.sample_body"
-msgstr "This is roughly how your compiled document appears to visitors."
-
-#: lib/typster_web/live/editor_live/index.ex:1302
-#, elixir-autogen, elixir-format
-msgid "share.embed.sample_meta"
-msgstr "Compiled preview"
-
-#: lib/typster_web/live/editor_live/index.ex:1277
-#, elixir-autogen, elixir-format
-msgid "share.embed.sandbox"
-msgstr "Sandbox"
-
-#: lib/typster_web/live/editor_live/index.html.heex:1347
+#: lib/typster_web/live/editor_live/index.html.heex:1351
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr "Save CTA"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1361
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr "Theme"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1367
+#: lib/typster_web/live/editor_live/index.html.heex:1371
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr "Auto"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1369
+#: lib/typster_web/live/editor_live/index.html.heex:1373
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr "Dark"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1368
+#: lib/typster_web/live/editor_live/index.html.heex:1372
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr "Light"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1375
+#: lib/typster_web/live/editor_live/index.html.heex:1379
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr "Width"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr "Log in"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Log out"
@@ -134,122 +134,122 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:407
+#: lib/typster_web/live/editor_live/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
 
-#: lib/typster_web/live/editor_live/index.html.heex:109
+#: lib/typster_web/live/editor_live/index.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:715
 #: lib/typster_web/live/editor_live/index.html.heex:716
+#: lib/typster_web/live/editor_live/index.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
-#: lib/typster_web/live/editor_live/index.html.heex:219
-#: lib/typster_web/live/editor_live/index.html.heex:292
+#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:635
+#: lib/typster_web/live/editor_live/index.ex:639
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:632
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:336
+#: lib/typster_web/live/editor_live/index.ex:340
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:666
+#: lib/typster_web/live/editor_live/index.ex:670
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:493
-#: lib/typster_web/live/editor_live/index.ex:517
-#: lib/typster_web/live/editor_live/index.ex:809
+#: lib/typster_web/live/editor_live/index.ex:497
+#: lib/typster_web/live/editor_live/index.ex:521
+#: lib/typster_web/live/editor_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:242
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:533
+#: lib/typster_web/live/editor_live/index.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:297
+#: lib/typster_web/live/editor_live/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:668
+#: lib/typster_web/live/editor_live/index.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:731
-#: lib/typster_web/live/shared_project_live.ex:113
+#: lib/typster_web/live/editor_live/index.html.heex:732
+#: lib/typster_web/live/shared_project_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:743
+#: lib/typster_web/live/editor_live/index.ex:747
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:741
+#: lib/typster_web/live/editor_live/index.ex:745
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:742
+#: lib/typster_web/live/editor_live/index.ex:746
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
-#: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:181
+#: lib/typster_web/live/editor_live/index.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Dark theme"
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:178
+#: lib/typster_web/live/editor_live/index.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Light theme"
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:184
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Use system theme"
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:138
+#: lib/typster_web/live/editor_live/index.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Toggle theme"
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr "My projects"
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:189
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Projects"
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:192
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Settings"
@@ -517,157 +517,157 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:99
-#: lib/typster_web/live/editor_live/index.html.heex:685
+#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:686
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:78
-#: lib/typster_web/live/editor_live/index.html.heex:681
+#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:682
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:212
 #: lib/typster_web/live/editor_live/index.html.heex:213
+#: lib/typster_web/live/editor_live/index.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
 #: lib/typster_web/live/editor_live/index.html.heex:543
+#: lib/typster_web/live/editor_live/index.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
 #: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:608
 #: lib/typster_web/live/editor_live/index.html.heex:609
+#: lib/typster_web/live/editor_live/index.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:551
 #: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:589
 #: lib/typster_web/live/editor_live/index.html.heex:590
+#: lib/typster_web/live/editor_live/index.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:570
 #: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:580
 #: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:582
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:598
 #: lib/typster_web/live/editor_live/index.html.heex:599
+#: lib/typster_web/live/editor_live/index.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:391
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:917
-#: lib/typster_web/live/editor_live/index.html.heex:925
-#: lib/typster_web/live/editor_live/index.html.heex:934
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:926
+#: lib/typster_web/live/editor_live/index.html.heex:935
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:969
-#: lib/typster_web/live/editor_live/index.html.heex:977
-#: lib/typster_web/live/editor_live/index.html.heex:986
+#: lib/typster_web/live/editor_live/index.html.heex:970
+#: lib/typster_web/live/editor_live/index.html.heex:978
+#: lib/typster_web/live/editor_live/index.html.heex:987
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:952
+#: lib/typster_web/live/editor_live/index.html.heex:953
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:975
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:909
+#: lib/typster_web/live/editor_live/index.html.heex:910
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:942
-#: lib/typster_web/live/editor_live/index.html.heex:948
+#: lib/typster_web/live/editor_live/index.html.heex:919
+#: lib/typster_web/live/editor_live/index.html.heex:943
+#: lib/typster_web/live/editor_live/index.html.heex:949
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:923
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:970
-#: lib/typster_web/live/editor_live/index.html.heex:989
-#: lib/typster_web/live/editor_live/index.html.heex:998
+#: lib/typster_web/live/editor_live/index.html.heex:971
+#: lib/typster_web/live/editor_live/index.html.heex:990
+#: lib/typster_web/live/editor_live/index.html.heex:999
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:707
+#: lib/typster_web/live/editor_live/index.html.heex:708
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:72
+#: lib/typster_web/live/editor_live/index.html.heex:71
+#: lib/typster_web/live/editor_live/index.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.html.heex:690
+#: lib/typster_web/live/editor_live/index.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:699
+#: lib/typster_web/live/editor_live/index.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:695
+#: lib/typster_web/live/editor_live/index.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -827,38 +827,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:651
+#: lib/typster_web/live/editor_live/index.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:659
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:657
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:647
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:645
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:618
 #: lib/typster_web/live/editor_live/index.html.heex:619
+#: lib/typster_web/live/editor_live/index.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1986,17 +1986,17 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:225
+#: lib/typster_web/live/editor_live/index.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
@@ -2006,40 +2006,40 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:337
+#: lib/typster_web/live/editor_live/index.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:458
-#: lib/typster_web/live/editor_live/index.ex:504
-#: lib/typster_web/live/editor_live/index.ex:665
+#: lib/typster_web/live/editor_live/index.ex:462
+#: lib/typster_web/live/editor_live/index.ex:508
+#: lib/typster_web/live/editor_live/index.ex:669
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,24 +2049,24 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:602
+#: lib/typster_web/live/editor_live/index.ex:606
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:571
+#: lib/typster_web/live/editor_live/index.ex:575
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
 
-#: lib/typster_web/live/editor_live/index.html.heex:283
+#: lib/typster_web/live/editor_live/index.html.heex:284
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Pinned"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:474
 #: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
@@ -2082,7 +2082,7 @@ msgid "editor.tree.pin"
 msgstr "Pin file"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
@@ -2092,19 +2092,19 @@ msgstr "Pinned"
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] "%{count} section"
 msgstr[1] "%{count} sections"
 
-#: lib/typster_web/live/editor_live/index.html.heex:234
+#: lib/typster_web/live/editor_live/index.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "New folder"
 
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "folder name"
@@ -2114,130 +2114,130 @@ msgstr "folder name"
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
 
-#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:759
+#: lib/typster_web/live/editor_live/index.ex:763
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
 
-#: lib/typster_web/live/editor_live/index.html.heex:447
+#: lib/typster_web/live/editor_live/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Your templates"
 
-#: lib/typster_web/live/editor_live/index.html.heex:473
+#: lib/typster_web/live/editor_live/index.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Remove this template?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:493
+#: lib/typster_web/live/editor_live/index.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Upload a file to reuse"
 
-#: lib/typster_web/live/editor_live/index.html.heex:463
 #: lib/typster_web/live/editor_live/index.html.heex:464
+#: lib/typster_web/live/editor_live/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:810
+#: lib/typster_web/live/editor_live/index.ex:814
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1154
-#: lib/typster_web/live/editor_live/index.html.heex:674
-#: lib/typster_web/live/editor_live/index.html.heex:882
+#: lib/typster_web/live/editor_live/index.ex:1158
+#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1156
+#: lib/typster_web/live/editor_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1160
+#: lib/typster_web/live/editor_live/index.ex:1164
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:788
+#: lib/typster_web/live/editor_live/index.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Clear log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:794
+#: lib/typster_web/live/editor_live/index.html.heex:795
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Close panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:770
+#: lib/typster_web/live/editor_live/index.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "Jump to first"
 
-#: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:884
+#: lib/typster_web/live/editor_live/index.html.heex:746
+#: lib/typster_web/live/editor_live/index.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Compile log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:802
+#: lib/typster_web/live/editor_live/index.html.heex:803
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "No compiles yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:815
+#: lib/typster_web/live/editor_live/index.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "No problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:754
+#: lib/typster_web/live/editor_live/index.html.heex:755
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:875
+#: lib/typster_web/live/editor_live/index.html.heex:876
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Toggle compile panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:776
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Off"
 
-#: lib/typster_web/live/editor_live/index.html.heex:773
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:864
+#: lib/typster_web/live/editor_live/index.ex:868
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:851
+#: lib/typster_web/live/editor_live/index.ex:855
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
 
-#: lib/typster_web/live/editor_live/index.html.heex:159
+#: lib/typster_web/live/editor_live/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr "Account"
 
-#: lib/typster_web/live/editor_live/index.html.heex:175
+#: lib/typster_web/live/editor_live/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr "Appearance"
@@ -2247,12 +2247,12 @@ msgstr "Appearance"
 msgid "editor.topbar.back"
 msgstr "Back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:120
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr "Collaborators"
 
-#: lib/typster_web/live/editor_live/index.html.heex:87
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr "Failed"
@@ -2262,12 +2262,12 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:936
+#: lib/typster_web/live/editor_live/index.ex:940
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
 
-#: lib/typster_web/live/editor_live/index.html.heex:148
+#: lib/typster_web/live/editor_live/index.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr "Language"
@@ -2287,263 +2287,263 @@ msgstr "Switch project"
 msgid "editor.topbar.branch"
 msgstr "Branch"
 
-#: lib/typster_web/live/editor_live/index.html.heex:854
+#: lib/typster_web/live/editor_live/index.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr "Compile times (last 12 runs)"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1026
+#: lib/typster_web/live/editor_live/index.html.heex:1027
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr "Close"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1149
-#: lib/typster_web/live/editor_live/index.html.heex:1344
+#: lib/typster_web/live/editor_live/index.html.heex:1150
+#: lib/typster_web/live/editor_live/index.html.heex:1345
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Copy"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1385
+#: lib/typster_web/live/editor_live/index.html.heex:1386
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Done"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1243
+#: lib/typster_web/live/editor_live/index.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Allow downloads"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1244
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Visitors can download the compiled PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1259
+#: lib/typster_web/live/editor_live/index.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Expires in 30 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1260
+#: lib/typster_web/live/editor_live/index.html.heex:1261
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Auto-revokes the link after the set period."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Password-protect"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1265
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Visitor must enter a passphrase before opening."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1254
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Require sign-in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1255
+#: lib/typster_web/live/editor_live/index.html.heex:1256
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Visitors must sign in with a Typster account."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1314
+#: lib/typster_web/live/editor_live/index.html.heex:1315
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Components"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1326
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Visitor can edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1318
+#: lib/typster_web/live/editor_live/index.html.heex:1319
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "File tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Visitors can read & open your project on any plan."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1307
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Embed is free — interactive sandbox is Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1322
+#: lib/typster_web/live/editor_live/index.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Compiled preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1371
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Download PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1376
+#: lib/typster_web/live/editor_live/index.html.heex:1377
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Exports the document compiled in your browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1354
+#: lib/typster_web/live/editor_live/index.html.heex:1355
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Last successful compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1362
+#: lib/typster_web/live/editor_live/index.html.heex:1363
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Includes embedded fonts. Re-export to refresh."
 
-#: lib/typster_web/live/editor_live/index.ex:294
+#: lib/typster_web/live/editor_live/index.ex:298
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Could not send that invite."
 
-#: lib/typster_web/live/editor_live/index.ex:291
+#: lib/typster_web/live/editor_live/index.ex:295
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Invited %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1382
+#: lib/typster_web/live/editor_live/index.html.heex:1383
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "Learn about permissions →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1271
+#: lib/typster_web/live/editor_live/index.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Link activity"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Advanced"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1136
+#: lib/typster_web/live/editor_live/index.html.heex:1137
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr "Share link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1165
+#: lib/typster_web/live/editor_live/index.html.heex:1166
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr "Anyone with this link can…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1159
+#: lib/typster_web/live/editor_live/index.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr "Rotate key"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1154
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr "Rotating the key revokes the current link instantly."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1072
+#: lib/typster_web/live/editor_live/index.html.heex:1073
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr "Add by email…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1059
+#: lib/typster_web/live/editor_live/index.html.heex:1060
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr "Invite people"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1085
+#: lib/typster_web/live/editor_live/index.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
 
-#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1117
+#: lib/typster_web/live/editor_live/index.html.heex:1118
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr "Pending"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1124
+#: lib/typster_web/live/editor_live/index.html.heex:1125
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr "Remove"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1082
+#: lib/typster_web/live/editor_live/index.html.heex:1083
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr "Send invite"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1090
+#: lib/typster_web/live/editor_live/index.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr "People with access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1100
+#: lib/typster_web/live/editor_live/index.html.heex:1101
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr "you"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "careful"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1230
+#: lib/typster_web/live/editor_live/index.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1231
+#: lib/typster_web/live/editor_live/index.html.heex:1232
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Read + write everything and manage the link. Same as Owner."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr "Compiled output only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1183
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr "Hides the source. Shows the latest successful compile."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1180
+#: lib/typster_web/live/editor_live/index.html.heex:1181
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr "PDF only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1172
+#: lib/typster_web/live/editor_live/index.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr "Read"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1173
+#: lib/typster_web/live/editor_live/index.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr "See realtime source and the rendered preview. No editing."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1202
+#: lib/typster_web/live/editor_live/index.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Write — specific files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1210
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
 
-#: lib/typster_web/live/editor_live/index.ex:1002
+#: lib/typster_web/live/editor_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1002
+#: lib/typster_web/live/editor_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2568,115 +2568,115 @@ msgstr "The share link may have been rotated or revoked."
 msgid "share.public.invalid_title"
 msgstr "This link isn't valid"
 
-#: lib/typster_web/live/shared_project_live.ex:69
+#: lib/typster_web/live/shared_project_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1007
-#: lib/typster_web/live/editor_live/index.html.heex:1078
+#: lib/typster_web/live/editor_live/index.ex:1011
+#: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
-#: lib/typster_web/live/editor_live/index.ex:1005
-#: lib/typster_web/live/editor_live/index.html.heex:1106
+#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.html.heex:1107
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
-#: lib/typster_web/live/editor_live/index.ex:1006
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.ex:1010
+#: lib/typster_web/live/editor_live/index.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Viewer"
 
-#: lib/typster_web/live/shared_project_live.ex:127
+#: lib/typster_web/live/shared_project_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/shared_project_live.ex:126
+#: lib/typster_web/live/shared_project_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Compiled output"
 
-#: lib/typster_web/live/shared_project_live.ex:128
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Read-only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1286
+#: lib/typster_web/live/editor_live/index.html.heex:1287
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Link created"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1282
+#: lib/typster_web/live/editor_live/index.html.heex:1283
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Active editors now"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1278
+#: lib/typster_web/live/editor_live/index.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Opens last 7 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1018
+#: lib/typster_web/live/editor_live/index.html.heex:1019
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr "Invite collaborators, share a link, embed the project, or download the PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1039
+#: lib/typster_web/live/editor_live/index.html.heex:1040
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr "Embed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1040
+#: lib/typster_web/live/editor_live/index.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr "Export PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1038
+#: lib/typster_web/live/editor_live/index.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1037
+#: lib/typster_web/live/editor_live/index.html.heex:1038
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr "People"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1016
+#: lib/typster_web/live/editor_live/index.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1058
+#: lib/typster_web/live/editor_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1296
+#: lib/typster_web/live/editor_live/index.html.heex:1297
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Real-time opens, active editors, and locations — with Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1295
+#: lib/typster_web/live/editor_live/index.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "See who opens your link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Unlock with Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Free links are read-only or fully editable. Upgrade to scope writes."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1217
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Per-file write access is Pro"
@@ -2690,3 +2690,8 @@ msgstr "You're in — welcome to the project."
 #, elixir-autogen, elixir-format
 msgid "share.invite.invalid"
 msgstr "That invite link is invalid or has expired."
+
+#: lib/typster_web/live/shared_project_live.ex:113
+#, elixir-autogen, elixir-format
+msgid "share.public.powered_by"
+msgstr "Powered by"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:639
+#: lib/typster_web/live/editor_live/index.ex:700
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:697
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:340
+#: lib/typster_web/live/editor_live/index.ex:401
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:670
+#: lib/typster_web/live/editor_live/index.ex:731
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:497
-#: lib/typster_web/live/editor_live/index.ex:521
-#: lib/typster_web/live/editor_live/index.ex:813
+#: lib/typster_web/live/editor_live/index.ex:558
+#: lib/typster_web/live/editor_live/index.ex:582
+#: lib/typster_web/live/editor_live/index.ex:874
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr "Preview"
 
 #: lib/typster_web/live/editor_live/index.html.heex:732
-#: lib/typster_web/live/shared_project_live.ex:106
+#: lib/typster_web/live/shared_project_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:747
+#: lib/typster_web/live/editor_live/index.ex:808
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:745
+#: lib/typster_web/live/editor_live/index.ex:806
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:746
+#: lib/typster_web/live/editor_live/index.ex:807
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -2037,9 +2037,9 @@ msgstr "Appended when you press Enter"
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:462
-#: lib/typster_web/live/editor_live/index.ex:508
-#: lib/typster_web/live/editor_live/index.ex:669
+#: lib/typster_web/live/editor_live/index.ex:523
+#: lib/typster_web/live/editor_live/index.ex:569
+#: lib/typster_web/live/editor_live/index.ex:730
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,12 +2049,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:606
+#: lib/typster_web/live/editor_live/index.ex:667
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:575
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2119,7 +2119,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:763
+#: lib/typster_web/live/editor_live/index.ex:824
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2145,12 +2145,12 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:814
+#: lib/typster_web/live/editor_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1158
+#: lib/typster_web/live/editor_live/index.ex:1393
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1160
+#: lib/typster_web/live/editor_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1164
+#: lib/typster_web/live/editor_live/index.ex:1399
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2222,12 +2222,12 @@ msgstr "Off"
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:868
+#: lib/typster_web/live/editor_live/index.ex:929
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:855
+#: lib/typster_web/live/editor_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
@@ -2262,7 +2262,7 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:940
+#: lib/typster_web/live/editor_live/index.ex:1001
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
@@ -2298,127 +2298,127 @@ msgid "common.close"
 msgstr "Close"
 
 #: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1345
+#: lib/typster_web/live/editor_live/index.html.heex:1428
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Copy"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1386
+#: lib/typster_web/live/editor_live/index.html.heex:1469
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Done"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1244
+#: lib/typster_web/live/editor_live/index.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Allow downloads"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1245
+#: lib/typster_web/live/editor_live/index.html.heex:1252
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Visitors can download the compiled PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1260
+#: lib/typster_web/live/editor_live/index.html.heex:1267
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Expires in 30 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1261
+#: lib/typster_web/live/editor_live/index.html.heex:1268
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Auto-revokes the link after the set period."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Password-protect"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1265
+#: lib/typster_web/live/editor_live/index.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Visitor must enter a passphrase before opening."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1255
+#: lib/typster_web/live/editor_live/index.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Require sign-in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1256
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Visitors must sign in with a Typster account."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1324
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Components"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1334
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Visitor can edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1319
+#: lib/typster_web/live/editor_live/index.html.heex:1326
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "File tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1309
+#: lib/typster_web/live/editor_live/index.html.heex:1316
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
-msgstr "Visitors can read & open your project on any plan."
+msgstr "Visitors can read & open your project on any plan. Upgrade to let them edit live in their browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1315
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Embed is free — interactive sandbox is Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1323
+#: lib/typster_web/live/editor_live/index.html.heex:1329
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Compiled preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1454
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Download PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1377
+#: lib/typster_web/live/editor_live/index.html.heex:1460
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Exports the document compiled in your browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1355
+#: lib/typster_web/live/editor_live/index.html.heex:1438
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Last successful compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1363
+#: lib/typster_web/live/editor_live/index.html.heex:1446
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Includes embedded fonts. Re-export to refresh."
 
-#: lib/typster_web/live/editor_live/index.ex:298
+#: lib/typster_web/live/editor_live/index.ex:359
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Could not send that invite."
 
-#: lib/typster_web/live/editor_live/index.ex:295
+#: lib/typster_web/live/editor_live/index.ex:356
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Invited %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1383
+#: lib/typster_web/live/editor_live/index.html.heex:1466
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "Learn about permissions →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1272
+#: lib/typster_web/live/editor_live/index.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Link activity"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Advanced"
@@ -2458,7 +2458,7 @@ msgstr "Invite people"
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
 
-#: lib/typster_web/live/editor_live/index.ex:1013
+#: lib/typster_web/live/editor_live/index.ex:1074
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
@@ -2488,17 +2488,17 @@ msgstr "People with access"
 msgid "share.people.you"
 msgstr "you"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1230
+#: lib/typster_web/live/editor_live/index.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "careful"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1231
+#: lib/typster_web/live/editor_live/index.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1232
+#: lib/typster_web/live/editor_live/index.html.heex:1239
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Read + write everything and manage the link. Same as Owner."
@@ -2528,22 +2528,22 @@ msgstr "Read"
 msgid "share.perm.read_desc"
 msgstr "See realtime source and the rendered preview. No editing."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1203
+#: lib/typster_web/live/editor_live/index.html.heex:1208
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Write — specific files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1211
+#: lib/typster_web/live/editor_live/index.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
 
-#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2568,55 +2568,56 @@ msgstr "The share link may have been rotated or revoked."
 msgid "share.public.invalid_title"
 msgstr "This link isn't valid"
 
-#: lib/typster_web/live/shared_project_live.ex:117
+#: lib/typster_web/live/editor_live/index.ex:1311
+#: lib/typster_web/live/shared_project_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1011
+#: lib/typster_web/live/editor_live/index.ex:1072
 #: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
-#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.ex:1070
 #: lib/typster_web/live/editor_live/index.html.heex:1107
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
-#: lib/typster_web/live/editor_live/index.ex:1010
+#: lib/typster_web/live/editor_live/index.ex:1071
 #: lib/typster_web/live/editor_live/index.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Viewer"
 
-#: lib/typster_web/live/shared_project_live.ex:138
+#: lib/typster_web/live/shared_project_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/shared_project_live.ex:137
+#: lib/typster_web/live/shared_project_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Compiled output"
 
-#: lib/typster_web/live/shared_project_live.ex:139
+#: lib/typster_web/live/shared_project_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Read-only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1287
+#: lib/typster_web/live/editor_live/index.html.heex:1294
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Link created"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1290
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Active editors now"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Opens last 7 days"
@@ -2651,32 +2652,32 @@ msgstr "People"
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1062
+#: lib/typster_web/live/editor_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1297
+#: lib/typster_web/live/editor_live/index.html.heex:1304
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Real-time opens, active editors, and locations — with Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1296
+#: lib/typster_web/live/editor_live/index.html.heex:1303
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "See who opens your link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Unlock with Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1219
+#: lib/typster_web/live/editor_live/index.html.heex:1226
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Free links are read-only or fully editable. Upgrade to scope writes."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1225
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Per-file write access is Pro"
@@ -2691,7 +2692,93 @@ msgstr "You're in — welcome to the project."
 msgid "share.invite.invalid"
 msgstr "That invite link is invalid or has expired."
 
-#: lib/typster_web/live/shared_project_live.ex:113
+#: lib/typster_web/live/editor_live/index.ex:1308
+#: lib/typster_web/live/shared_project_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Powered by"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1353
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_always"
+msgstr "Always"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1355
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_hidden"
+msgstr "Hidden"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1354
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_onedit"
+msgstr "On edit"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1340
+#, elixir-autogen, elixir-format
+msgid "share.embed.hide_footer"
+msgstr "Hide Typster footer"
+
+#: lib/typster_web/live/editor_live/index.ex:1267
+#, elixir-autogen, elixir-format
+msgid "share.embed.host_example"
+msgstr "yoursite.dev/embedded-report"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1391
+#, elixir-autogen, elixir-format
+msgid "share.embed.live_preview"
+msgstr "Live preview"
+
+#: lib/typster_web/live/editor_live/index.ex:1280
+#, elixir-autogen, elixir-format
+msgid "share.embed.readonly"
+msgstr "Read-only"
+
+#: lib/typster_web/live/editor_live/index.ex:1303
+#, elixir-autogen, elixir-format
+msgid "share.embed.sample_body"
+msgstr "This is roughly how your compiled document appears to visitors."
+
+#: lib/typster_web/live/editor_live/index.ex:1302
+#, elixir-autogen, elixir-format
+msgid "share.embed.sample_meta"
+msgstr "Compiled preview"
+
+#: lib/typster_web/live/editor_live/index.ex:1277
+#, elixir-autogen, elixir-format
+msgid "share.embed.sandbox"
+msgstr "Sandbox"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1347
+#, elixir-autogen, elixir-format
+msgid "share.embed.save_cta"
+msgstr "Save CTA"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1361
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme"
+msgstr "Theme"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1367
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_auto"
+msgstr "Auto"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1369
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_dark"
+msgstr "Dark"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1368
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_light"
+msgstr "Light"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1375
+#, elixir-autogen, elixir-format
+msgid "share.embed.width"
+msgstr "Width"
+
+#: lib/typster_web/live/editor_live/index.ex:1115
+#, elixir-autogen, elixir-format
+msgid "share.embed.coming_soon"
+msgstr "// soon™ — still cooking 🍳  grab the iframe for now"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:635
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:540
+#: lib/typster_web/live/editor_live/index.ex:632
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:244
+#: lib/typster_web/live/editor_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:574
+#: lib/typster_web/live/editor_live/index.ex:666
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:401
-#: lib/typster_web/live/editor_live/index.ex:425
-#: lib/typster_web/live/editor_live/index.ex:717
+#: lib/typster_web/live/editor_live/index.ex:493
+#: lib/typster_web/live/editor_live/index.ex:517
+#: lib/typster_web/live/editor_live/index.ex:809
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -204,21 +204,22 @@ msgid "editor.preview"
 msgstr "Preview"
 
 #: lib/typster_web/live/editor_live/index.html.heex:731
+#: lib/typster_web/live/shared_project_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:651
+#: lib/typster_web/live/editor_live/index.ex:743
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:649
+#: lib/typster_web/live/editor_live/index.ex:741
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:650
+#: lib/typster_web/live/editor_live/index.ex:742
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -650,15 +651,11 @@ msgstr "Build failed"
 msgid "editor.refresh"
 msgstr "Recompile"
 
+#: lib/typster_web/live/editor_live/index.html.heex:70
 #: lib/typster_web/live/editor_live/index.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
-
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#, elixir-autogen, elixir-format
-msgid "editor.share_soon"
-msgstr "Sharing is coming soon"
 
 #: lib/typster_web/live/editor_live/index.html.heex:690
 #, elixir-autogen, elixir-format
@@ -2040,9 +2037,9 @@ msgstr "Appended when you press Enter"
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:366
-#: lib/typster_web/live/editor_live/index.ex:412
-#: lib/typster_web/live/editor_live/index.ex:573
+#: lib/typster_web/live/editor_live/index.ex:458
+#: lib/typster_web/live/editor_live/index.ex:504
+#: lib/typster_web/live/editor_live/index.ex:665
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2052,12 +2049,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:479
+#: lib/typster_web/live/editor_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2122,7 +2119,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:667
+#: lib/typster_web/live/editor_live/index.ex:759
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2148,12 +2145,12 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:718
+#: lib/typster_web/live/editor_live/index.ex:810
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:925
+#: lib/typster_web/live/editor_live/index.ex:1154
 #: lib/typster_web/live/editor_live/index.html.heex:674
 #: lib/typster_web/live/editor_live/index.html.heex:882
 #, elixir-autogen, elixir-format
@@ -2162,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:927
+#: lib/typster_web/live/editor_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:931
+#: lib/typster_web/live/editor_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2225,12 +2222,12 @@ msgstr "Off"
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:772
+#: lib/typster_web/live/editor_live/index.ex:864
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:759
+#: lib/typster_web/live/editor_live/index.ex:851
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
@@ -2265,7 +2262,7 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:844
+#: lib/typster_web/live/editor_live/index.ex:936
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
@@ -2294,3 +2291,392 @@ msgstr "Branch"
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr "Compile times (last 12 runs)"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1022
+#, elixir-autogen, elixir-format
+msgid "common.close"
+msgstr "Close"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1133
+#: lib/typster_web/live/editor_live/index.html.heex:1303
+#, elixir-autogen, elixir-format
+msgid "common.copy"
+msgstr "Copy"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1341
+#, elixir-autogen, elixir-format
+msgid "common.done"
+msgstr "Done"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1217
+#, elixir-autogen, elixir-format
+msgid "share.adv.download"
+msgstr "Allow downloads"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1218
+#, elixir-autogen, elixir-format
+msgid "share.adv.download_sub"
+msgstr "Visitors can download the compiled PDF."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1228
+#, elixir-autogen, elixir-format
+msgid "share.adv.expires"
+msgstr "Expires in 30 days"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1228
+#, elixir-autogen, elixir-format
+msgid "share.adv.expires_sub"
+msgstr "Auto-revokes the link after the set period."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1229
+#, elixir-autogen, elixir-format
+msgid "share.adv.password"
+msgstr "Password-protect"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1229
+#, elixir-autogen, elixir-format
+msgid "share.adv.password_sub"
+msgstr "Visitor must enter a passphrase before opening."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1227
+#, elixir-autogen, elixir-format
+msgid "share.adv.signin"
+msgstr "Require sign-in"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1227
+#, elixir-autogen, elixir-format
+msgid "share.adv.signin_sub"
+msgstr "Visitors must sign in with a Typster account."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1275
+#, elixir-autogen, elixir-format
+msgid "share.embed.components"
+msgstr "Components"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1287
+#, elixir-autogen, elixir-format
+msgid "share.embed.editable"
+msgstr "Visitor can edit"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1279
+#, elixir-autogen, elixir-format
+msgid "share.embed.file_tree"
+msgstr "File tree"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1269
+#, elixir-autogen, elixir-format
+msgid "share.embed.free_desc"
+msgstr "Visitors can read & open your project on any plan."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1268
+#, elixir-autogen, elixir-format
+msgid "share.embed.free_title"
+msgstr "Embed is free — interactive sandbox is Pro"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1283
+#, elixir-autogen, elixir-format
+msgid "share.embed.preview"
+msgstr "Compiled preview"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1329
+#, elixir-autogen, elixir-format
+msgid "share.export.download"
+msgstr "Download PDF"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1333
+#, elixir-autogen, elixir-format
+msgid "share.export.hint"
+msgstr "Exports the document compiled in your browser."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1313
+#, elixir-autogen, elixir-format
+msgid "share.export.label"
+msgstr "Last successful compile"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1321
+#, elixir-autogen, elixir-format
+msgid "share.export.meta"
+msgstr "Includes embedded fonts. Re-export to refresh."
+
+#: lib/typster_web/live/editor_live/index.ex:294
+#, elixir-autogen, elixir-format
+msgid "share.flash.invite_failed"
+msgstr "Could not send that invite."
+
+#: lib/typster_web/live/editor_live/index.ex:291
+#, elixir-autogen, elixir-format
+msgid "share.flash.invited"
+msgstr "Invited %{email}"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1339
+#, elixir-autogen, elixir-format
+msgid "share.learn"
+msgstr "Learn about permissions →"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1235
+#, elixir-autogen, elixir-format
+msgid "share.link.activity"
+msgstr "Link activity"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1211
+#, elixir-autogen, elixir-format
+msgid "share.link.advanced"
+msgstr "Advanced"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1120
+#, elixir-autogen, elixir-format
+msgid "share.link.label"
+msgstr "Share link"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1145
+#, elixir-autogen, elixir-format
+msgid "share.link.perm_label"
+msgstr "Anyone with this link can…"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1139
+#, elixir-autogen, elixir-format
+msgid "share.link.rotate"
+msgstr "Rotate key"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1137
+#, elixir-autogen, elixir-format
+msgid "share.link.rotate_hint"
+msgstr "Rotating the key revokes the current link instantly."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1062
+#, elixir-autogen, elixir-format
+msgid "share.people.add_placeholder"
+msgstr "Add by email…"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1054
+#, elixir-autogen, elixir-format
+msgid "share.people.invite"
+msgstr "Invite people"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1075
+#, elixir-autogen, elixir-format
+msgid "share.people.invite_hint"
+msgstr "Invitees get an email with a link and can edit after signing in."
+
+#: lib/typster_web/live/editor_live/index.ex:1009
+#, elixir-autogen, elixir-format
+msgid "share.people.invite_sent"
+msgstr "Invitation sent"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1102
+#, elixir-autogen, elixir-format
+msgid "share.people.pending"
+msgstr "Pending"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1108
+#, elixir-autogen, elixir-format
+msgid "share.people.remove"
+msgstr "Remove"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1072
+#, elixir-autogen, elixir-format
+msgid "share.people.send"
+msgstr "Send invite"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1080
+#, elixir-autogen, elixir-format
+msgid "share.people.with_access"
+msgstr "People with access"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1088
+#, elixir-autogen, elixir-format
+msgid "share.people.you"
+msgstr "you"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1203
+#, elixir-autogen, elixir-format
+msgid "share.perm.careful"
+msgstr "careful"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1204
+#, elixir-autogen, elixir-format
+msgid "share.perm.full"
+msgstr "Full access"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1205
+#, elixir-autogen, elixir-format
+msgid "share.perm.full_desc"
+msgstr "Read + write everything and manage the link. Same as Owner."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1161
+#, elixir-autogen, elixir-format
+msgid "share.perm.output"
+msgstr "Compiled output only"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1162
+#, elixir-autogen, elixir-format
+msgid "share.perm.output_desc"
+msgstr "Hides the source. Shows the latest successful compile."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1160
+#, elixir-autogen, elixir-format
+msgid "share.perm.pdf_only"
+msgstr "PDF only"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1152
+#, elixir-autogen, elixir-format
+msgid "share.perm.read"
+msgstr "Read"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1153
+#, elixir-autogen, elixir-format
+msgid "share.perm.read_desc"
+msgstr "See realtime source and the rendered preview. No editing."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1182
+#, elixir-autogen, elixir-format
+msgid "share.perm.write"
+msgstr "Write — specific files"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1187
+#, elixir-autogen, elixir-format
+msgid "share.perm.write_desc"
+msgstr "Pick exactly which files visitors can edit."
+
+#: lib/typster_web/live/editor_live/index.ex:1002
+#, elixir-autogen, elixir-format
+msgid "share.plan.free"
+msgstr "Free"
+
+#: lib/typster_web/live/editor_live/index.ex:1002
+#, elixir-autogen, elixir-format
+msgid "share.plan.pro"
+msgstr "Pro"
+
+#: lib/typster_web/live/shared_project_live.ex:53
+#, elixir-autogen, elixir-format
+msgid "share.public.home"
+msgstr "Go to Typster"
+
+#: lib/typster_web/live/shared_project_live.ex:25
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid"
+msgstr "Invalid link"
+
+#: lib/typster_web/live/shared_project_live.ex:52
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid_sub"
+msgstr "The share link may have been rotated or revoked."
+
+#: lib/typster_web/live/shared_project_live.ex:51
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid_title"
+msgstr "This link isn't valid"
+
+#: lib/typster_web/live/shared_project_live.ex:69
+#, elixir-autogen, elixir-format
+msgid "share.public.open_in_typster"
+msgstr "Open in Typster ↗"
+
+#: lib/typster_web/live/editor_live/index.ex:1007
+#: lib/typster_web/live/editor_live/index.html.heex:1068
+#, elixir-autogen, elixir-format
+msgid "share.role.editor"
+msgstr "Editor"
+
+#: lib/typster_web/live/editor_live/index.ex:1005
+#: lib/typster_web/live/editor_live/index.html.heex:1094
+#, elixir-autogen, elixir-format
+msgid "share.role.owner"
+msgstr "Owner"
+
+#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.html.heex:1069
+#, elixir-autogen, elixir-format
+msgid "share.role.viewer"
+msgstr "Viewer"
+
+#: lib/typster_web/live/shared_project_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "share.scope.full"
+msgstr "Full access"
+
+#: lib/typster_web/live/shared_project_live.ex:126
+#, elixir-autogen, elixir-format
+msgid "share.scope.output"
+msgstr "Compiled output"
+
+#: lib/typster_web/live/shared_project_live.ex:128
+#, elixir-autogen, elixir-format
+msgid "share.scope.read"
+msgstr "Read-only"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1250
+#, elixir-autogen, elixir-format
+msgid "share.stats.created"
+msgstr "Link created"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1246
+#, elixir-autogen, elixir-format
+msgid "share.stats.editors"
+msgstr "Active editors now"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1242
+#, elixir-autogen, elixir-format
+msgid "share.stats.opens"
+msgstr "Opens last 7 days"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1018
+#, elixir-autogen, elixir-format
+msgid "share.subtitle"
+msgstr "Invite collaborators, share a link, embed the project, or download the PDF."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1034
+#, elixir-autogen, elixir-format
+msgid "share.tab.embed"
+msgstr "Embed"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1035
+#, elixir-autogen, elixir-format
+msgid "share.tab.export"
+msgstr "Export PDF"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1033
+#, elixir-autogen, elixir-format
+msgid "share.tab.link"
+msgstr "Link"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1032
+#, elixir-autogen, elixir-format
+msgid "share.tab.people"
+msgstr "People"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1016
+#, elixir-autogen, elixir-format
+msgid "share.title"
+msgstr "Share"
+
+#: lib/typster_web/live/editor_live/index.ex:1058
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.cta"
+msgstr "Upgrade"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1257
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.stats_desc"
+msgstr "Real-time opens, active editors, and locations — with Pro."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1256
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.stats_title"
+msgstr "See who opens your link"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1224
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.unlock"
+msgstr "Unlock with Pro"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1192
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.write_desc"
+msgstr "Free links are read-only or fully editable. Upgrade to scope writes."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1191
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.write_title"
+msgstr "Per-file write access is Pro"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -2301,108 +2301,108 @@ msgstr "Ветка"
 msgid "editor.status.compile_times"
 msgstr "Время компиляции (последние 12)"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1022
+#: lib/typster_web/live/editor_live/index.html.heex:1026
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr "Закрыть"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1133
-#: lib/typster_web/live/editor_live/index.html.heex:1303
+#: lib/typster_web/live/editor_live/index.html.heex:1149
+#: lib/typster_web/live/editor_live/index.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Копировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1341
+#: lib/typster_web/live/editor_live/index.html.heex:1385
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1217
+#: lib/typster_web/live/editor_live/index.html.heex:1243
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Разрешить скачивание"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Посетители могут скачать готовый PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1259
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Истекает через 30 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Автоматически отзывает ссылку по сроку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Пароль"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Посетитель вводит пароль перед открытием."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1227
+#: lib/typster_web/live/editor_live/index.html.heex:1254
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Требовать вход"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1227
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Нужен вход в аккаунт Typster."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1275
+#: lib/typster_web/live/editor_live/index.html.heex:1314
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Компоненты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1287
+#: lib/typster_web/live/editor_live/index.html.heex:1326
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Гость может править"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1318
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "Дерево файлов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1269
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Посетители могут читать и открывать проект на любом тарифе."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1268
+#: lib/typster_web/live/editor_live/index.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Встраивание бесплатно — интерактивная песочница в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1322
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1329
+#: lib/typster_web/live/editor_live/index.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Скачать PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1333
+#: lib/typster_web/live/editor_live/index.html.heex:1376
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Экспортирует документ, собранный в вашем браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1313
+#: lib/typster_web/live/editor_live/index.html.heex:1354
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Последний успешный результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1321
+#: lib/typster_web/live/editor_live/index.html.heex:1362
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
@@ -2417,52 +2417,52 @@ msgstr "Не удалось отправить приглашение."
 msgid "share.flash.invited"
 msgstr "Приглашён %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1339
+#: lib/typster_web/live/editor_live/index.html.heex:1382
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "О правах доступа →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1235
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Активность ссылки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1211
+#: lib/typster_web/live/editor_live/index.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Дополнительно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1120
+#: lib/typster_web/live/editor_live/index.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1145
+#: lib/typster_web/live/editor_live/index.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr "Любой по ссылке может…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1139
+#: lib/typster_web/live/editor_live/index.html.heex:1159
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr "Сменить ключ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1137
+#: lib/typster_web/live/editor_live/index.html.heex:1153
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr "Смена ключа мгновенно отзывает текущую ссылку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1062
+#: lib/typster_web/live/editor_live/index.html.heex:1072
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr "Добавить по email…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1054
+#: lib/typster_web/live/editor_live/index.html.heex:1059
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr "Пригласить людей"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1075
+#: lib/typster_web/live/editor_live/index.html.heex:1085
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
@@ -2472,77 +2472,77 @@ msgstr "Приглашённые получат письмо со ссылкой
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1102
+#: lib/typster_web/live/editor_live/index.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr "Ожидает"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1108
+#: lib/typster_web/live/editor_live/index.html.heex:1124
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr "Удалить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1072
+#: lib/typster_web/live/editor_live/index.html.heex:1082
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr "Отправить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1080
+#: lib/typster_web/live/editor_live/index.html.heex:1090
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr "Есть доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1088
+#: lib/typster_web/live/editor_live/index.html.heex:1100
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr "вы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1203
+#: lib/typster_web/live/editor_live/index.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "осторожно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1204
+#: lib/typster_web/live/editor_live/index.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1205
+#: lib/typster_web/live/editor_live/index.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Чтение и запись всего, управление ссылкой. Как у владельца."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1161
+#: lib/typster_web/live/editor_live/index.html.heex:1181
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1162
+#: lib/typster_web/live/editor_live/index.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr "Скрывает исходник. Показывает последний успешный результат."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1180
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr "только PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1152
+#: lib/typster_web/live/editor_live/index.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr "Чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr "Видит исходник и превью в реальном времени. Без правок."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1202
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Запись — выбранные файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1187
+#: lib/typster_web/live/editor_live/index.html.heex:1210
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
@@ -2583,19 +2583,19 @@ msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
 #: lib/typster_web/live/editor_live/index.ex:1007
-#: lib/typster_web/live/editor_live/index.html.heex:1068
+#: lib/typster_web/live/editor_live/index.html.heex:1078
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
 #: lib/typster_web/live/editor_live/index.ex:1005
-#: lib/typster_web/live/editor_live/index.html.heex:1094
+#: lib/typster_web/live/editor_live/index.html.heex:1106
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
 #: lib/typster_web/live/editor_live/index.ex:1006
-#: lib/typster_web/live/editor_live/index.html.heex:1069
+#: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Читатель"
@@ -2615,17 +2615,17 @@ msgstr "Только результат"
 msgid "share.scope.read"
 msgstr "Только чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Ссылка создана"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1246
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Сейчас редактируют"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1242
+#: lib/typster_web/live/editor_live/index.html.heex:1278
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Открытий за 7 дней"
@@ -2635,22 +2635,22 @@ msgstr "Открытий за 7 дней"
 msgid "share.subtitle"
 msgstr "Пригласите соавторов, поделитесь ссылкой, встройте проект или скачайте PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1034
+#: lib/typster_web/live/editor_live/index.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr "Встроить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1035
+#: lib/typster_web/live/editor_live/index.html.heex:1040
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr "Экспорт PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1033
+#: lib/typster_web/live/editor_live/index.html.heex:1038
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1032
+#: lib/typster_web/live/editor_live/index.html.heex:1037
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr "Люди"
@@ -2665,27 +2665,37 @@ msgstr "Поделиться"
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1257
+#: lib/typster_web/live/editor_live/index.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Открытия, активные редакторы и геолокация — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1256
+#: lib/typster_web/live/editor_live/index.html.heex:1295
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "Кто открывает вашу ссылку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1224
+#: lib/typster_web/live/editor_live/index.html.heex:1250
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Открыть в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1192
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Бесплатные ссылки — только чтение или полный доступ. Точечная запись — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1191
+#: lib/typster_web/live/editor_live/index.html.heex:1217
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Пофайловая запись — в Pro"
+
+#: lib/typster_web/controllers/invite_controller.ex:18
+#, elixir-autogen, elixir-format
+msgid "share.invite.accepted"
+msgstr "Готово — добро пожаловать в проект."
+
+#: lib/typster_web/controllers/invite_controller.ex:23
+#, elixir-autogen, elixir-format
+msgid "share.invite.invalid"
+msgstr "Эта ссылка-приглашение недействительна или истекла."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr "Войти"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Выйти"
@@ -134,122 +134,122 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:407
+#: lib/typster_web/live/editor_live/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:109
+#: lib/typster_web/live/editor_live/index.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:715
 #: lib/typster_web/live/editor_live/index.html.heex:716
+#: lib/typster_web/live/editor_live/index.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:219
-#: lib/typster_web/live/editor_live/index.html.heex:292
+#: lib/typster_web/live/editor_live/index.html.heex:220
+#: lib/typster_web/live/editor_live/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:635
+#: lib/typster_web/live/editor_live/index.ex:639
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:632
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:336
+#: lib/typster_web/live/editor_live/index.ex:340
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:666
+#: lib/typster_web/live/editor_live/index.ex:670
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:493
-#: lib/typster_web/live/editor_live/index.ex:517
-#: lib/typster_web/live/editor_live/index.ex:809
+#: lib/typster_web/live/editor_live/index.ex:497
+#: lib/typster_web/live/editor_live/index.ex:521
+#: lib/typster_web/live/editor_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:242
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:533
+#: lib/typster_web/live/editor_live/index.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:297
+#: lib/typster_web/live/editor_live/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:668
+#: lib/typster_web/live/editor_live/index.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:731
-#: lib/typster_web/live/shared_project_live.ex:113
+#: lib/typster_web/live/editor_live/index.html.heex:732
+#: lib/typster_web/live/shared_project_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:743
+#: lib/typster_web/live/editor_live/index.ex:747
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:741
+#: lib/typster_web/live/editor_live/index.ex:745
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:742
+#: lib/typster_web/live/editor_live/index.ex:746
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:412
-#: lib/typster_web/live/editor_live/index.html.heex:441
+#: lib/typster_web/live/editor_live/index.html.heex:413
+#: lib/typster_web/live/editor_live/index.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:181
+#: lib/typster_web/live/editor_live/index.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Темная тема"
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:178
+#: lib/typster_web/live/editor_live/index.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Светлая тема"
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:184
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Как в системе"
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:138
+#: lib/typster_web/live/editor_live/index.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Переключить тему"
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr "Мои проекты"
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:189
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Проекты"
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:192
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Настройки"
@@ -519,157 +519,157 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:99
-#: lib/typster_web/live/editor_live/index.html.heex:685
+#: lib/typster_web/live/editor_live/index.html.heex:100
+#: lib/typster_web/live/editor_live/index.html.heex:686
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:78
-#: lib/typster_web/live/editor_live/index.html.heex:681
+#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:682
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:212
 #: lib/typster_web/live/editor_live/index.html.heex:213
+#: lib/typster_web/live/editor_live/index.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:542
 #: lib/typster_web/live/editor_live/index.html.heex:543
+#: lib/typster_web/live/editor_live/index.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:561
 #: lib/typster_web/live/editor_live/index.html.heex:562
+#: lib/typster_web/live/editor_live/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:608
 #: lib/typster_web/live/editor_live/index.html.heex:609
+#: lib/typster_web/live/editor_live/index.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:551
 #: lib/typster_web/live/editor_live/index.html.heex:552
+#: lib/typster_web/live/editor_live/index.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:589
 #: lib/typster_web/live/editor_live/index.html.heex:590
+#: lib/typster_web/live/editor_live/index.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:570
 #: lib/typster_web/live/editor_live/index.html.heex:571
+#: lib/typster_web/live/editor_live/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:580
 #: lib/typster_web/live/editor_live/index.html.heex:581
+#: lib/typster_web/live/editor_live/index.html.heex:582
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:598
 #: lib/typster_web/live/editor_live/index.html.heex:599
+#: lib/typster_web/live/editor_live/index.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:384
+#: lib/typster_web/live/editor_live/index.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:391
+#: lib/typster_web/live/editor_live/index.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:917
-#: lib/typster_web/live/editor_live/index.html.heex:925
-#: lib/typster_web/live/editor_live/index.html.heex:934
+#: lib/typster_web/live/editor_live/index.html.heex:918
+#: lib/typster_web/live/editor_live/index.html.heex:926
+#: lib/typster_web/live/editor_live/index.html.heex:935
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:969
-#: lib/typster_web/live/editor_live/index.html.heex:977
-#: lib/typster_web/live/editor_live/index.html.heex:986
+#: lib/typster_web/live/editor_live/index.html.heex:970
+#: lib/typster_web/live/editor_live/index.html.heex:978
+#: lib/typster_web/live/editor_live/index.html.heex:987
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:952
+#: lib/typster_web/live/editor_live/index.html.heex:953
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:975
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:909
+#: lib/typster_web/live/editor_live/index.html.heex:910
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:942
-#: lib/typster_web/live/editor_live/index.html.heex:948
+#: lib/typster_web/live/editor_live/index.html.heex:919
+#: lib/typster_web/live/editor_live/index.html.heex:943
+#: lib/typster_web/live/editor_live/index.html.heex:949
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:923
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:970
-#: lib/typster_web/live/editor_live/index.html.heex:989
-#: lib/typster_web/live/editor_live/index.html.heex:998
+#: lib/typster_web/live/editor_live/index.html.heex:971
+#: lib/typster_web/live/editor_live/index.html.heex:990
+#: lib/typster_web/live/editor_live/index.html.heex:999
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:676
+#: lib/typster_web/live/editor_live/index.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:707
+#: lib/typster_web/live/editor_live/index.html.heex:708
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#: lib/typster_web/live/editor_live/index.html.heex:72
+#: lib/typster_web/live/editor_live/index.html.heex:71
+#: lib/typster_web/live/editor_live/index.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.html.heex:690
+#: lib/typster_web/live/editor_live/index.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:699
+#: lib/typster_web/live/editor_live/index.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:695
+#: lib/typster_web/live/editor_live/index.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -833,38 +833,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:651
+#: lib/typster_web/live/editor_live/index.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:659
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:648
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:657
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:647
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:645
+#: lib/typster_web/live/editor_live/index.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:618
 #: lib/typster_web/live/editor_live/index.html.heex:619
+#: lib/typster_web/live/editor_live/index.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1992,17 +1992,17 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:225
+#: lib/typster_web/live/editor_live/index.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
@@ -2012,40 +2012,40 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:257
+#: lib/typster_web/live/editor_live/index.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:350
+#: lib/typster_web/live/editor_live/index.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:337
+#: lib/typster_web/live/editor_live/index.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:458
-#: lib/typster_web/live/editor_live/index.ex:504
-#: lib/typster_web/live/editor_live/index.ex:665
+#: lib/typster_web/live/editor_live/index.ex:462
+#: lib/typster_web/live/editor_live/index.ex:508
+#: lib/typster_web/live/editor_live/index.ex:669
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,24 +2055,24 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:602
+#: lib/typster_web/live/editor_live/index.ex:606
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:571
+#: lib/typster_web/live/editor_live/index.ex:575
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:283
+#: lib/typster_web/live/editor_live/index.html.heex:284
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:474
 #: lib/typster_web/live/editor_live/index.html.heex:475
+#: lib/typster_web/live/editor_live/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
@@ -2088,7 +2088,7 @@ msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:513
+#: lib/typster_web/live/editor_live/index.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
@@ -2098,7 +2098,7 @@ msgstr "Закреплён"
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:386
+#: lib/typster_web/live/editor_live/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2106,12 +2106,12 @@ msgstr[0] "%{count} раздел"
 msgstr[1] "%{count} раздела"
 msgstr[2] "%{count} разделов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:234
+#: lib/typster_web/live/editor_live/index.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "Новая папка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:336
+#: lib/typster_web/live/editor_live/index.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "имя папки"
@@ -2121,45 +2121,45 @@ msgstr "имя папки"
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:526
+#: lib/typster_web/live/editor_live/index.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:759
+#: lib/typster_web/live/editor_live/index.ex:763
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:447
+#: lib/typster_web/live/editor_live/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Ваши шаблоны"
 
-#: lib/typster_web/live/editor_live/index.html.heex:473
+#: lib/typster_web/live/editor_live/index.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Удалить этот шаблон?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:493
+#: lib/typster_web/live/editor_live/index.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Загрузите файл для повторного использования"
 
-#: lib/typster_web/live/editor_live/index.html.heex:463
 #: lib/typster_web/live/editor_live/index.html.heex:464
+#: lib/typster_web/live/editor_live/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:810
+#: lib/typster_web/live/editor_live/index.ex:814
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1154
-#: lib/typster_web/live/editor_live/index.html.heex:674
-#: lib/typster_web/live/editor_live/index.html.heex:882
+#: lib/typster_web/live/editor_live/index.ex:1158
+#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1156
+#: lib/typster_web/live/editor_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,78 +2175,78 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1160
+#: lib/typster_web/live/editor_live/index.ex:1164
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:788
+#: lib/typster_web/live/editor_live/index.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Очистить лог"
 
-#: lib/typster_web/live/editor_live/index.html.heex:794
+#: lib/typster_web/live/editor_live/index.html.heex:795
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Закрыть панель"
 
-#: lib/typster_web/live/editor_live/index.html.heex:770
+#: lib/typster_web/live/editor_live/index.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "К первой"
 
-#: lib/typster_web/live/editor_live/index.html.heex:745
-#: lib/typster_web/live/editor_live/index.html.heex:884
+#: lib/typster_web/live/editor_live/index.html.heex:746
+#: lib/typster_web/live/editor_live/index.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Лог компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:802
+#: lib/typster_web/live/editor_live/index.html.heex:803
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "Пока нет компиляций"
 
-#: lib/typster_web/live/editor_live/index.html.heex:815
+#: lib/typster_web/live/editor_live/index.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "Нет проблем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:754
+#: lib/typster_web/live/editor_live/index.html.heex:755
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Проблемы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:875
+#: lib/typster_web/live/editor_live/index.html.heex:876
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Показать панель компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:775
+#: lib/typster_web/live/editor_live/index.html.heex:776
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Выкл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:773
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:864
+#: lib/typster_web/live/editor_live/index.ex:868
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:851
+#: lib/typster_web/live/editor_live/index.ex:855
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
 
-#: lib/typster_web/live/editor_live/index.html.heex:159
+#: lib/typster_web/live/editor_live/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr "Аккаунт"
 
-#: lib/typster_web/live/editor_live/index.html.heex:175
+#: lib/typster_web/live/editor_live/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr "Оформление"
@@ -2256,12 +2256,12 @@ msgstr "Оформление"
 msgid "editor.topbar.back"
 msgstr "Назад"
 
-#: lib/typster_web/live/editor_live/index.html.heex:120
+#: lib/typster_web/live/editor_live/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr "Соавторы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:87
+#: lib/typster_web/live/editor_live/index.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr "Ошибка"
@@ -2271,12 +2271,12 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:936
+#: lib/typster_web/live/editor_live/index.ex:940
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
 
-#: lib/typster_web/live/editor_live/index.html.heex:148
+#: lib/typster_web/live/editor_live/index.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr "Язык"
@@ -2296,263 +2296,263 @@ msgstr "Сменить проект"
 msgid "editor.topbar.branch"
 msgstr "Ветка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:854
+#: lib/typster_web/live/editor_live/index.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr "Время компиляции (последние 12)"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1026
+#: lib/typster_web/live/editor_live/index.html.heex:1027
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr "Закрыть"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1149
-#: lib/typster_web/live/editor_live/index.html.heex:1344
+#: lib/typster_web/live/editor_live/index.html.heex:1150
+#: lib/typster_web/live/editor_live/index.html.heex:1345
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Копировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1385
+#: lib/typster_web/live/editor_live/index.html.heex:1386
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1243
+#: lib/typster_web/live/editor_live/index.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Разрешить скачивание"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1244
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Посетители могут скачать готовый PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1259
+#: lib/typster_web/live/editor_live/index.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Истекает через 30 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1260
+#: lib/typster_web/live/editor_live/index.html.heex:1261
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Автоматически отзывает ссылку по сроку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Пароль"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1265
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Посетитель вводит пароль перед открытием."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1254
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Требовать вход"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1255
+#: lib/typster_web/live/editor_live/index.html.heex:1256
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Нужен вход в аккаунт Typster."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1314
+#: lib/typster_web/live/editor_live/index.html.heex:1315
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Компоненты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1326
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Гость может править"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1318
+#: lib/typster_web/live/editor_live/index.html.heex:1319
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "Дерево файлов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Посетители могут читать и открывать проект на любом тарифе."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1307
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Встраивание бесплатно — интерактивная песочница в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1322
+#: lib/typster_web/live/editor_live/index.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1371
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Скачать PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1376
+#: lib/typster_web/live/editor_live/index.html.heex:1377
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Экспортирует документ, собранный в вашем браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1354
+#: lib/typster_web/live/editor_live/index.html.heex:1355
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Последний успешный результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1362
+#: lib/typster_web/live/editor_live/index.html.heex:1363
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
 
-#: lib/typster_web/live/editor_live/index.ex:294
+#: lib/typster_web/live/editor_live/index.ex:298
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Не удалось отправить приглашение."
 
-#: lib/typster_web/live/editor_live/index.ex:291
+#: lib/typster_web/live/editor_live/index.ex:295
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Приглашён %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1382
+#: lib/typster_web/live/editor_live/index.html.heex:1383
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "О правах доступа →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1271
+#: lib/typster_web/live/editor_live/index.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Активность ссылки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Дополнительно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1136
+#: lib/typster_web/live/editor_live/index.html.heex:1137
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1165
+#: lib/typster_web/live/editor_live/index.html.heex:1166
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr "Любой по ссылке может…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1159
+#: lib/typster_web/live/editor_live/index.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr "Сменить ключ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1154
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr "Смена ключа мгновенно отзывает текущую ссылку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1072
+#: lib/typster_web/live/editor_live/index.html.heex:1073
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr "Добавить по email…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1059
+#: lib/typster_web/live/editor_live/index.html.heex:1060
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr "Пригласить людей"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1085
+#: lib/typster_web/live/editor_live/index.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
 
-#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1117
+#: lib/typster_web/live/editor_live/index.html.heex:1118
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr "Ожидает"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1124
+#: lib/typster_web/live/editor_live/index.html.heex:1125
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr "Удалить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1082
+#: lib/typster_web/live/editor_live/index.html.heex:1083
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr "Отправить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1090
+#: lib/typster_web/live/editor_live/index.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr "Есть доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1100
+#: lib/typster_web/live/editor_live/index.html.heex:1101
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr "вы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1229
+#: lib/typster_web/live/editor_live/index.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "осторожно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1230
+#: lib/typster_web/live/editor_live/index.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1231
+#: lib/typster_web/live/editor_live/index.html.heex:1232
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Чтение и запись всего, управление ссылкой. Как у владельца."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1183
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr "Скрывает исходник. Показывает последний успешный результат."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1180
+#: lib/typster_web/live/editor_live/index.html.heex:1181
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr "только PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1172
+#: lib/typster_web/live/editor_live/index.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr "Чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1173
+#: lib/typster_web/live/editor_live/index.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr "Видит исходник и превью в реальном времени. Без правок."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1202
+#: lib/typster_web/live/editor_live/index.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Запись — выбранные файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1210
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
 
-#: lib/typster_web/live/editor_live/index.ex:1002
+#: lib/typster_web/live/editor_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1002
+#: lib/typster_web/live/editor_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2577,115 +2577,115 @@ msgstr "Ссылку могли сменить или отозвать."
 msgid "share.public.invalid_title"
 msgstr "Ссылка недействительна"
 
-#: lib/typster_web/live/shared_project_live.ex:69
+#: lib/typster_web/live/shared_project_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1007
-#: lib/typster_web/live/editor_live/index.html.heex:1078
+#: lib/typster_web/live/editor_live/index.ex:1011
+#: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
-#: lib/typster_web/live/editor_live/index.ex:1005
-#: lib/typster_web/live/editor_live/index.html.heex:1106
+#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.html.heex:1107
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
-#: lib/typster_web/live/editor_live/index.ex:1006
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.ex:1010
+#: lib/typster_web/live/editor_live/index.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Читатель"
 
-#: lib/typster_web/live/shared_project_live.ex:127
+#: lib/typster_web/live/shared_project_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/shared_project_live.ex:126
+#: lib/typster_web/live/shared_project_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/shared_project_live.ex:128
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Только чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1286
+#: lib/typster_web/live/editor_live/index.html.heex:1287
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Ссылка создана"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1282
+#: lib/typster_web/live/editor_live/index.html.heex:1283
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Сейчас редактируют"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1278
+#: lib/typster_web/live/editor_live/index.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Открытий за 7 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1018
+#: lib/typster_web/live/editor_live/index.html.heex:1019
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr "Пригласите соавторов, поделитесь ссылкой, встройте проект или скачайте PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1039
+#: lib/typster_web/live/editor_live/index.html.heex:1040
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr "Встроить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1040
+#: lib/typster_web/live/editor_live/index.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr "Экспорт PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1038
+#: lib/typster_web/live/editor_live/index.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1037
+#: lib/typster_web/live/editor_live/index.html.heex:1038
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr "Люди"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1016
+#: lib/typster_web/live/editor_live/index.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1058
+#: lib/typster_web/live/editor_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1296
+#: lib/typster_web/live/editor_live/index.html.heex:1297
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Открытия, активные редакторы и геолокация — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1295
+#: lib/typster_web/live/editor_live/index.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "Кто открывает вашу ссылку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Открыть в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Бесплатные ссылки — только чтение или полный доступ. Точечная запись — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1217
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Пофайловая запись — в Pro"
@@ -2699,3 +2699,8 @@ msgstr "Готово — добро пожаловать в проект."
 #, elixir-autogen, elixir-format
 msgid "share.invite.invalid"
 msgstr "Эта ссылка-приглашение недействительна или истекла."
+
+#: lib/typster_web/live/shared_project_live.ex:113
+#, elixir-autogen, elixir-format
+msgid "share.public.powered_by"
+msgstr "Работает на"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:543
+#: lib/typster_web/live/editor_live/index.ex:635
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:540
+#: lib/typster_web/live/editor_live/index.ex:632
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:244
+#: lib/typster_web/live/editor_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:574
+#: lib/typster_web/live/editor_live/index.ex:666
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:401
-#: lib/typster_web/live/editor_live/index.ex:425
-#: lib/typster_web/live/editor_live/index.ex:717
+#: lib/typster_web/live/editor_live/index.ex:493
+#: lib/typster_web/live/editor_live/index.ex:517
+#: lib/typster_web/live/editor_live/index.ex:809
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -204,21 +204,22 @@ msgid "editor.preview"
 msgstr "Превью"
 
 #: lib/typster_web/live/editor_live/index.html.heex:731
+#: lib/typster_web/live/shared_project_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:651
+#: lib/typster_web/live/editor_live/index.ex:743
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:649
+#: lib/typster_web/live/editor_live/index.ex:741
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:650
+#: lib/typster_web/live/editor_live/index.ex:742
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -652,15 +653,11 @@ msgstr "Ошибка сборки"
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
+#: lib/typster_web/live/editor_live/index.html.heex:70
 #: lib/typster_web/live/editor_live/index.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
-
-#: lib/typster_web/live/editor_live/index.html.heex:70
-#, elixir-autogen, elixir-format
-msgid "editor.share_soon"
-msgstr "Совместный доступ скоро появится"
 
 #: lib/typster_web/live/editor_live/index.html.heex:690
 #, elixir-autogen, elixir-format
@@ -2046,9 +2043,9 @@ msgstr "Добавится по нажатию Enter"
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:366
-#: lib/typster_web/live/editor_live/index.ex:412
-#: lib/typster_web/live/editor_live/index.ex:573
+#: lib/typster_web/live/editor_live/index.ex:458
+#: lib/typster_web/live/editor_live/index.ex:504
+#: lib/typster_web/live/editor_live/index.ex:665
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2058,12 +2055,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:510
+#: lib/typster_web/live/editor_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:479
+#: lib/typster_web/live/editor_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2129,7 +2126,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:667
+#: lib/typster_web/live/editor_live/index.ex:759
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2155,12 +2152,12 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:718
+#: lib/typster_web/live/editor_live/index.ex:810
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:925
+#: lib/typster_web/live/editor_live/index.ex:1154
 #: lib/typster_web/live/editor_live/index.html.heex:674
 #: lib/typster_web/live/editor_live/index.html.heex:882
 #, elixir-autogen, elixir-format
@@ -2170,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:927
+#: lib/typster_web/live/editor_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2178,7 +2175,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:931
+#: lib/typster_web/live/editor_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2234,12 +2231,12 @@ msgstr "Выкл"
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:772
+#: lib/typster_web/live/editor_live/index.ex:864
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:759
+#: lib/typster_web/live/editor_live/index.ex:851
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
@@ -2274,7 +2271,7 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:844
+#: lib/typster_web/live/editor_live/index.ex:936
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
@@ -2303,3 +2300,392 @@ msgstr "Ветка"
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr "Время компиляции (последние 12)"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1022
+#, elixir-autogen, elixir-format
+msgid "common.close"
+msgstr "Закрыть"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1133
+#: lib/typster_web/live/editor_live/index.html.heex:1303
+#, elixir-autogen, elixir-format
+msgid "common.copy"
+msgstr "Копировать"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1341
+#, elixir-autogen, elixir-format
+msgid "common.done"
+msgstr "Готово"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1217
+#, elixir-autogen, elixir-format
+msgid "share.adv.download"
+msgstr "Разрешить скачивание"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1218
+#, elixir-autogen, elixir-format
+msgid "share.adv.download_sub"
+msgstr "Посетители могут скачать готовый PDF."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1228
+#, elixir-autogen, elixir-format
+msgid "share.adv.expires"
+msgstr "Истекает через 30 дней"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1228
+#, elixir-autogen, elixir-format
+msgid "share.adv.expires_sub"
+msgstr "Автоматически отзывает ссылку по сроку."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1229
+#, elixir-autogen, elixir-format
+msgid "share.adv.password"
+msgstr "Пароль"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1229
+#, elixir-autogen, elixir-format
+msgid "share.adv.password_sub"
+msgstr "Посетитель вводит пароль перед открытием."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1227
+#, elixir-autogen, elixir-format
+msgid "share.adv.signin"
+msgstr "Требовать вход"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1227
+#, elixir-autogen, elixir-format
+msgid "share.adv.signin_sub"
+msgstr "Нужен вход в аккаунт Typster."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1275
+#, elixir-autogen, elixir-format
+msgid "share.embed.components"
+msgstr "Компоненты"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1287
+#, elixir-autogen, elixir-format
+msgid "share.embed.editable"
+msgstr "Гость может править"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1279
+#, elixir-autogen, elixir-format
+msgid "share.embed.file_tree"
+msgstr "Дерево файлов"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1269
+#, elixir-autogen, elixir-format
+msgid "share.embed.free_desc"
+msgstr "Посетители могут читать и открывать проект на любом тарифе."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1268
+#, elixir-autogen, elixir-format
+msgid "share.embed.free_title"
+msgstr "Встраивание бесплатно — интерактивная песочница в Pro"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1283
+#, elixir-autogen, elixir-format
+msgid "share.embed.preview"
+msgstr "Превью"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1329
+#, elixir-autogen, elixir-format
+msgid "share.export.download"
+msgstr "Скачать PDF"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1333
+#, elixir-autogen, elixir-format
+msgid "share.export.hint"
+msgstr "Экспортирует документ, собранный в вашем браузере."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1313
+#, elixir-autogen, elixir-format
+msgid "share.export.label"
+msgstr "Последний успешный результат"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1321
+#, elixir-autogen, elixir-format
+msgid "share.export.meta"
+msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
+
+#: lib/typster_web/live/editor_live/index.ex:294
+#, elixir-autogen, elixir-format
+msgid "share.flash.invite_failed"
+msgstr "Не удалось отправить приглашение."
+
+#: lib/typster_web/live/editor_live/index.ex:291
+#, elixir-autogen, elixir-format
+msgid "share.flash.invited"
+msgstr "Приглашён %{email}"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1339
+#, elixir-autogen, elixir-format
+msgid "share.learn"
+msgstr "О правах доступа →"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1235
+#, elixir-autogen, elixir-format
+msgid "share.link.activity"
+msgstr "Активность ссылки"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1211
+#, elixir-autogen, elixir-format
+msgid "share.link.advanced"
+msgstr "Дополнительно"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1120
+#, elixir-autogen, elixir-format
+msgid "share.link.label"
+msgstr "Ссылка"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1145
+#, elixir-autogen, elixir-format
+msgid "share.link.perm_label"
+msgstr "Любой по ссылке может…"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1139
+#, elixir-autogen, elixir-format
+msgid "share.link.rotate"
+msgstr "Сменить ключ"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1137
+#, elixir-autogen, elixir-format
+msgid "share.link.rotate_hint"
+msgstr "Смена ключа мгновенно отзывает текущую ссылку."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1062
+#, elixir-autogen, elixir-format
+msgid "share.people.add_placeholder"
+msgstr "Добавить по email…"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1054
+#, elixir-autogen, elixir-format
+msgid "share.people.invite"
+msgstr "Пригласить людей"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1075
+#, elixir-autogen, elixir-format
+msgid "share.people.invite_hint"
+msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
+
+#: lib/typster_web/live/editor_live/index.ex:1009
+#, elixir-autogen, elixir-format
+msgid "share.people.invite_sent"
+msgstr "Приглашение отправлено"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1102
+#, elixir-autogen, elixir-format
+msgid "share.people.pending"
+msgstr "Ожидает"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1108
+#, elixir-autogen, elixir-format
+msgid "share.people.remove"
+msgstr "Удалить"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1072
+#, elixir-autogen, elixir-format
+msgid "share.people.send"
+msgstr "Отправить"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1080
+#, elixir-autogen, elixir-format
+msgid "share.people.with_access"
+msgstr "Есть доступ"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1088
+#, elixir-autogen, elixir-format
+msgid "share.people.you"
+msgstr "вы"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1203
+#, elixir-autogen, elixir-format
+msgid "share.perm.careful"
+msgstr "осторожно"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1204
+#, elixir-autogen, elixir-format
+msgid "share.perm.full"
+msgstr "Полный доступ"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1205
+#, elixir-autogen, elixir-format
+msgid "share.perm.full_desc"
+msgstr "Чтение и запись всего, управление ссылкой. Как у владельца."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1161
+#, elixir-autogen, elixir-format
+msgid "share.perm.output"
+msgstr "Только результат"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1162
+#, elixir-autogen, elixir-format
+msgid "share.perm.output_desc"
+msgstr "Скрывает исходник. Показывает последний успешный результат."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1160
+#, elixir-autogen, elixir-format
+msgid "share.perm.pdf_only"
+msgstr "только PDF"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1152
+#, elixir-autogen, elixir-format
+msgid "share.perm.read"
+msgstr "Чтение"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1153
+#, elixir-autogen, elixir-format
+msgid "share.perm.read_desc"
+msgstr "Видит исходник и превью в реальном времени. Без правок."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1182
+#, elixir-autogen, elixir-format
+msgid "share.perm.write"
+msgstr "Запись — выбранные файлы"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1187
+#, elixir-autogen, elixir-format
+msgid "share.perm.write_desc"
+msgstr "Выберите, какие файлы можно редактировать."
+
+#: lib/typster_web/live/editor_live/index.ex:1002
+#, elixir-autogen, elixir-format
+msgid "share.plan.free"
+msgstr "Free"
+
+#: lib/typster_web/live/editor_live/index.ex:1002
+#, elixir-autogen, elixir-format
+msgid "share.plan.pro"
+msgstr "Pro"
+
+#: lib/typster_web/live/shared_project_live.ex:53
+#, elixir-autogen, elixir-format
+msgid "share.public.home"
+msgstr "На главную"
+
+#: lib/typster_web/live/shared_project_live.ex:25
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid"
+msgstr "Недействительная ссылка"
+
+#: lib/typster_web/live/shared_project_live.ex:52
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid_sub"
+msgstr "Ссылку могли сменить или отозвать."
+
+#: lib/typster_web/live/shared_project_live.ex:51
+#, elixir-autogen, elixir-format
+msgid "share.public.invalid_title"
+msgstr "Ссылка недействительна"
+
+#: lib/typster_web/live/shared_project_live.ex:69
+#, elixir-autogen, elixir-format
+msgid "share.public.open_in_typster"
+msgstr "Открыть в Typster ↗"
+
+#: lib/typster_web/live/editor_live/index.ex:1007
+#: lib/typster_web/live/editor_live/index.html.heex:1068
+#, elixir-autogen, elixir-format
+msgid "share.role.editor"
+msgstr "Редактор"
+
+#: lib/typster_web/live/editor_live/index.ex:1005
+#: lib/typster_web/live/editor_live/index.html.heex:1094
+#, elixir-autogen, elixir-format
+msgid "share.role.owner"
+msgstr "Владелец"
+
+#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.html.heex:1069
+#, elixir-autogen, elixir-format
+msgid "share.role.viewer"
+msgstr "Читатель"
+
+#: lib/typster_web/live/shared_project_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "share.scope.full"
+msgstr "Полный доступ"
+
+#: lib/typster_web/live/shared_project_live.ex:126
+#, elixir-autogen, elixir-format
+msgid "share.scope.output"
+msgstr "Только результат"
+
+#: lib/typster_web/live/shared_project_live.ex:128
+#, elixir-autogen, elixir-format
+msgid "share.scope.read"
+msgstr "Только чтение"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1250
+#, elixir-autogen, elixir-format
+msgid "share.stats.created"
+msgstr "Ссылка создана"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1246
+#, elixir-autogen, elixir-format
+msgid "share.stats.editors"
+msgstr "Сейчас редактируют"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1242
+#, elixir-autogen, elixir-format
+msgid "share.stats.opens"
+msgstr "Открытий за 7 дней"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1018
+#, elixir-autogen, elixir-format
+msgid "share.subtitle"
+msgstr "Пригласите соавторов, поделитесь ссылкой, встройте проект или скачайте PDF."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1034
+#, elixir-autogen, elixir-format
+msgid "share.tab.embed"
+msgstr "Встроить"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1035
+#, elixir-autogen, elixir-format
+msgid "share.tab.export"
+msgstr "Экспорт PDF"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1033
+#, elixir-autogen, elixir-format
+msgid "share.tab.link"
+msgstr "Ссылка"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1032
+#, elixir-autogen, elixir-format
+msgid "share.tab.people"
+msgstr "Люди"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1016
+#, elixir-autogen, elixir-format
+msgid "share.title"
+msgstr "Поделиться"
+
+#: lib/typster_web/live/editor_live/index.ex:1058
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.cta"
+msgstr "Перейти на Pro"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1257
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.stats_desc"
+msgstr "Открытия, активные редакторы и геолокация — в Pro."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1256
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.stats_title"
+msgstr "Кто открывает вашу ссылку"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1224
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.unlock"
+msgstr "Открыть в Pro"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1192
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.write_desc"
+msgstr "Бесплатные ссылки — только чтение или полный доступ. Точечная запись — в Pro."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1191
+#, elixir-autogen, elixir-format
+msgid "share.upgrade.write_title"
+msgstr "Пофайловая запись — в Pro"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -204,7 +204,7 @@ msgid "editor.preview"
 msgstr "Превью"
 
 #: lib/typster_web/live/editor_live/index.html.heex:732
-#: lib/typster_web/live/shared_project_live.ex:111
+#: lib/typster_web/live/shared_project_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
@@ -2157,7 +2157,7 @@ msgstr "Создать файл из этого шаблона"
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1393
+#: lib/typster_web/live/editor_live/index.ex:1308
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1395
+#: lib/typster_web/live/editor_live/index.ex:1310
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,7 +2175,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1399
+#: lib/typster_web/live/editor_live/index.ex:1314
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2307,12 +2307,12 @@ msgid "common.close"
 msgstr "Закрыть"
 
 #: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1428
+#: lib/typster_web/live/editor_live/index.html.heex:1441
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Копировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1469
+#: lib/typster_web/live/editor_live/index.html.heex:1482
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Готово"
@@ -2362,12 +2362,12 @@ msgstr "Нужен вход в аккаунт Typster."
 msgid "share.embed.components"
 msgstr "Компоненты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1334
+#: lib/typster_web/live/editor_live/index.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Гость может править"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1326
+#: lib/typster_web/live/editor_live/index.html.heex:1328
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "Дерево файлов"
@@ -2382,27 +2382,27 @@ msgstr "Гости могут читать и открывать проект н
 msgid "share.embed.free_title"
 msgstr "Встраивание бесплатно — интерактивная песочница в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1329
+#: lib/typster_web/live/editor_live/index.html.heex:1333
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1454
+#: lib/typster_web/live/editor_live/index.html.heex:1467
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Скачать PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1460
+#: lib/typster_web/live/editor_live/index.html.heex:1473
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Экспортирует документ, собранный в вашем браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1438
+#: lib/typster_web/live/editor_live/index.html.heex:1451
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Последний успешный результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1446
+#: lib/typster_web/live/editor_live/index.html.heex:1459
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
@@ -2417,7 +2417,7 @@ msgstr "Не удалось отправить приглашение."
 msgid "share.flash.invited"
 msgstr "Приглашён %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1466
+#: lib/typster_web/live/editor_live/index.html.heex:1479
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "О правах доступа →"
@@ -2557,7 +2557,7 @@ msgstr "Free"
 msgid "share.plan.pro"
 msgstr "Pro"
 
-#: lib/typster_web/live/shared_project_live.ex:53
+#: lib/typster_web/live/shared_project_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr "На главную"
@@ -2567,18 +2567,17 @@ msgstr "На главную"
 msgid "share.public.invalid"
 msgstr "Недействительная ссылка"
 
-#: lib/typster_web/live/shared_project_live.ex:52
+#: lib/typster_web/live/shared_project_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr "Ссылку могли сменить или отозвать."
 
-#: lib/typster_web/live/shared_project_live.ex:51
+#: lib/typster_web/live/shared_project_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr "Ссылка недействительна"
 
-#: lib/typster_web/live/editor_live/index.ex:1311
-#: lib/typster_web/live/shared_project_live.ex:122
+#: lib/typster_web/live/shared_project_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
@@ -2601,17 +2600,17 @@ msgstr "Владелец"
 msgid "share.role.viewer"
 msgstr "Читатель"
 
-#: lib/typster_web/live/shared_project_live.ex:143
+#: lib/typster_web/live/shared_project_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/shared_project_live.ex:142
+#: lib/typster_web/live/shared_project_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/shared_project_live.ex:144
+#: lib/typster_web/live/shared_project_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Только чтение"
@@ -2661,7 +2660,7 @@ msgstr "Люди"
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1186
+#: lib/typster_web/live/editor_live/index.ex:1169
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
@@ -2701,88 +2700,63 @@ msgstr "Готово — добро пожаловать в проект."
 msgid "share.invite.invalid"
 msgstr "Эта ссылка-приглашение недействительна или истекла."
 
-#: lib/typster_web/live/editor_live/index.ex:1308
-#: lib/typster_web/live/shared_project_live.ex:118
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Работает на"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1353
+#: lib/typster_web/live/editor_live/index.html.heex:1357
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr "Всегда"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1355
+#: lib/typster_web/live/editor_live/index.html.heex:1359
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr "Скрыта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1354
+#: lib/typster_web/live/editor_live/index.html.heex:1358
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr "При правке"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr "Скрыть подпись Typster"
 
-#: lib/typster_web/live/editor_live/index.ex:1267
-#, elixir-autogen, elixir-format
-msgid "share.embed.host_example"
-msgstr "твой-сайт.рф/встроенный-отчёт"
-
-#: lib/typster_web/live/editor_live/index.html.heex:1391
+#: lib/typster_web/live/editor_live/index.html.heex:1395
+#: lib/typster_web/live/editor_live/index.html.heex:1405
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr "Живой предпросмотр"
 
-#: lib/typster_web/live/editor_live/index.ex:1280
-#, elixir-autogen, elixir-format
-msgid "share.embed.readonly"
-msgstr "Только чтение"
-
-#: lib/typster_web/live/editor_live/index.ex:1303
-#, elixir-autogen, elixir-format
-msgid "share.embed.sample_body"
-msgstr "Примерно так скомпилированный документ видят гости."
-
-#: lib/typster_web/live/editor_live/index.ex:1302
-#, elixir-autogen, elixir-format
-msgid "share.embed.sample_meta"
-msgstr "Скомпилированный предпросмотр"
-
-#: lib/typster_web/live/editor_live/index.ex:1277
-#, elixir-autogen, elixir-format
-msgid "share.embed.sandbox"
-msgstr "Песочница"
-
-#: lib/typster_web/live/editor_live/index.html.heex:1347
+#: lib/typster_web/live/editor_live/index.html.heex:1351
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr "Кнопка «Сохранить»"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1361
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr "Тема"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1367
+#: lib/typster_web/live/editor_live/index.html.heex:1371
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr "Авто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1369
+#: lib/typster_web/live/editor_live/index.html.heex:1373
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr "Тёмная"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1368
+#: lib/typster_web/live/editor_live/index.html.heex:1372
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr "Светлая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1375
+#: lib/typster_web/live/editor_live/index.html.heex:1379
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr "Ширина"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:639
+#: lib/typster_web/live/editor_live/index.ex:700
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:697
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:340
+#: lib/typster_web/live/editor_live/index.ex:401
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:670
+#: lib/typster_web/live/editor_live/index.ex:731
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:497
-#: lib/typster_web/live/editor_live/index.ex:521
-#: lib/typster_web/live/editor_live/index.ex:813
+#: lib/typster_web/live/editor_live/index.ex:558
+#: lib/typster_web/live/editor_live/index.ex:582
+#: lib/typster_web/live/editor_live/index.ex:874
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr "Превью"
 
 #: lib/typster_web/live/editor_live/index.html.heex:732
-#: lib/typster_web/live/shared_project_live.ex:106
+#: lib/typster_web/live/shared_project_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:747
+#: lib/typster_web/live/editor_live/index.ex:808
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:745
+#: lib/typster_web/live/editor_live/index.ex:806
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:746
+#: lib/typster_web/live/editor_live/index.ex:807
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -2043,9 +2043,9 @@ msgstr "Добавится по нажатию Enter"
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:462
-#: lib/typster_web/live/editor_live/index.ex:508
-#: lib/typster_web/live/editor_live/index.ex:669
+#: lib/typster_web/live/editor_live/index.ex:523
+#: lib/typster_web/live/editor_live/index.ex:569
+#: lib/typster_web/live/editor_live/index.ex:730
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,12 +2055,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:606
+#: lib/typster_web/live/editor_live/index.ex:667
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:575
+#: lib/typster_web/live/editor_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2126,7 +2126,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:763
+#: lib/typster_web/live/editor_live/index.ex:824
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2152,12 +2152,12 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:814
+#: lib/typster_web/live/editor_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1158
+#: lib/typster_web/live/editor_live/index.ex:1393
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1160
+#: lib/typster_web/live/editor_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,7 +2175,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1164
+#: lib/typster_web/live/editor_live/index.ex:1399
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2231,12 +2231,12 @@ msgstr "Выкл"
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:868
+#: lib/typster_web/live/editor_live/index.ex:929
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:855
+#: lib/typster_web/live/editor_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
@@ -2271,7 +2271,7 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:940
+#: lib/typster_web/live/editor_live/index.ex:1001
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
@@ -2307,127 +2307,127 @@ msgid "common.close"
 msgstr "Закрыть"
 
 #: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1345
+#: lib/typster_web/live/editor_live/index.html.heex:1428
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Копировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1386
+#: lib/typster_web/live/editor_live/index.html.heex:1469
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1244
+#: lib/typster_web/live/editor_live/index.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Разрешить скачивание"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1245
+#: lib/typster_web/live/editor_live/index.html.heex:1252
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Посетители могут скачать готовый PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1260
+#: lib/typster_web/live/editor_live/index.html.heex:1267
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Истекает через 30 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1261
+#: lib/typster_web/live/editor_live/index.html.heex:1268
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Автоматически отзывает ссылку по сроку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Пароль"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1265
+#: lib/typster_web/live/editor_live/index.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Посетитель вводит пароль перед открытием."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1255
+#: lib/typster_web/live/editor_live/index.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Требовать вход"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1256
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Нужен вход в аккаунт Typster."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1324
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Компоненты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1334
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Гость может править"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1319
+#: lib/typster_web/live/editor_live/index.html.heex:1326
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "Дерево файлов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1309
+#: lib/typster_web/live/editor_live/index.html.heex:1316
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
-msgstr "Посетители могут читать и открывать проект на любом тарифе."
+msgstr "Гости могут читать и открывать проект на любом тарифе. Обновитесь до Pro, чтобы они правили прямо в браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1315
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Встраивание бесплатно — интерактивная песочница в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1323
+#: lib/typster_web/live/editor_live/index.html.heex:1329
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1454
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Скачать PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1377
+#: lib/typster_web/live/editor_live/index.html.heex:1460
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Экспортирует документ, собранный в вашем браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1355
+#: lib/typster_web/live/editor_live/index.html.heex:1438
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Последний успешный результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1363
+#: lib/typster_web/live/editor_live/index.html.heex:1446
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
 
-#: lib/typster_web/live/editor_live/index.ex:298
+#: lib/typster_web/live/editor_live/index.ex:359
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Не удалось отправить приглашение."
 
-#: lib/typster_web/live/editor_live/index.ex:295
+#: lib/typster_web/live/editor_live/index.ex:356
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Приглашён %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1383
+#: lib/typster_web/live/editor_live/index.html.heex:1466
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "О правах доступа →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1272
+#: lib/typster_web/live/editor_live/index.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Активность ссылки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Дополнительно"
@@ -2467,7 +2467,7 @@ msgstr "Пригласить людей"
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
 
-#: lib/typster_web/live/editor_live/index.ex:1013
+#: lib/typster_web/live/editor_live/index.ex:1074
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
@@ -2497,17 +2497,17 @@ msgstr "Есть доступ"
 msgid "share.people.you"
 msgstr "вы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1230
+#: lib/typster_web/live/editor_live/index.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "осторожно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1231
+#: lib/typster_web/live/editor_live/index.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1232
+#: lib/typster_web/live/editor_live/index.html.heex:1239
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Чтение и запись всего, управление ссылкой. Как у владельца."
@@ -2537,22 +2537,22 @@ msgstr "Чтение"
 msgid "share.perm.read_desc"
 msgstr "Видит исходник и превью в реальном времени. Без правок."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1203
+#: lib/typster_web/live/editor_live/index.html.heex:1208
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Запись — выбранные файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1211
+#: lib/typster_web/live/editor_live/index.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
 
-#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1006
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2577,55 +2577,56 @@ msgstr "Ссылку могли сменить или отозвать."
 msgid "share.public.invalid_title"
 msgstr "Ссылка недействительна"
 
-#: lib/typster_web/live/shared_project_live.ex:117
+#: lib/typster_web/live/editor_live/index.ex:1311
+#: lib/typster_web/live/shared_project_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1011
+#: lib/typster_web/live/editor_live/index.ex:1072
 #: lib/typster_web/live/editor_live/index.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
-#: lib/typster_web/live/editor_live/index.ex:1009
+#: lib/typster_web/live/editor_live/index.ex:1070
 #: lib/typster_web/live/editor_live/index.html.heex:1107
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
-#: lib/typster_web/live/editor_live/index.ex:1010
+#: lib/typster_web/live/editor_live/index.ex:1071
 #: lib/typster_web/live/editor_live/index.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Читатель"
 
-#: lib/typster_web/live/shared_project_live.ex:138
+#: lib/typster_web/live/shared_project_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/shared_project_live.ex:137
+#: lib/typster_web/live/shared_project_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/shared_project_live.ex:139
+#: lib/typster_web/live/shared_project_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Только чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1287
+#: lib/typster_web/live/editor_live/index.html.heex:1294
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Ссылка создана"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1290
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Сейчас редактируют"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Открытий за 7 дней"
@@ -2660,32 +2661,32 @@ msgstr "Люди"
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1062
+#: lib/typster_web/live/editor_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1297
+#: lib/typster_web/live/editor_live/index.html.heex:1304
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Открытия, активные редакторы и геолокация — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1296
+#: lib/typster_web/live/editor_live/index.html.heex:1303
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "Кто открывает вашу ссылку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Открыть в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1219
+#: lib/typster_web/live/editor_live/index.html.heex:1226
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Бесплатные ссылки — только чтение или полный доступ. Точечная запись — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1218
+#: lib/typster_web/live/editor_live/index.html.heex:1225
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Пофайловая запись — в Pro"
@@ -2700,7 +2701,93 @@ msgstr "Готово — добро пожаловать в проект."
 msgid "share.invite.invalid"
 msgstr "Эта ссылка-приглашение недействительна или истекла."
 
-#: lib/typster_web/live/shared_project_live.ex:113
+#: lib/typster_web/live/editor_live/index.ex:1308
+#: lib/typster_web/live/shared_project_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Работает на"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1353
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_always"
+msgstr "Всегда"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1355
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_hidden"
+msgstr "Скрыта"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1354
+#, elixir-autogen, elixir-format
+msgid "share.embed.cta_onedit"
+msgstr "При правке"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1340
+#, elixir-autogen, elixir-format
+msgid "share.embed.hide_footer"
+msgstr "Скрыть подпись Typster"
+
+#: lib/typster_web/live/editor_live/index.ex:1267
+#, elixir-autogen, elixir-format
+msgid "share.embed.host_example"
+msgstr "твой-сайт.рф/встроенный-отчёт"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1391
+#, elixir-autogen, elixir-format
+msgid "share.embed.live_preview"
+msgstr "Живой предпросмотр"
+
+#: lib/typster_web/live/editor_live/index.ex:1280
+#, elixir-autogen, elixir-format
+msgid "share.embed.readonly"
+msgstr "Только чтение"
+
+#: lib/typster_web/live/editor_live/index.ex:1303
+#, elixir-autogen, elixir-format
+msgid "share.embed.sample_body"
+msgstr "Примерно так скомпилированный документ видят гости."
+
+#: lib/typster_web/live/editor_live/index.ex:1302
+#, elixir-autogen, elixir-format
+msgid "share.embed.sample_meta"
+msgstr "Скомпилированный предпросмотр"
+
+#: lib/typster_web/live/editor_live/index.ex:1277
+#, elixir-autogen, elixir-format
+msgid "share.embed.sandbox"
+msgstr "Песочница"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1347
+#, elixir-autogen, elixir-format
+msgid "share.embed.save_cta"
+msgstr "Кнопка «Сохранить»"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1361
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme"
+msgstr "Тема"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1367
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_auto"
+msgstr "Авто"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1369
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_dark"
+msgstr "Тёмная"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1368
+#, elixir-autogen, elixir-format
+msgid "share.embed.theme_light"
+msgstr "Светлая"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1375
+#, elixir-autogen, elixir-format
+msgid "share.embed.width"
+msgstr "Ширина"
+
+#: lib/typster_web/live/editor_live/index.ex:1115
+#, elixir-autogen, elixir-format
+msgid "share.embed.coming_soon"
+msgstr "// скоро™ — ещё готовим 🍳  пока бери iframe"

--- a/priv/repo/migrations/20260601051627_create_share_links.exs
+++ b/priv/repo/migrations/20260601051627_create_share_links.exs
@@ -1,0 +1,20 @@
+defmodule Typster.Repo.Migrations.CreateShareLinks do
+  use Ecto.Migration
+
+  def change do
+    create table(:share_links, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :token, :string, null: false
+      add :scope, :string, null: false, default: "read"
+      add :allow_download, :boolean, null: false, default: true
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:share_links, [:token])
+    create unique_index(:share_links, [:project_id])
+  end
+end

--- a/priv/repo/migrations/20260601051628_create_collaborators.exs
+++ b/priv/repo/migrations/20260601051628_create_collaborators.exs
@@ -1,0 +1,22 @@
+defmodule Typster.Repo.Migrations.CreateCollaborators do
+  use Ecto.Migration
+
+  def change do
+    create table(:collaborators, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :email, :string, null: false
+      add :role, :string, null: false, default: "viewer"
+      add :status, :string, null: false, default: "pending"
+      add :user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:collaborators, [:project_id])
+    create index(:collaborators, [:user_id])
+    create unique_index(:collaborators, [:project_id, :email])
+  end
+end

--- a/test/typster/features_test.exs
+++ b/test/typster/features_test.exs
@@ -27,6 +27,13 @@ defmodule Typster.FeaturesTest do
   end
 
   describe "can?/2 (open-core fallback)" do
+    # Force the Free impl so these assert the community-build contract even when
+    # the Pro submodule (Typster.Pro.Features) happens to be compiled in locally.
+    setup do
+      Application.put_env(:typster, :features_impl, Typster.Features.Free)
+      :ok
+    end
+
     test "denies every Pro feature when no Pro impl is loaded" do
       scope = %Scope{user: nil, plan: :free}
 

--- a/test/typster/files_test.exs
+++ b/test/typster/files_test.exs
@@ -152,4 +152,39 @@ defmodule Typster.FilesTest do
       refute unpinned.pinned
     end
   end
+
+  describe "accepted collaborators can read and write files" do
+    setup do
+      owner = Typster.AccountsFixtures.user_scope_fixture()
+      project = project_fixture(owner)
+      member = Typster.AccountsFixtures.user_scope_fixture()
+
+      {:ok, invite} =
+        Typster.Sharing.invite_collaborator(owner, project.id, "g@example.com", :editor)
+
+      %{owner: owner, project: project, member: member, invite: invite}
+    end
+
+    test "a pending invitee has no file access yet", %{member: member, project: project} do
+      assert_raise Ecto.NoResultsError, fn -> Files.get_file_tree(member, project.id) end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Files.create_file(member, project.id, %{path: "main.typ"})
+      end
+    end
+
+    test "an accepted collaborator can create, read, and update files", ctx do
+      %{owner: owner, project: project, member: member, invite: invite} = ctx
+      {:ok, file} = Files.create_file(owner, project.id, %{path: "main.typ", content: "= Hi"})
+      {:ok, _} = Typster.Sharing.accept_invite(member, invite.id)
+
+      assert [_ | _] = Files.get_file_tree(member, project.id)
+      assert Files.get_file!(member, file.id).id == file.id
+      assert {:ok, saved} = Files.update_file_content(member, file, "= Edited by collaborator")
+      assert saved.content == "= Edited by collaborator"
+
+      assert {:ok, made} = Files.create_file(member, project.id, %{path: "chapter.typ"})
+      assert made.project_id == project.id
+    end
+  end
 end

--- a/test/typster/projects_test.exs
+++ b/test/typster/projects_test.exs
@@ -6,6 +6,7 @@ defmodule Typster.ProjectsTest do
 
   alias Typster.Accounts.Scope
   alias Typster.Projects
+  alias Typster.Sharing
 
   describe "project scoping" do
     test "create_project/2 assigns ownership to the current scope user" do
@@ -36,6 +37,61 @@ defmodule Typster.ProjectsTest do
       assert_raise Ecto.NoResultsError, fn ->
         Projects.get_project!(Scope.for_user(user), project.id)
       end
+    end
+  end
+
+  describe "collaborator access (member-aware)" do
+    setup do
+      owner = user_scope_fixture()
+      project = project_fixture(owner)
+      member = user_scope_fixture()
+      stranger = user_scope_fixture()
+      {:ok, invite} = Sharing.invite_collaborator(owner, project.id, "guest@example.com", :editor)
+      %{owner: owner, project: project, member: member, stranger: stranger, invite: invite}
+    end
+
+    test "get_editable_project!/2 allows owner + accepted collaborator, rejects others", ctx do
+      %{owner: owner, project: project, member: member, stranger: stranger, invite: invite} = ctx
+
+      assert Projects.get_editable_project!(owner, project.id).id == project.id
+
+      # Pending invite is not yet access.
+      assert_raise Ecto.NoResultsError, fn ->
+        Projects.get_editable_project!(member, project.id)
+      end
+
+      {:ok, _} = Sharing.accept_invite(member, invite.id)
+      assert Projects.get_editable_project!(member, project.id).id == project.id
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Projects.get_editable_project!(stranger, project.id)
+      end
+    end
+
+    test "owner-only get_project!/2 still rejects accepted collaborators", ctx do
+      %{project: project, member: member, invite: invite} = ctx
+      {:ok, _} = Sharing.accept_invite(member, invite.id)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Projects.get_project!(member, project.id)
+      end
+    end
+
+    test "list_projects/1 includes projects shared as an accepted collaborator", ctx do
+      %{project: project, member: member, invite: invite} = ctx
+
+      assert Projects.list_projects(member) == []
+      {:ok, _} = Sharing.accept_invite(member, invite.id)
+      assert [shared] = Projects.list_projects(member)
+      assert shared.id == project.id
+    end
+
+    test "owner?/2 distinguishes owner from collaborator", ctx do
+      %{owner: owner, project: project, member: member, invite: invite} = ctx
+      {:ok, _} = Sharing.accept_invite(member, invite.id)
+
+      assert Projects.owner?(owner, project)
+      refute Projects.owner?(member, project)
     end
   end
 end

--- a/test/typster/sharing_test.exs
+++ b/test/typster/sharing_test.exs
@@ -1,0 +1,231 @@
+defmodule Typster.SharingTest do
+  use Typster.DataCase, async: true
+
+  import Swoosh.TestAssertions
+  import Typster.AccountsFixtures, only: [user_scope_fixture: 0]
+  import Typster.ProjectsFixtures, only: [project_fixture: 1]
+
+  alias Typster.Sharing
+  alias Typster.Sharing.Collaborator
+  alias Typster.Sharing.ShareLink
+
+  setup do
+    scope = user_scope_fixture()
+    project = project_fixture(scope)
+    # Drain the confirmation/login emails emitted while building the user
+    # fixture so each test asserts only against its own sent emails.
+    flush_emails()
+    %{scope: scope, project: project}
+  end
+
+  # Removes any pending `{:email, _}` messages from the test process inbox.
+  defp flush_emails do
+    receive do
+      {:email, _} -> flush_emails()
+    after
+      0 -> :ok
+    end
+  end
+
+  describe "get_or_create_link/2" do
+    test "creates a link with a token and default read scope", %{scope: scope, project: project} do
+      link = Sharing.get_or_create_link(scope, project.id)
+
+      assert %ShareLink{} = link
+      assert link.project_id == project.id
+      assert link.scope == :read
+      assert link.allow_download == true
+      assert is_binary(link.token) and link.token != ""
+      assert link.token =~ ~r/^[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/
+    end
+
+    test "is idempotent: returns the same link on repeat calls", %{
+      scope: scope,
+      project: project
+    } do
+      first = Sharing.get_or_create_link(scope, project.id)
+      second = Sharing.get_or_create_link(scope, project.id)
+
+      assert first.id == second.id
+      assert first.token == second.token
+    end
+
+    test "raises when the scope does not own the project", %{project: project} do
+      other = user_scope_fixture()
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Sharing.get_or_create_link(other, project.id)
+      end
+    end
+  end
+
+  describe "update_link/3" do
+    test "changes the link scope and allow_download", %{scope: scope, project: project} do
+      link = Sharing.get_or_create_link(scope, project.id)
+
+      assert {:ok, updated} =
+               Sharing.update_link(scope, link, %{scope: :full, allow_download: false})
+
+      assert updated.scope == :full
+      assert updated.allow_download == false
+    end
+
+    test "raises when the scope does not own the project", %{scope: scope, project: project} do
+      link = Sharing.get_or_create_link(scope, project.id)
+      other = user_scope_fixture()
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Sharing.update_link(other, link, %{scope: :full})
+      end
+    end
+  end
+
+  describe "rotate_link/2" do
+    test "generates a new token", %{scope: scope, project: project} do
+      link = Sharing.get_or_create_link(scope, project.id)
+
+      assert {:ok, rotated} = Sharing.rotate_link(scope, link)
+      assert rotated.token != link.token
+      assert rotated.token =~ ~r/^[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/
+    end
+
+    test "raises when the scope does not own the project", %{scope: scope, project: project} do
+      link = Sharing.get_or_create_link(scope, project.id)
+      other = user_scope_fixture()
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Sharing.rotate_link(other, link)
+      end
+    end
+  end
+
+  describe "get_link_by_token/1 (public)" do
+    test "resolves a created link and preloads the project", %{scope: scope, project: project} do
+      link = Sharing.get_or_create_link(scope, project.id)
+
+      resolved = Sharing.get_link_by_token(link.token)
+
+      assert %ShareLink{} = resolved
+      assert resolved.id == link.id
+      assert resolved.project.id == project.id
+    end
+
+    test "returns nil for an unknown token" do
+      assert Sharing.get_link_by_token("zzzz-zzzz-zzzz") == nil
+    end
+
+    test "returns nil for a blank or non-binary token" do
+      assert Sharing.get_link_by_token("") == nil
+      assert Sharing.get_link_by_token("   ") == nil
+      assert Sharing.get_link_by_token(nil) == nil
+    end
+  end
+
+  describe "invite_collaborator/4" do
+    test "creates a pending collaborator and sends an email", %{scope: scope, project: project} do
+      assert {:ok, %Collaborator{} = collab} =
+               Sharing.invite_collaborator(scope, project.id, "friend@example.com", :editor)
+
+      assert collab.email == "friend@example.com"
+      assert collab.role == :editor
+      assert collab.status == :pending
+      assert collab.project_id == project.id
+
+      assert_received {:email, %Swoosh.Email{} = email}
+      assert {"", "friend@example.com"} in email.to
+      assert email.subject =~ project.name
+      assert email.text_body =~ project.name
+    end
+
+    test "defaults the role to viewer", %{scope: scope, project: project} do
+      assert {:ok, collab} =
+               Sharing.invite_collaborator(scope, project.id, "viewer@example.com")
+
+      assert collab.role == :viewer
+    end
+
+    test "returns an error changeset for an invalid email", %{scope: scope, project: project} do
+      assert {:error, changeset} =
+               Sharing.invite_collaborator(scope, project.id, "not-an-email", :viewer)
+
+      refute changeset.valid?
+      assert "must have the @ sign and no spaces" in errors_on(changeset).email
+      assert_no_email_sent()
+    end
+
+    test "rejects a duplicate email for the same project", %{scope: scope, project: project} do
+      assert {:ok, _} =
+               Sharing.invite_collaborator(scope, project.id, "dupe@example.com", :viewer)
+
+      assert {:error, changeset} =
+               Sharing.invite_collaborator(scope, project.id, "dupe@example.com", :viewer)
+
+      refute changeset.valid?
+
+      errors = errors_on(changeset)
+
+      assert "is already a collaborator on this project" in (errors[:email] || errors[:project_id])
+    end
+
+    test "raises when the scope does not own the project", %{project: project} do
+      other = user_scope_fixture()
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Sharing.invite_collaborator(other, project.id, "x@example.com", :viewer)
+      end
+    end
+  end
+
+  describe "list_collaborators/2, update_collaborator_role/3, remove_collaborator/2" do
+    test "lists collaborators for the project", %{scope: scope, project: project} do
+      {:ok, a} = Sharing.invite_collaborator(scope, project.id, "a@example.com", :viewer)
+      {:ok, b} = Sharing.invite_collaborator(scope, project.id, "b@example.com", :editor)
+
+      ids = scope |> Sharing.list_collaborators(project.id) |> Enum.map(& &1.id)
+      assert a.id in ids
+      assert b.id in ids
+      assert length(ids) == 2
+    end
+
+    test "updates a collaborator role", %{scope: scope, project: project} do
+      {:ok, collab} = Sharing.invite_collaborator(scope, project.id, "c@example.com", :viewer)
+
+      assert {:ok, updated} = Sharing.update_collaborator_role(scope, collab, :editor)
+      assert updated.role == :editor
+    end
+
+    test "removes a collaborator", %{scope: scope, project: project} do
+      {:ok, collab} = Sharing.invite_collaborator(scope, project.id, "d@example.com", :viewer)
+
+      assert {:ok, _} = Sharing.remove_collaborator(scope, collab)
+      assert Sharing.list_collaborators(scope, project.id) == []
+    end
+
+    test "raises when a non-owner lists, updates, or removes", %{scope: scope, project: project} do
+      {:ok, collab} = Sharing.invite_collaborator(scope, project.id, "e@example.com", :viewer)
+      other = user_scope_fixture()
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Sharing.list_collaborators(other, project.id)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Sharing.update_collaborator_role(other, collab, :editor)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Sharing.remove_collaborator(other, collab)
+      end
+    end
+  end
+
+  describe "changesets for forms" do
+    test "change_link/1 returns a changeset" do
+      assert %Ecto.Changeset{} = Sharing.change_link(%ShareLink{})
+    end
+
+    test "change_collaborator/2 returns a changeset" do
+      assert %Ecto.Changeset{} = Sharing.change_collaborator(%Collaborator{})
+    end
+  end
+end

--- a/test/typster/sharing_test.exs
+++ b/test/typster/sharing_test.exs
@@ -5,6 +5,7 @@ defmodule Typster.SharingTest do
   import Typster.AccountsFixtures, only: [user_scope_fixture: 0]
   import Typster.ProjectsFixtures, only: [project_fixture: 1]
 
+  alias Typster.Accounts.Scope
   alias Typster.Sharing
   alias Typster.Sharing.Collaborator
   alias Typster.Sharing.ShareLink
@@ -216,6 +217,40 @@ defmodule Typster.SharingTest do
       assert_raise Ecto.NoResultsError, fn ->
         Sharing.remove_collaborator(other, collab)
       end
+    end
+  end
+
+  describe "accept_invite/2 (bearer)" do
+    test "links the invitee, marks accepted, preloads project", %{scope: scope, project: project} do
+      {:ok, invite} = Sharing.invite_collaborator(scope, project.id, "i@example.com", :editor)
+      invitee = user_scope_fixture()
+
+      assert {:ok, accepted} = Sharing.accept_invite(invitee, invite.id)
+      assert accepted.status == :accepted
+      assert accepted.user_id == invitee.user.id
+      assert accepted.project.id == project.id
+    end
+
+    test "is idempotent on re-accept", %{scope: scope, project: project} do
+      {:ok, invite} = Sharing.invite_collaborator(scope, project.id, "j@example.com", :viewer)
+      invitee = user_scope_fixture()
+
+      assert {:ok, _} = Sharing.accept_invite(invitee, invite.id)
+      assert {:ok, again} = Sharing.accept_invite(invitee, invite.id)
+      assert again.status == :accepted
+    end
+
+    test "returns :not_found for an unknown id", %{scope: scope} do
+      assert {:error, :not_found} = Sharing.accept_invite(scope, Ecto.UUID.generate())
+    end
+
+    test "returns :not_found for a malformed id", %{scope: scope} do
+      assert {:error, :not_found} = Sharing.accept_invite(scope, "not-a-uuid")
+    end
+
+    test "returns :not_found when no user is in scope", %{scope: scope, project: project} do
+      {:ok, invite} = Sharing.invite_collaborator(scope, project.id, "k@example.com", :viewer)
+      assert {:error, :not_found} = Sharing.accept_invite(%Scope{user: nil}, invite.id)
     end
   end
 

--- a/test/typster_web/controllers/embed_framing_test.exs
+++ b/test/typster_web/controllers/embed_framing_test.exs
@@ -1,0 +1,65 @@
+defmodule TypsterWeb.EmbedFramingTest do
+  @moduledoc """
+  Verifies the framing contract of the two public share surfaces:
+
+    * `/embed/:token` runs through the `:embeddable` pipeline, which overrides
+      the CSP to `frame-ancestors *` so third-party sites can iframe it.
+    * `/p/:slug?key=…` runs through the default `:browser` pipeline, which pins
+      `frame-ancestors 'self'` and so refuses cross-origin framing.
+
+  The initial GET of a LiveView returns static HTML carrying the pipeline's
+  response headers, so a plain `get/2` ConnCase request can inspect the CSP via
+  `get_resp_header/2` without ever booting the LiveView socket.
+  """
+  use TypsterWeb.ConnCase, async: true
+
+  alias Typster.Accounts.Scope
+  alias Typster.Sharing
+
+  import Typster.AccountsFixtures, only: [user_fixture: 0]
+  import Typster.ProjectsFixtures, only: [project_fixture: 1, file_fixture: 3]
+
+  setup %{conn: conn} do
+    owner = user_fixture()
+    scope = Scope.for_user(owner)
+    project = project_fixture(owner)
+    file_fixture(project, owner, %{path: "main.typ", content: "= Hi"})
+    link = Sharing.get_or_create_link(scope, project.id)
+
+    %{conn: conn, project: project, link: link}
+  end
+
+  # CSP header values can be split across multiple response-header entries, so
+  # collapse them into a single lowercased string before substring matching.
+  defp csp(conn) do
+    conn
+    |> get_resp_header("content-security-policy")
+    |> Enum.join(" ")
+    |> String.downcase()
+  end
+
+  describe "/embed/:token (the :embeddable pipeline)" do
+    test "is framable from any origin and not pinned to 'self'", %{conn: conn, link: link} do
+      conn = get(conn, ~p"/embed/#{link.token}")
+
+      assert conn.status == 200
+
+      csp = csp(conn)
+      assert String.contains?(csp, "frame-ancestors *")
+      refute String.contains?(csp, "frame-ancestors 'self'")
+    end
+  end
+
+  describe "/p/:slug?key=token (the default :browser pipeline)" do
+    test "pins frame-ancestors 'self' so it cannot be framed cross-origin", %{
+      conn: conn,
+      project: project,
+      link: link
+    } do
+      conn = get(conn, ~p"/p/#{project.id}?#{[key: link.token]}")
+
+      csp = csp(conn)
+      assert String.contains?(csp, "frame-ancestors 'self'")
+    end
+  end
+end

--- a/test/typster_web/controllers/invite_controller_test.exs
+++ b/test/typster_web/controllers/invite_controller_test.exs
@@ -1,0 +1,60 @@
+defmodule TypsterWeb.InviteControllerTest do
+  use TypsterWeb.ConnCase, async: true
+
+  import Typster.AccountsFixtures, only: [user_scope_fixture: 0]
+  import Typster.ProjectsFixtures, only: [project_fixture: 1]
+
+  alias Typster.Sharing
+
+  defp invite(_context) do
+    owner = user_scope_fixture()
+    project = project_fixture(owner)
+    {:ok, collab} = Sharing.invite_collaborator(owner, project.id, "guest@example.com", :viewer)
+    %{project: project, collab: collab}
+  end
+
+  describe "GET /invites/:id while unauthenticated" do
+    setup :invite
+
+    test "bounces to log-in and remembers the invite path", %{conn: conn, collab: collab} do
+      conn = get(conn, ~p"/invites/#{collab.id}")
+
+      assert redirected_to(conn) == ~p"/users/log-in"
+      assert get_session(conn, :user_return_to) == "/invites/#{collab.id}"
+    end
+  end
+
+  describe "GET /invites/:id while authenticated" do
+    setup [:register_and_log_in_user, :invite]
+
+    test "accepts the invite and redirects to the editor", %{
+      conn: conn,
+      user: user,
+      collab: collab,
+      project: project
+    } do
+      conn = get(conn, ~p"/invites/#{collab.id}")
+
+      assert redirected_to(conn) == ~p"/projects/#{project.id}/edit"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "welcome"
+
+      accepted = Typster.Repo.get!(Typster.Sharing.Collaborator, collab.id)
+      assert accepted.status == :accepted
+      assert accepted.user_id == user.id
+    end
+
+    test "redirects to projects with an error for an unknown invite", %{conn: conn} do
+      conn = get(conn, ~p"/invites/#{Ecto.UUID.generate()}")
+
+      assert redirected_to(conn) == ~p"/projects"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "invalid"
+    end
+
+    test "redirects to projects with an error for a malformed id", %{conn: conn} do
+      conn = get(conn, ~p"/invites/not-a-uuid")
+
+      assert redirected_to(conn) == ~p"/projects"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "invalid"
+    end
+  end
+end

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -429,6 +429,32 @@ defmodule TypsterWeb.EditorLiveTest do
     Enum.any?(Typster.Files.get_file_tree(scope, project.id), &(&1.path == path))
   end
 
+  describe "share modal — Pro write-scope card" do
+    test "is clickable, previews the upsell, but never changes the link scope",
+         %{conn: conn, user: user, project: project} do
+      view = open_editor(conn, project)
+
+      view |> element(".ts-tb__share") |> render_click()
+      assert has_element?(view, ".perm-card.tone-write")
+      # Resting state: not active, no upgrade banner yet.
+      refute has_element?(view, ".perm-card.tone-write.active")
+
+      # Clicking the Pro card activates it and reveals the upsell (not usable)…
+      view |> element("[phx-click='share_scope'][phx-value-scope='write']") |> render_click()
+      assert has_element?(view, ".perm-card.tone-write.active")
+      assert has_element?(view, ".perm-card.tone-write .upgrade-banner")
+
+      # …but the real link scope is unchanged (still a free scope, never :write).
+      scope = Typster.Accounts.Scope.for_user(user)
+      link = Typster.Sharing.get_or_create_link(scope, project.id)
+      assert link.scope in [:read, :output, :full]
+
+      # Choosing a real scope clears the preview.
+      view |> element("[phx-click='share_scope'][phx-value-scope='output']") |> render_click()
+      refute has_element?(view, ".perm-card.tone-write.active")
+    end
+  end
+
   describe "collaborator access" do
     setup %{user: owner, project: project} do
       owner_scope = Typster.Accounts.Scope.for_user(owner)

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -428,4 +428,36 @@ defmodule TypsterWeb.EditorLiveTest do
     scope = Typster.Accounts.Scope.for_user(user)
     Enum.any?(Typster.Files.get_file_tree(scope, project.id), &(&1.path == path))
   end
+
+  describe "collaborator access" do
+    setup %{user: owner, project: project} do
+      owner_scope = Typster.Accounts.Scope.for_user(owner)
+
+      {:ok, invite} =
+        Typster.Sharing.invite_collaborator(owner_scope, project.id, "c@x.com", :editor)
+
+      collaborator = Typster.AccountsFixtures.user_fixture()
+
+      {:ok, _} =
+        Typster.Sharing.accept_invite(Typster.Accounts.Scope.for_user(collaborator), invite.id)
+
+      collab_conn = log_in_user(build_conn(), collaborator)
+      %{collab_conn: collab_conn}
+    end
+
+    test "an accepted collaborator can open the owner's editor",
+         %{collab_conn: conn, user: user, project: project} do
+      file_fixture(project, user, %{path: "main.typ"})
+      view = open_editor(conn, project)
+
+      assert has_element?(view, ".ts-tb__proj", project.name)
+      assert has_element?(view, "#create-main-file-button")
+    end
+
+    test "the Share button is owner-only",
+         %{conn: owner_conn, collab_conn: collab_conn, project: project} do
+      assert has_element?(open_editor(owner_conn, project), ".ts-tb__share")
+      refute has_element?(open_editor(collab_conn, project), ".ts-tb__share")
+    end
+  end
 end

--- a/test/typster_web/live/share_modal_test.exs
+++ b/test/typster_web/live/share_modal_test.exs
@@ -1,0 +1,142 @@
+defmodule TypsterWeb.ShareModalTest do
+  use TypsterWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Typster.ProjectsFixtures
+
+  alias Typster.Accounts.Scope
+  alias Typster.Sharing
+
+  # The logged-in user OWNS the project (project_fixture/2 derives the scope from
+  # the user), so the owner-only Share button and all share_* handlers are wired.
+  setup :register_and_log_in_user
+
+  setup %{conn: conn, user: user} do
+    project = project_fixture(user, %{name: "Quarterly Report"})
+    file_fixture(project, user, %{path: "main.typ"})
+    %{conn: conn, user: user, project: project}
+  end
+
+  defp open_editor(conn, project) do
+    {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/edit")
+    view
+  end
+
+  defp open_share(conn, project) do
+    view = open_editor(conn, project)
+    view |> element(".ts-tb__share") |> render_click()
+    view
+  end
+
+  defp scope_for(user), do: Scope.for_user(user)
+
+  test "owner sees the Share button and opening it renders the modal",
+       %{conn: conn, project: project} do
+    view = open_editor(conn, project)
+
+    assert has_element?(view, ".ts-tb__share")
+    refute has_element?(view, "#share-modal")
+
+    view |> element(".ts-tb__share") |> render_click()
+
+    assert has_element?(view, ".share-overlay #share-modal")
+  end
+
+  test "share_tab switches to the Embed tab and shows the copy control",
+       %{conn: conn, project: project} do
+    view = open_share(conn, project)
+
+    view |> element("button.tab[phx-value-tab='embed']") |> render_click()
+
+    assert has_element?(view, "button.tab.active[phx-value-tab='embed']")
+    assert has_element?(view, "#embed-copy")
+  end
+
+  test "share_scope on the Link tab sets the link scope to :output",
+       %{conn: conn, user: user, project: project} do
+    view = open_share(conn, project)
+
+    view |> element("button.tab[phx-value-tab='link']") |> render_click()
+    view |> element(".perm-card[phx-value-scope='output']") |> render_click()
+
+    assert Sharing.get_or_create_link(scope_for(user), project.id).scope == :output
+  end
+
+  test "share_rotate generates a new token for the link",
+       %{conn: conn, user: user, project: project} do
+    scope = scope_for(user)
+    token0 = Sharing.get_or_create_link(scope, project.id).token
+
+    view = open_share(conn, project)
+    view |> element("button.tab[phx-value-tab='link']") |> render_click()
+    view |> element("button[phx-click='share_rotate']") |> render_click()
+
+    assert Sharing.get_or_create_link(scope, project.id).token != token0
+  end
+
+  test "share_toggle_download flips the link's allow_download flag",
+       %{conn: conn, user: user, project: project} do
+    scope = scope_for(user)
+    before = Sharing.get_or_create_link(scope, project.id).allow_download
+
+    view = open_share(conn, project)
+    view |> element("button.tab[phx-value-tab='link']") |> render_click()
+    view |> element("[phx-click='share_toggle_download']") |> render_click()
+
+    assert Sharing.get_or_create_link(scope, project.id).allow_download == not before
+  end
+
+  test "inviting a person adds a collaborator and shows the People badge count",
+       %{conn: conn, user: user, project: project} do
+    view = open_share(conn, project)
+    view |> element("button.tab[phx-value-tab='people']") |> render_click()
+
+    view
+    |> form("#invite-form", %{"invite" => %{"email" => "x@example.com", "role" => "viewer"}})
+    |> render_submit()
+
+    collaborators = Sharing.list_collaborators(scope_for(user), project.id)
+    assert [%{email: "x@example.com"}] = collaborators
+
+    # The People tab badge reflects the single pending collaborator.
+    assert has_element?(view, "button.tab[phx-value-tab='people'] .badge", "1")
+  end
+
+  test "share_remove_collab removes the invited collaborator",
+       %{conn: conn, user: user, project: project} do
+    scope = scope_for(user)
+
+    view = open_share(conn, project)
+    view |> element("button.tab[phx-value-tab='people']") |> render_click()
+
+    view
+    |> form("#invite-form", %{"invite" => %{"email" => "x@example.com", "role" => "viewer"}})
+    |> render_submit()
+
+    [collab] = Sharing.list_collaborators(scope, project.id)
+
+    view
+    |> element("[phx-click='share_remove_collab'][phx-value-id='#{collab.id}']")
+    |> render_click()
+
+    assert Sharing.list_collaborators(scope, project.id) == []
+  end
+
+  test "free plan locks the advanced link section and link activity stats",
+       %{conn: conn, project: project} do
+    view = open_share(conn, project)
+    view |> element("button.tab[phx-value-tab='link']") |> render_click()
+
+    assert has_element?(view, ".locked-section")
+    assert has_element?(view, ".link-stats.locked-stats")
+  end
+
+  test "the Embed tab renders an iframe snippet pointing at the embed route",
+       %{conn: conn, project: project} do
+    view = open_share(conn, project)
+    view |> element("button.tab[phx-value-tab='embed']") |> render_click()
+
+    assert has_element?(view, "#embed-copy")
+    assert view |> element("#share-modal pre") |> render() =~ "/embed/"
+  end
+end

--- a/test/typster_web/live/shared_project_live_test.exs
+++ b/test/typster_web/live/shared_project_live_test.exs
@@ -1,0 +1,93 @@
+defmodule TypsterWeb.SharedProjectLiveTest do
+  use TypsterWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Typster.ProjectsFixtures
+
+  alias Typster.Accounts.Scope
+  alias Typster.Sharing
+
+  setup do
+    owner = Typster.AccountsFixtures.user_fixture()
+    scope = Scope.for_user(owner)
+    project = project_fixture(owner)
+    file_fixture(project, owner, %{path: "main.typ", content: "= Hi"})
+    link = Sharing.get_or_create_link(scope, project.id)
+
+    %{owner: owner, scope: scope, project: project, link: link}
+  end
+
+  describe ":read scope via /p" do
+    test "renders the split read-only comp with source, preview and chrome", %{
+      conn: conn,
+      project: project,
+      link: link
+    } do
+      {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: link.token]}")
+
+      # Split layout (source + preview side by side).
+      assert has_element?(view, ".embed-comp.embed-comp--split")
+      # Read-only CodeMirror source pane is shown.
+      assert has_element?(view, ".embed-source #editor-container")
+      # Live preview pane.
+      assert has_element?(view, ".embed-preview #preview-container")
+      # Top bar shows the project name and the read-only pill.
+      assert has_element?(view, ".embed-bar .slug", project.name)
+      assert has_element?(view, ".ro-pill")
+      # Open-in-Typster CTA in the footer.
+      assert has_element?(view, ".embed-foot__cta")
+    end
+  end
+
+  describe ":output scope via /p" do
+    test "hides the source pane but keeps the preview", %{
+      conn: conn,
+      scope: scope,
+      link: link
+    } do
+      {:ok, _link} = Sharing.update_link(scope, link, %{scope: :output})
+
+      {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: link.token]}")
+
+      # Not a split layout when the source is hidden.
+      refute has_element?(view, ".embed-comp.embed-comp--split")
+      # The visible source section is gone (only a hidden mirror remains).
+      refute has_element?(view, ".embed-source #editor-container")
+      # Preview is still rendered.
+      assert has_element?(view, ".embed-preview #preview-container")
+    end
+  end
+
+  describe "invalid link" do
+    test "renders the invalid panel and no embed comp", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: "does-not-exist"]}")
+
+      assert has_element?(view, ".share-public--invalid .share-public__panel")
+      refute has_element?(view, ".embed-comp")
+    end
+  end
+
+  describe "/embed/:token" do
+    test "mounts the embed variant", %{conn: conn, link: link} do
+      {:ok, view, _html} = live(conn, ~p"/embed/#{link.token}")
+
+      assert has_element?(view, ".share-public--embed")
+      assert has_element?(view, ".embed-comp")
+    end
+  end
+
+  describe "read-only client hook events" do
+    test "tolerates preview hook pushes without crashing", %{conn: conn, link: link} do
+      {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: link.token]}")
+
+      # The CodeMirror/Preview hooks push these editor events; the read-only
+      # view must swallow them via its catch-all handle_event/3.
+      render_hook(view, "update_preview", %{"ms" => 12, "pages" => 1})
+      render_hook(view, "preview_error", %{"message" => "x", "errors" => 1})
+
+      # If the catch-all clause were missing, the pushes above would have
+      # crashed the LiveView and this assertion would fail.
+      assert has_element?(view, ".embed-comp")
+    end
+  end
+end


### PR DESCRIPTION
PR3 of the editor v3.1 / Share redesign (epic #108, issue #106). The **open-source half of Share**: a fully-wired modal plus a public read-only view. Paid Share features are shown gated (the Pro half lands in the `typster-pro` submodule, PR4).

## Backend — `Typster.Sharing`
- **`ShareLink`** (token, scope `:read | :output | :full`, allow_download) and **`Collaborator`** (email, role, status) schemas + migrations. Owner-management functions authorize via the project owner; `get_link_by_token/1` resolves a link publicly (no scope) — the token is the authorization.
- Email invites via a `Sharing.Notifier` (Swoosh). **21 context tests.**

## Share modal (free, functional; Pro gated)
Opened from the top-bar Share button. Four tabs:
- **Link** — a real, copyable tokened URL (`/p/:slug?key=…`), rotate-key, and the four permission cards with risk-graded subtones (Read=info, Output=success, Write=warn, Full=error). **Write-scoped, Advanced config, and Link analytics are Pro** — rendered with the upgrade UI via `Typster.Features.can?/2`.
- **People** — invite by email + role, list collaborators, remove. Sends a real invite email.
- **Export** — downloads the browser-compiled PDF.
- **Embed** — read-only config + a real `<iframe>` snippet (`/embed/:token`); interactive sandbox is Pro.

## Public view — `SharedProjectLive`
`/p/:slug?key=…` (and `/embed/:token`) render the project **read-only** and compile it **client-side** (same WASM worker, no server-side PDF). `:read`/`:full` show source + preview; `:output` shows the preview only. The editor gained a `readonly` mode (no autosave/lint/assists — just highlighting).

## Submodule
Moved `pro/` → **`vendor/pro/`** (per request) and re-pinned to the corrected `typster-pro` commit. `mix.exs` guard now checks `vendor/pro/mix.exs`; path-deps still never touch `mix.lock`.

## Verification
- `mix precommit` green — `--warning-as-errors`, format, sobelow, **215 tests, 0 failures**.
- New Playwright E2E: opens the modal, asserts the real tokened link + Pro gating, invites a collaborator, then loads the public read-only view.
- Visually confirmed both modal tabs (screenshots).

## Deferred → PR4 (`typster-pro`)
Per-file write scope · advanced link config (sign-in/expiry/password) · link analytics · interactive embed sandbox + smart CTA + unbranded. All gated here already.

Closes #106. Part of #108.