### PR TITLE
feat(jobs): schedule snapshot+cleanup via Oban cron, fix asset bug

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -85,7 +85,18 @@ config :phoenix, :json_library, Jason
 config :typster, Oban,
   engine: Oban.Engines.Basic,
   queues: [default: 10],
-  repo: Typster.Repo
+  repo: Typster.Repo,
+  plugins: [
+    # Schedule the previously-orphaned background jobs. `config/test.exs` sets
+    # `plugins: false`, so Cron never fires during tests.
+    {Oban.Plugins.Cron,
+     crontab: [
+       # Checkpoint each file's content into a revision every 5 minutes.
+       {"*/5 * * * *", Typster.Jobs.PeriodicSnapshot},
+       # Sweep assets whose project was deleted, daily at 03:00.
+       {"0 3 * * *", Typster.Jobs.AssetCleanup}
+     ]}
+  ]
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/typster/jobs/asset_cleanup.ex
+++ b/lib/typster/jobs/asset_cleanup.ex
@@ -10,16 +10,16 @@ defmodule Typster.Jobs.AssetCleanup do
 
     all_assets = Repo.all(Typster.Assets.Asset)
 
-    all_project_ids =
-      Repo.all(
-        from p in Typster.Projects.Project,
-          select: p.id
-      )
-      |> Enum.map(& &1.id)
+    # `select: p.id` already returns a flat list of ids — use it directly (a
+    # MapSet keeps the membership check O(1) across many assets).
+    project_ids =
+      from(p in Typster.Projects.Project, select: p.id)
+      |> Repo.all()
+      |> MapSet.new()
 
     orphaned_assets =
       Enum.filter(all_assets, fn asset ->
-        not Enum.member?(all_project_ids, asset.project_id)
+        not MapSet.member?(project_ids, asset.project_id)
       end)
 
     Enum.each(orphaned_assets, fn asset ->

--- a/test/typster/jobs_test.exs
+++ b/test/typster/jobs_test.exs
@@ -1,0 +1,59 @@
+defmodule Typster.JobsTest do
+  use Typster.DataCase, async: true
+
+  import Typster.AccountsFixtures, only: [user_scope_fixture: 0]
+  import Typster.ProjectsFixtures, only: [project_fixture: 1, file_fixture: 3, asset_fixture: 2]
+
+  alias Typster.{Assets, Repo, Revisions}
+  alias Typster.Jobs.{AssetCleanup, PeriodicSnapshot}
+
+  setup do
+    scope = user_scope_fixture()
+    %{scope: scope, project: project_fixture(scope)}
+  end
+
+  describe "PeriodicSnapshot" do
+    test "checkpoints a file whose content drifted from its latest revision", ctx do
+      %{scope: scope, project: project} = ctx
+      file = file_fixture(project, scope, %{path: "main.typ", content: "v1"})
+      {:ok, _rev} = Revisions.create_revision(scope, file.id, "v1")
+
+      # Content moved on (e.g. autosave) but no new revision was cut yet.
+      Repo.update_all(
+        from(f in Typster.Projects.File, where: f.id == ^file.id),
+        set: [content: "v2"]
+      )
+
+      assert :ok = PeriodicSnapshot.perform(%Oban.Job{})
+
+      assert [latest | _] = Revisions.list_revisions(scope, file.id)
+      assert latest.content == "v2"
+    end
+
+    test "does nothing for a file with no prior revision", ctx do
+      %{scope: scope, project: project} = ctx
+      file = file_fixture(project, scope, %{path: "fresh.typ", content: "hi"})
+
+      assert :ok = PeriodicSnapshot.perform(%Oban.Job{})
+      assert Revisions.list_revisions(scope, file.id) == []
+    end
+  end
+
+  describe "AssetCleanup" do
+    test "runs cleanly and keeps assets whose project still exists", ctx do
+      %{scope: scope, project: project} = ctx
+      asset = asset_fixture(project, scope)
+
+      assert :ok = AssetCleanup.perform(%Oban.Job{})
+      assert Repo.get(Assets.Asset, asset.id)
+    end
+  end
+
+  describe "cron schedule" do
+    test "every configured cron expression is valid syntax" do
+      for expr <- ["*/5 * * * *", "0 3 * * *"] do
+        assert %Oban.Cron.Expression{} = Oban.Cron.Expression.parse!(expr)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Wire the orphaned Oban jobs + fix a latent bug

`Typster.Jobs.PeriodicSnapshot` and `Typster.Jobs.AssetCleanup` existed but were **never scheduled** (no `Oban.Plugins.Cron`, no enqueue) — dead code. This adds the Cron plugin:

- `PeriodicSnapshot` every 5 min — checkpoints each file's content into a `file_revision`.
- `AssetCleanup` daily at 03:00 — sweeps assets whose project was deleted.

`config/test.exs` already sets `plugins: false`, so Cron never fires in tests.

### Bug caught by finally running the job
`AssetCleanup` did `Repo.all(from p in Project, select: p.id) |> Enum.map(& &1.id)` — but `select: p.id` already returns a flat id list, so `&1.id` blew up on a binary. It never surfaced because the job was never run. Fixed (and switched the lookup to a `MapSet` for O(1) membership).

### Tests
New `Typster.JobsTest` covers both jobs' `perform/1` and validates the cron expressions. 253 green.

> Follow-up (stacks on #114): route collaborative-editing persistence through a **deduped** Oban job (one save per file per window) instead of every client autosaving every keystroke.