### PR TITLE
fix(share): surface shared projects + bind invites to their email

### DIFF
--- a/assets/css/_editor_topbar.css
+++ b/assets/css/_editor_topbar.css
@@ -195,6 +195,13 @@
 
 /* ── Share button — pin the action cluster to the right edge ──────────────── */
 .ts-tb__share { margin-left: auto; flex-shrink: 0; }
+/* Collaborators see the Share button for a consistent top bar, but it's inert:
+   only the owner can manage sharing. */
+.ts-tb__share.is-inactive {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
 
 /* ── Compile button (single element + state modifiers) ────────────────────── */
 .ts-tb__compile {

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -130,6 +130,20 @@
 .ts-list__icon { color: var(--fg3); flex-shrink: 0; }
 .ts-list__main { flex: 1; min-width: 0; }
 .ts-list__title { font: 500 14px 'Inter', system-ui, sans-serif; color: var(--fg); }
+.ts-shared-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 8px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  vertical-align: middle;
+  font: 600 11.5px 'Inter', system-ui, sans-serif;
+  letter-spacing: 0.01em;
+  color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 16%, transparent);
+}
+.ts-shared-badge svg { width: 14px; height: 14px; }
 .ts-list__sub { font: 400 12px 'Inter', system-ui, sans-serif; color: var(--fg3); margin-top: 2px; }
 .ts-list__actions { display: flex; gap: 4px; flex-shrink: 0; opacity: 0; transition: opacity 120ms var(--ease); }
 .ts-list__row:hover .ts-list__actions, .ts-list__row:focus-within .ts-list__actions { opacity: 1; }

--- a/lib/typster/sharing.ex
+++ b/lib/typster/sharing.ex
@@ -10,6 +10,7 @@ defmodule Typster.Sharing do
   import Ecto.Query, warn: false
 
   alias Typster.Accounts.Scope
+  alias Typster.Accounts.User
   alias Typster.Projects
   alias Typster.Repo
   alias Typster.Sharing.Collaborator
@@ -165,31 +166,63 @@ defmodule Typster.Sharing do
   @doc """
   PUBLIC (bearer): accepts a pending invite for the authenticated user.
 
-  The invite `id` is the bearer credential — the invitee is not the project
-  owner, so authorization is the unguessable id itself, not project ownership.
-  Links the collaborator row to the current user and marks it `:accepted`.
+  The invite `id` is the bearer credential, but it is **not** sufficient on its
+  own: the invite is addressed to a specific email, so we only link it to a user
+  whose account email matches that address (case-insensitive). Otherwise anyone
+  authenticated — including the project owner clicking the link to "preview" it —
+  would silently claim the invite and bind it to the wrong account, leaving the
+  real invitee unable to see the project.
 
-  Idempotent: re-accepting an already-accepted invite is a no-op success.
-  Returns `{:ok, collaborator}` with the project preloaded, or
+  Idempotent: re-accepting an already-accepted invite by the same user is a
+  no-op success. Returns `{:ok, collaborator}` with the project preloaded,
+  `{:error, :forbidden}` when the invite is for a different email, or
   `{:error, :not_found}` when the id is malformed or no invite exists.
   """
-  def accept_invite(%Scope{user: %{id: user_id}}, invite_id) when is_binary(invite_id) do
-    case fetch_collaborator(invite_id) do
-      nil ->
-        {:error, :not_found}
-
-      %Collaborator{} = collaborator ->
-        collaborator
-        |> Collaborator.accept_changeset(user_id)
-        |> Repo.update()
-        |> case do
-          {:ok, accepted} -> {:ok, Repo.preload(accepted, :project)}
-          {:error, _changeset} = error -> error
-        end
+  def accept_invite(%Scope{user: %{id: user_id, email: email}}, invite_id)
+      when is_binary(invite_id) do
+    with %Collaborator{} = collaborator <- fetch_collaborator(invite_id),
+         true <- same_email?(collaborator.email, email),
+         {:ok, accepted} <-
+           collaborator |> Collaborator.accept_changeset(user_id) |> Repo.update() do
+      {:ok, Repo.preload(accepted, :project)}
+    else
+      nil -> {:error, :not_found}
+      false -> {:error, :forbidden}
+      {:error, _changeset} = error -> error
     end
   end
 
   def accept_invite(_scope, _invite_id), do: {:error, :not_found}
+
+  @doc """
+  Links every invite addressed to this user's email to their account and marks
+  it `:accepted`, so projects shared with them appear in their list **without**
+  having to click the email accept-link. The invite *email* is the source of
+  truth for who an invite belongs to, so this also self-heals rows that were
+  mis-linked to another account. Idempotent; returns the number of rows touched.
+  """
+  @spec link_invites_for_user(Scope.t()) :: non_neg_integer()
+  def link_invites_for_user(%Scope{user: %User{id: user_id, email: email}})
+      when is_binary(email) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {count, _} =
+      from(c in Collaborator,
+        where:
+          fragment("lower(?)", c.email) == ^String.downcase(email) and
+            (is_nil(c.user_id) or c.user_id != ^user_id or c.status != :accepted)
+      )
+      |> Repo.update_all(set: [user_id: user_id, status: :accepted, updated_at: now])
+
+    count
+  end
+
+  def link_invites_for_user(_scope), do: 0
+
+  defp same_email?(a, b) when is_binary(a) and is_binary(b),
+    do: String.downcase(a) == String.downcase(b)
+
+  defp same_email?(_a, _b), do: false
 
   defp fetch_collaborator(id) do
     case Ecto.UUID.cast(id) do

--- a/lib/typster_web/controllers/invite_controller.ex
+++ b/lib/typster_web/controllers/invite_controller.ex
@@ -18,6 +18,11 @@ defmodule TypsterWeb.InviteController do
         |> put_flash(:info, gettext("share.invite.accepted"))
         |> redirect(to: ~p"/projects/#{collaborator.project_id}/edit")
 
+      {:error, :forbidden} ->
+        conn
+        |> put_flash(:error, gettext("share.invite.wrong_account"))
+        |> redirect(to: ~p"/projects")
+
       {:error, :not_found} ->
         conn
         |> put_flash(:error, gettext("share.invite.invalid"))

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -252,6 +252,15 @@ defmodule TypsterWeb.EditorLive.Index do
   # Sharing is managed by the owner only; collaborators can edit but not invite.
   def handle_event("open_share", _params, socket), do: {:noreply, socket}
 
+  # Owner-only guard for every share mutation. The UI already disables these for
+  # collaborators, but this makes the backend authoritative: a crafted event from
+  # a non-owner no-ops here instead of reaching `Sharing.*` (which would raise on
+  # the owner-only `Projects.get_project!`). Must precede the specific handlers.
+  def handle_event(event, _params, %{assigns: %{owner?: false}} = socket)
+      when event in ~w(share_scope share_rotate share_toggle_download share_invite share_remove_collab) do
+    {:noreply, socket}
+  end
+
   @impl true
   def handle_event("close_share", _params, socket) do
     {:noreply, assign(socket, :show_share, false)}

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -63,12 +63,15 @@
         </span>
       </button>
 
+      <%!-- Shown to everyone for a consistent top bar, but inactive for
+            collaborators: only the owner can manage sharing (enforced server-side). --%>
       <button
-        :if={@owner?}
         type="button"
-        class="ts-btn ts-btn--ghost ts-btn--sm ts-tb__share"
-        phx-click="open_share"
-        title={gettext("editor.share")}
+        class={["ts-btn ts-btn--ghost ts-btn--sm ts-tb__share", !@owner? && "is-inactive"]}
+        phx-click={@owner? && "open_share"}
+        disabled={!@owner?}
+        aria-disabled={to_string(!@owner?)}
+        title={if(@owner?, do: gettext("editor.share"), else: gettext("editor.share_owner_only"))}
       >
         <i data-lucide="upload" aria-hidden="true"></i> {gettext("editor.share")}
       </button>

--- a/lib/typster_web/live/project_live/index.ex
+++ b/lib/typster_web/live/project_live/index.ex
@@ -2,6 +2,7 @@ defmodule TypsterWeb.ProjectLive.Index do
   use TypsterWeb, :live_view
 
   alias Typster.Projects
+  alias Typster.Sharing
 
   @accent_hexes %{
     "indigo" => "#4f46e5",
@@ -13,6 +14,11 @@ defmodule TypsterWeb.ProjectLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    # Claim any invites addressed to this user's email (and heal mis-linked
+    # ones) so projects shared with them show up here. Connected mount only, to
+    # keep the write off the dead render — the connected mount re-fetches below.
+    if connected?(socket), do: Sharing.link_invites_for_user(socket.assigns.current_scope)
+
     {:ok,
      socket
      |> assign(:page_title, gettext("projects.index.title"))
@@ -30,13 +36,20 @@ defmodule TypsterWeb.ProjectLive.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    project = Projects.get_project!(socket.assigns.current_scope, id)
-    {:ok, _} = Projects.delete_project(socket.assigns.current_scope, project)
+    # Owner-only and crash-proof: collaborators don't get a delete button, but a
+    # crafted event must still no-op rather than raise on the ownership check.
+    case Projects.get_project(socket.assigns.current_scope, id) do
+      nil ->
+        {:noreply, socket}
 
-    {:noreply,
-     socket
-     |> assign(:project_count, max(socket.assigns.project_count - 1, 0))
-     |> stream_delete(:projects, project)}
+      project ->
+        {:ok, _} = Projects.delete_project(socket.assigns.current_scope, project)
+
+        {:noreply,
+         socket
+         |> assign(:project_count, max(socket.assigns.project_count - 1, 0))
+         |> stream_delete(:projects, project)}
+    end
   end
 
   @impl true
@@ -105,6 +118,10 @@ defmodule TypsterWeb.ProjectLive.Index do
   defp listed_projects(scope, _all), do: Projects.list_projects(scope)
 
   defp file_count(counts, project_id), do: Map.get(counts, project_id, 0)
+
+  # The current user owns this project (vs. reaching it as a collaborator).
+  # Drives the "Shared" badge and gates owner-only actions like delete.
+  defp owned?(scope, project), do: project.user_id == scope.user.id
 
   # Deterministic accent hue per project name, so initials stay stable.
   defp project_hue(name) do

--- a/lib/typster_web/live/project_live/index.html.heex
+++ b/lib/typster_web/live/project_live/index.html.heex
@@ -69,7 +69,12 @@
             {project_initial(project.name)}
           </div>
           <div class="ts-list__main">
-            <div class="ts-list__title">{project.name}</div>
+            <div class="ts-list__title">
+              {project.name}
+              <span :if={!owned?(@current_scope, project)} class="ts-shared-badge">
+                <.icon name="hero-user-group" class="size-4" /> {gettext("projects.row.shared")}
+              </span>
+            </div>
             <div class="ts-list__sub">
               {gettext("projects.row.edited")} {relative_time(project.updated_at)} · {ngettext(
                 "1 file",
@@ -89,6 +94,7 @@
               <.icon name="hero-star" class="size-3.5" />
             </button>
             <button
+              :if={owned?(@current_scope, project)}
               id={"delete-project-#{project.id}"}
               phx-click="delete"
               phx-value-id={project.id}

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -53,7 +53,7 @@ msgstr ""
 msgid "auth.sign_up"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:157
+#: lib/typster_web/live/project_live/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "common.cancel"
 msgstr ""
@@ -72,7 +72,7 @@ msgstr ""
 msgid "common.email"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:106
+#: lib/typster_web/live/project_live/index.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "common.open"
 msgstr ""
@@ -361,22 +361,22 @@ msgid_plural "projects.count.other"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/project_live/index.html.heex:160
+#: lib/typster_web/live/project_live/index.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "projects.create"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:95
+#: lib/typster_web/live/project_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "projects.delete.confirm"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:97
+#: lib/typster_web/live/project_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "projects.delete.label"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:141
+#: lib/typster_web/live/project_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "projects.dialog.description"
 msgstr ""
@@ -391,23 +391,23 @@ msgstr ""
 msgid "projects.index.subtitle"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.ex:18
+#: lib/typster_web/live/project_live/index.ex:24
 #, elixir-autogen, elixir-format
 msgid "projects.index.title"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:146
+#: lib/typster_web/live/project_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "projects.name.label"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:151
+#: lib/typster_web/live/project_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "projects.name.placeholder"
 msgstr ""
 
 #: lib/typster_web/live/project_live/index.html.heex:17
-#: lib/typster_web/live/project_live/index.html.heex:140
+#: lib/typster_web/live/project_live/index.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "projects.new"
 msgstr ""
@@ -707,28 +707,28 @@ msgstr ""
 msgid "settings.appearance.title"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.ex:127
+#: lib/typster_web/live/project_live/index.ex:144
 #, elixir-autogen, elixir-format
 msgid "1 day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/project_live/index.html.heex:74
+#: lib/typster_web/live/project_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "1 file"
 msgid_plural "%{count} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/project_live/index.ex:126
+#: lib/typster_web/live/project_live/index.ex:143
 #, elixir-autogen, elixir-format
 msgid "1 hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/project_live/index.ex:125
+#: lib/typster_web/live/project_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "1 minute ago"
 msgid_plural "%{count} minutes ago"
@@ -765,43 +765,43 @@ msgstr ""
 msgid "projects.heading_lead"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:122
+#: lib/typster_web/live/project_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "projects.import.soon"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:128
+#: lib/typster_web/live/project_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "projects.import.sub"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:127
+#: lib/typster_web/live/project_live/index.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "projects.import.title"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:74
+#: lib/typster_web/live/project_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "projects.row.edited"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:86
-#: lib/typster_web/live/project_live/index.html.heex:87
+#: lib/typster_web/live/project_live/index.html.heex:91
+#: lib/typster_web/live/project_live/index.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "projects.star_soon"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:118
+#: lib/typster_web/live/project_live/index.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "projects.template.sub"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.html.heex:117
+#: lib/typster_web/live/project_live/index.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "projects.template.title"
 msgstr ""
 
-#: lib/typster_web/live/project_live/index.ex:124
+#: lib/typster_web/live/project_live/index.ex:141
 #, elixir-autogen, elixir-format
 msgid "time.just_now"
 msgstr ""
@@ -2150,7 +2150,7 @@ msgstr ""
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1308
+#: lib/typster_web/live/editor_live/index.ex:1307
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1310
+#: lib/typster_web/live/editor_live/index.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1314
+#: lib/typster_web/live/editor_live/index.ex:1313
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2651,7 +2651,7 @@ msgstr ""
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1169
+#: lib/typster_web/live/editor_live/index.ex:1168
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "share.invite.accepted"
 msgstr ""
 
-#: lib/typster_web/controllers/invite_controller.ex:23
+#: lib/typster_web/controllers/invite_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "share.invite.invalid"
 msgstr ""
@@ -2755,4 +2755,14 @@ msgstr ""
 #: lib/typster_web/live/editor_live/index.ex:1115
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
+msgstr ""
+
+#: lib/typster_web/live/project_live/index.html.heex:75
+#, elixir-autogen, elixir-format
+msgid "projects.row.shared"
+msgstr ""
+
+#: lib/typster_web/controllers/invite_controller.ex:23
+#, elixir-autogen, elixir-format
+msgid "share.invite.wrong_account"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -35,7 +35,7 @@ msgstr ""
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:197
+#: lib/typster_web/live/editor_live/index.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr ""
@@ -134,122 +134,122 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:110
+#: lib/typster_web/live/editor_live/index.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:716
-#: lib/typster_web/live/editor_live/index.html.heex:717
+#: lib/typster_web/live/editor_live/index.html.heex:719
+#: lib/typster_web/live/editor_live/index.html.heex:720
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:220
-#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:223
+#: lib/typster_web/live/editor_live/index.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:700
+#: lib/typster_web/live/editor_live/index.ex:709
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:697
+#: lib/typster_web/live/editor_live/index.ex:706
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:401
+#: lib/typster_web/live/editor_live/index.ex:410
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:731
+#: lib/typster_web/live/editor_live/index.ex:740
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:558
-#: lib/typster_web/live/editor_live/index.ex:582
-#: lib/typster_web/live/editor_live/index.ex:874
+#: lib/typster_web/live/editor_live/index.ex:567
+#: lib/typster_web/live/editor_live/index.ex:591
+#: lib/typster_web/live/editor_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:246
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:298
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:669
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:732
+#: lib/typster_web/live/editor_live/index.html.heex:735
 #: lib/typster_web/live/shared_project_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:808
+#: lib/typster_web/live/editor_live/index.ex:817
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:806
+#: lib/typster_web/live/editor_live/index.ex:815
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:807
+#: lib/typster_web/live/editor_live/index.ex:816
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
-#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:416
+#: lib/typster_web/live/editor_live/index.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:182
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:179
+#: lib/typster_web/live/editor_live/index.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:139
+#: lib/typster_web/live/editor_live/index.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr ""
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:190
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr ""
@@ -517,157 +517,157 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
-#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:689
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:79
-#: lib/typster_web/live/editor_live/index.html.heex:682
+#: lib/typster_web/live/editor_live/index.html.heex:82
+#: lib/typster_web/live/editor_live/index.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:213
-#: lib/typster_web/live/editor_live/index.html.heex:214
+#: lib/typster_web/live/editor_live/index.html.heex:216
+#: lib/typster_web/live/editor_live/index.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:543
-#: lib/typster_web/live/editor_live/index.html.heex:544
+#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:563
+#: lib/typster_web/live/editor_live/index.html.heex:565
+#: lib/typster_web/live/editor_live/index.html.heex:566
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:609
-#: lib/typster_web/live/editor_live/index.html.heex:610
+#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:613
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:552
-#: lib/typster_web/live/editor_live/index.html.heex:553
+#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:590
-#: lib/typster_web/live/editor_live/index.html.heex:591
+#: lib/typster_web/live/editor_live/index.html.heex:593
+#: lib/typster_web/live/editor_live/index.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:571
-#: lib/typster_web/live/editor_live/index.html.heex:572
+#: lib/typster_web/live/editor_live/index.html.heex:574
+#: lib/typster_web/live/editor_live/index.html.heex:575
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:581
-#: lib/typster_web/live/editor_live/index.html.heex:582
+#: lib/typster_web/live/editor_live/index.html.heex:584
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:599
-#: lib/typster_web/live/editor_live/index.html.heex:600
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:385
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:926
-#: lib/typster_web/live/editor_live/index.html.heex:935
+#: lib/typster_web/live/editor_live/index.html.heex:921
+#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:938
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:970
-#: lib/typster_web/live/editor_live/index.html.heex:978
-#: lib/typster_web/live/editor_live/index.html.heex:987
+#: lib/typster_web/live/editor_live/index.html.heex:973
+#: lib/typster_web/live/editor_live/index.html.heex:981
+#: lib/typster_web/live/editor_live/index.html.heex:990
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:953
+#: lib/typster_web/live/editor_live/index.html.heex:956
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:975
+#: lib/typster_web/live/editor_live/index.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:910
+#: lib/typster_web/live/editor_live/index.html.heex:913
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:919
-#: lib/typster_web/live/editor_live/index.html.heex:943
-#: lib/typster_web/live/editor_live/index.html.heex:949
+#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:946
+#: lib/typster_web/live/editor_live/index.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:923
+#: lib/typster_web/live/editor_live/index.html.heex:926
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:971
-#: lib/typster_web/live/editor_live/index.html.heex:990
-#: lib/typster_web/live/editor_live/index.html.heex:999
+#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:993
+#: lib/typster_web/live/editor_live/index.html.heex:1002
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:677
+#: lib/typster_web/live/editor_live/index.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:711
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:71
-#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:694
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:700
+#: lib/typster_web/live/editor_live/index.html.heex:703
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:699
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -827,38 +827,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:660
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:661
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:647
+#: lib/typster_web/live/editor_live/index.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:619
-#: lib/typster_web/live/editor_live/index.html.heex:620
+#: lib/typster_web/live/editor_live/index.html.heex:622
+#: lib/typster_web/live/editor_live/index.html.heex:623
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1986,17 +1986,17 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:226
+#: lib/typster_web/live/editor_live/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr ""
@@ -2006,40 +2006,40 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:263
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:354
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:523
-#: lib/typster_web/live/editor_live/index.ex:569
-#: lib/typster_web/live/editor_live/index.ex:730
+#: lib/typster_web/live/editor_live/index.ex:532
+#: lib/typster_web/live/editor_live/index.ex:578
+#: lib/typster_web/live/editor_live/index.ex:739
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,24 +2049,24 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:667
+#: lib/typster_web/live/editor_live/index.ex:676
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:645
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:284
+#: lib/typster_web/live/editor_live/index.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
@@ -2082,7 +2082,7 @@ msgid "editor.tree.pin"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:514
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
@@ -2092,19 +2092,19 @@ msgstr ""
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:235
+#: lib/typster_web/live/editor_live/index.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:337
+#: lib/typster_web/live/editor_live/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr ""
@@ -2114,130 +2114,130 @@ msgstr ""
 msgid "editor.breadcrumb"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:527
+#: lib/typster_web/live/editor_live/index.html.heex:530
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:824
+#: lib/typster_web/live/editor_live/index.ex:833
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:448
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:474
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:494
+#: lib/typster_web/live/editor_live/index.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:464
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:467
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:875
+#: lib/typster_web/live/editor_live/index.ex:884
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1307
-#: lib/typster_web/live/editor_live/index.html.heex:675
-#: lib/typster_web/live/editor_live/index.html.heex:883
+#: lib/typster_web/live/editor_live/index.ex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:678
+#: lib/typster_web/live/editor_live/index.html.heex:886
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1309
+#: lib/typster_web/live/editor_live/index.ex:1318
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1313
+#: lib/typster_web/live/editor_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:789
+#: lib/typster_web/live/editor_live/index.html.heex:792
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:795
+#: lib/typster_web/live/editor_live/index.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:771
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:746
-#: lib/typster_web/live/editor_live/index.html.heex:885
+#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:888
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:803
+#: lib/typster_web/live/editor_live/index.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:816
+#: lib/typster_web/live/editor_live/index.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:755
+#: lib/typster_web/live/editor_live/index.html.heex:758
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:876
+#: lib/typster_web/live/editor_live/index.html.heex:879
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:776
+#: lib/typster_web/live/editor_live/index.html.heex:779
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:774
+#: lib/typster_web/live/editor_live/index.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:929
+#: lib/typster_web/live/editor_live/index.ex:938
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:916
+#: lib/typster_web/live/editor_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:160
+#: lib/typster_web/live/editor_live/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:176
+#: lib/typster_web/live/editor_live/index.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr ""
@@ -2247,12 +2247,12 @@ msgstr ""
 msgid "editor.topbar.back"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr ""
@@ -2262,12 +2262,12 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1001
+#: lib/typster_web/live/editor_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:149
+#: lib/typster_web/live/editor_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr ""
@@ -2287,263 +2287,263 @@ msgstr ""
 msgid "editor.topbar.branch"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:855
+#: lib/typster_web/live/editor_live/index.html.heex:858
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1027
+#: lib/typster_web/live/editor_live/index.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1441
+#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1444
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1482
+#: lib/typster_web/live/editor_live/index.html.heex:1485
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1254
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1252
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1267
+#: lib/typster_web/live/editor_live/index.html.heex:1270
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1268
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1271
+#: lib/typster_web/live/editor_live/index.html.heex:1274
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1272
+#: lib/typster_web/live/editor_live/index.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1262
+#: lib/typster_web/live/editor_live/index.html.heex:1265
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1266
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1324
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1338
+#: lib/typster_web/live/editor_live/index.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1328
+#: lib/typster_web/live/editor_live/index.html.heex:1331
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1319
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1318
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1333
+#: lib/typster_web/live/editor_live/index.html.heex:1336
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1467
+#: lib/typster_web/live/editor_live/index.html.heex:1470
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1473
+#: lib/typster_web/live/editor_live/index.html.heex:1476
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1451
+#: lib/typster_web/live/editor_live/index.html.heex:1454
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1459
+#: lib/typster_web/live/editor_live/index.html.heex:1462
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:359
+#: lib/typster_web/live/editor_live/index.ex:368
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:365
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1479
+#: lib/typster_web/live/editor_live/index.html.heex:1482
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1245
+#: lib/typster_web/live/editor_live/index.html.heex:1248
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1137
+#: lib/typster_web/live/editor_live/index.html.heex:1140
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1166
+#: lib/typster_web/live/editor_live/index.html.heex:1169
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1163
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1154
+#: lib/typster_web/live/editor_live/index.html.heex:1157
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1073
+#: lib/typster_web/live/editor_live/index.html.heex:1076
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1060
+#: lib/typster_web/live/editor_live/index.html.heex:1063
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1086
+#: lib/typster_web/live/editor_live/index.html.heex:1089
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1074
+#: lib/typster_web/live/editor_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1118
+#: lib/typster_web/live/editor_live/index.html.heex:1121
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1125
+#: lib/typster_web/live/editor_live/index.html.heex:1128
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1083
+#: lib/typster_web/live/editor_live/index.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1091
+#: lib/typster_web/live/editor_live/index.html.heex:1094
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1101
+#: lib/typster_web/live/editor_live/index.html.heex:1104
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1240
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1241
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1239
+#: lib/typster_web/live/editor_live/index.html.heex:1242
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1185
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1183
+#: lib/typster_web/live/editor_live/index.html.heex:1186
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1184
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1173
+#: lib/typster_web/live/editor_live/index.html.heex:1176
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1174
+#: lib/typster_web/live/editor_live/index.html.heex:1177
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1208
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1216
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr ""
@@ -2573,20 +2573,20 @@ msgstr ""
 msgid "share.public.open_in_typster"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1072
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.ex:1081
+#: lib/typster_web/live/editor_live/index.html.heex:1082
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1070
-#: lib/typster_web/live/editor_live/index.html.heex:1107
+#: lib/typster_web/live/editor_live/index.ex:1079
+#: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1071
-#: lib/typster_web/live/editor_live/index.html.heex:1080
+#: lib/typster_web/live/editor_live/index.ex:1080
+#: lib/typster_web/live/editor_live/index.html.heex:1083
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr ""
@@ -2606,77 +2606,77 @@ msgstr ""
 msgid "share.scope.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1294
+#: lib/typster_web/live/editor_live/index.html.heex:1297
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1290
+#: lib/typster_web/live/editor_live/index.html.heex:1293
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1286
+#: lib/typster_web/live/editor_live/index.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1019
+#: lib/typster_web/live/editor_live/index.html.heex:1022
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1040
+#: lib/typster_web/live/editor_live/index.html.heex:1043
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1041
+#: lib/typster_web/live/editor_live/index.html.heex:1044
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1039
+#: lib/typster_web/live/editor_live/index.html.heex:1042
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1038
+#: lib/typster_web/live/editor_live/index.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1017
+#: lib/typster_web/live/editor_live/index.html.heex:1020
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1168
+#: lib/typster_web/live/editor_live/index.ex:1177
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1304
+#: lib/typster_web/live/editor_live/index.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1303
+#: lib/typster_web/live/editor_live/index.html.heex:1306
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1258
+#: lib/typster_web/live/editor_live/index.html.heex:1261
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1226
+#: lib/typster_web/live/editor_live/index.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1225
+#: lib/typster_web/live/editor_live/index.html.heex:1228
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr ""
@@ -2696,63 +2696,63 @@ msgstr ""
 msgid "share.public.powered_by"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1357
+#: lib/typster_web/live/editor_live/index.html.heex:1360
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1359
+#: lib/typster_web/live/editor_live/index.html.heex:1362
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1358
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1344
+#: lib/typster_web/live/editor_live/index.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1395
-#: lib/typster_web/live/editor_live/index.html.heex:1405
+#: lib/typster_web/live/editor_live/index.html.heex:1398
+#: lib/typster_web/live/editor_live/index.html.heex:1408
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1351
+#: lib/typster_web/live/editor_live/index.html.heex:1354
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1365
+#: lib/typster_web/live/editor_live/index.html.heex:1368
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1373
+#: lib/typster_web/live/editor_live/index.html.heex:1376
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1372
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1379
+#: lib/typster_web/live/editor_live/index.html.heex:1382
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1115
+#: lib/typster_web/live/editor_live/index.ex:1124
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr ""
@@ -2765,4 +2765,9 @@ msgstr ""
 #: lib/typster_web/controllers/invite_controller.ex:23
 #, elixir-autogen, elixir-format
 msgid "share.invite.wrong_account"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#, elixir-autogen, elixir-format
+msgid "editor.share_owner_only"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -53,7 +53,7 @@ msgstr "Logging in…"
 msgid "auth.sign_up"
 msgstr "Sign up"
 
-#: lib/typster_web/live/project_live/index.html.heex:157
+#: lib/typster_web/live/project_live/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "common.cancel"
 msgstr "Not now"
@@ -72,7 +72,7 @@ msgstr "Created %{date}"
 msgid "common.email"
 msgstr "Email"
 
-#: lib/typster_web/live/project_live/index.html.heex:106
+#: lib/typster_web/live/project_live/index.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "common.open"
 msgstr "Open"
@@ -361,22 +361,22 @@ msgid_plural "projects.count.other"
 msgstr[0] "%{count} project"
 msgstr[1] "%{count} projects"
 
-#: lib/typster_web/live/project_live/index.html.heex:160
+#: lib/typster_web/live/project_live/index.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "projects.create"
 msgstr "Create project"
 
-#: lib/typster_web/live/project_live/index.html.heex:95
+#: lib/typster_web/live/project_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "projects.delete.confirm"
 msgstr "Delete this project? There is no undo."
 
-#: lib/typster_web/live/project_live/index.html.heex:97
+#: lib/typster_web/live/project_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "projects.delete.label"
 msgstr "Delete project"
 
-#: lib/typster_web/live/project_live/index.html.heex:141
+#: lib/typster_web/live/project_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "projects.dialog.description"
 msgstr "Give it a short name future-you can parse."
@@ -391,23 +391,23 @@ msgstr "No projects yet. Clean slate, mildly suspicious. Time to start one? 🤔
 msgid "projects.index.subtitle"
 msgstr "Open an existing project or start a new one. The document will not typeset itself."
 
-#: lib/typster_web/live/project_live/index.ex:18
+#: lib/typster_web/live/project_live/index.ex:24
 #, elixir-autogen, elixir-format
 msgid "projects.index.title"
 msgstr "Projects"
 
-#: lib/typster_web/live/project_live/index.html.heex:146
+#: lib/typster_web/live/project_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "projects.name.label"
 msgstr "Project name"
 
-#: lib/typster_web/live/project_live/index.html.heex:151
+#: lib/typster_web/live/project_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "projects.name.placeholder"
 msgstr "Thesis, under control"
 
 #: lib/typster_web/live/project_live/index.html.heex:17
-#: lib/typster_web/live/project_live/index.html.heex:140
+#: lib/typster_web/live/project_live/index.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "projects.new"
 msgstr "New project"
@@ -707,28 +707,28 @@ msgstr "Light, dark, or follow your system."
 msgid "settings.appearance.title"
 msgstr "Appearance"
 
-#: lib/typster_web/live/project_live/index.ex:127
+#: lib/typster_web/live/project_live/index.ex:144
 #, elixir-autogen, elixir-format
 msgid "1 day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "1 day ago"
 msgstr[1] "%{count} days ago"
 
-#: lib/typster_web/live/project_live/index.html.heex:74
+#: lib/typster_web/live/project_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "1 file"
 msgid_plural "%{count} files"
 msgstr[0] "1 file"
 msgstr[1] "%{count} files"
 
-#: lib/typster_web/live/project_live/index.ex:126
+#: lib/typster_web/live/project_live/index.ex:143
 #, elixir-autogen, elixir-format
 msgid "1 hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "1 hour ago"
 msgstr[1] "%{count} hours ago"
 
-#: lib/typster_web/live/project_live/index.ex:125
+#: lib/typster_web/live/project_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "1 minute ago"
 msgid_plural "%{count} minutes ago"
@@ -765,43 +765,43 @@ msgstr "projects"
 msgid "projects.heading_lead"
 msgstr "Your"
 
-#: lib/typster_web/live/project_live/index.html.heex:122
+#: lib/typster_web/live/project_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "projects.import.soon"
 msgstr "Import is coming soon"
 
-#: lib/typster_web/live/project_live/index.html.heex:128
+#: lib/typster_web/live/project_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "projects.import.sub"
 msgstr "Drag-drop or paste a GitHub URL"
 
-#: lib/typster_web/live/project_live/index.html.heex:127
+#: lib/typster_web/live/project_live/index.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "projects.import.title"
 msgstr "Import .zip or git repo"
 
-#: lib/typster_web/live/project_live/index.html.heex:74
+#: lib/typster_web/live/project_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "projects.row.edited"
 msgstr "Edited"
 
-#: lib/typster_web/live/project_live/index.html.heex:86
-#: lib/typster_web/live/project_live/index.html.heex:87
+#: lib/typster_web/live/project_live/index.html.heex:91
+#: lib/typster_web/live/project_live/index.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "projects.star_soon"
 msgstr "Starring is coming soon"
 
-#: lib/typster_web/live/project_live/index.html.heex:118
+#: lib/typster_web/live/project_live/index.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "projects.template.sub"
 msgstr "IEEE, thesis, résumé, invoice, slides"
 
-#: lib/typster_web/live/project_live/index.html.heex:117
+#: lib/typster_web/live/project_live/index.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "projects.template.title"
 msgstr "Start from a template"
 
-#: lib/typster_web/live/project_live/index.ex:124
+#: lib/typster_web/live/project_live/index.ex:141
 #, elixir-autogen, elixir-format
 msgid "time.just_now"
 msgstr "just now"
@@ -2150,7 +2150,7 @@ msgstr "Start a file from this template"
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1308
+#: lib/typster_web/live/editor_live/index.ex:1307
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1310
+#: lib/typster_web/live/editor_live/index.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1314
+#: lib/typster_web/live/editor_live/index.ex:1313
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2651,7 +2651,7 @@ msgstr "People"
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1169
+#: lib/typster_web/live/editor_live/index.ex:1168
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
@@ -2686,7 +2686,7 @@ msgstr "Per-file write access is Pro"
 msgid "share.invite.accepted"
 msgstr "You're in — welcome to the project."
 
-#: lib/typster_web/controllers/invite_controller.ex:23
+#: lib/typster_web/controllers/invite_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "share.invite.invalid"
 msgstr "That invite link is invalid or has expired."
@@ -2756,3 +2756,13 @@ msgstr "Width"
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// soon™ — still cooking 🍳  grab the iframe for now"
+
+#: lib/typster_web/live/project_live/index.html.heex:75
+#, elixir-autogen, elixir-format
+msgid "projects.row.shared"
+msgstr "Shared"
+
+#: lib/typster_web/controllers/invite_controller.ex:23
+#, elixir-autogen, elixir-format
+msgid "share.invite.wrong_account"
+msgstr "Plot twist — this invite's addressed to a different email. Log in as the invited account to claim it."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr "Log in"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:197
+#: lib/typster_web/live/editor_live/index.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Log out"
@@ -134,122 +134,122 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
 
-#: lib/typster_web/live/editor_live/index.html.heex:110
+#: lib/typster_web/live/editor_live/index.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:716
-#: lib/typster_web/live/editor_live/index.html.heex:717
+#: lib/typster_web/live/editor_live/index.html.heex:719
+#: lib/typster_web/live/editor_live/index.html.heex:720
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
-#: lib/typster_web/live/editor_live/index.html.heex:220
-#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:223
+#: lib/typster_web/live/editor_live/index.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:700
+#: lib/typster_web/live/editor_live/index.ex:709
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:697
+#: lib/typster_web/live/editor_live/index.ex:706
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:401
+#: lib/typster_web/live/editor_live/index.ex:410
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:731
+#: lib/typster_web/live/editor_live/index.ex:740
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:558
-#: lib/typster_web/live/editor_live/index.ex:582
-#: lib/typster_web/live/editor_live/index.ex:874
+#: lib/typster_web/live/editor_live/index.ex:567
+#: lib/typster_web/live/editor_live/index.ex:591
+#: lib/typster_web/live/editor_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:246
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:298
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:669
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:732
+#: lib/typster_web/live/editor_live/index.html.heex:735
 #: lib/typster_web/live/shared_project_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:808
+#: lib/typster_web/live/editor_live/index.ex:817
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:806
+#: lib/typster_web/live/editor_live/index.ex:815
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:807
+#: lib/typster_web/live/editor_live/index.ex:816
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
-#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:416
+#: lib/typster_web/live/editor_live/index.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:182
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Dark theme"
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:179
+#: lib/typster_web/live/editor_live/index.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Light theme"
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Use system theme"
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:139
+#: lib/typster_web/live/editor_live/index.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Toggle theme"
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr "My projects"
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:190
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Projects"
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Settings"
@@ -517,157 +517,157 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
-#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:689
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:79
-#: lib/typster_web/live/editor_live/index.html.heex:682
+#: lib/typster_web/live/editor_live/index.html.heex:82
+#: lib/typster_web/live/editor_live/index.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:213
-#: lib/typster_web/live/editor_live/index.html.heex:214
+#: lib/typster_web/live/editor_live/index.html.heex:216
+#: lib/typster_web/live/editor_live/index.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:543
-#: lib/typster_web/live/editor_live/index.html.heex:544
+#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:563
+#: lib/typster_web/live/editor_live/index.html.heex:565
+#: lib/typster_web/live/editor_live/index.html.heex:566
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:609
-#: lib/typster_web/live/editor_live/index.html.heex:610
+#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:613
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:552
-#: lib/typster_web/live/editor_live/index.html.heex:553
+#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:590
-#: lib/typster_web/live/editor_live/index.html.heex:591
+#: lib/typster_web/live/editor_live/index.html.heex:593
+#: lib/typster_web/live/editor_live/index.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:571
-#: lib/typster_web/live/editor_live/index.html.heex:572
+#: lib/typster_web/live/editor_live/index.html.heex:574
+#: lib/typster_web/live/editor_live/index.html.heex:575
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:581
-#: lib/typster_web/live/editor_live/index.html.heex:582
+#: lib/typster_web/live/editor_live/index.html.heex:584
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:599
-#: lib/typster_web/live/editor_live/index.html.heex:600
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:385
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:926
-#: lib/typster_web/live/editor_live/index.html.heex:935
+#: lib/typster_web/live/editor_live/index.html.heex:921
+#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:938
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:970
-#: lib/typster_web/live/editor_live/index.html.heex:978
-#: lib/typster_web/live/editor_live/index.html.heex:987
+#: lib/typster_web/live/editor_live/index.html.heex:973
+#: lib/typster_web/live/editor_live/index.html.heex:981
+#: lib/typster_web/live/editor_live/index.html.heex:990
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:953
+#: lib/typster_web/live/editor_live/index.html.heex:956
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:975
+#: lib/typster_web/live/editor_live/index.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:910
+#: lib/typster_web/live/editor_live/index.html.heex:913
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:919
-#: lib/typster_web/live/editor_live/index.html.heex:943
-#: lib/typster_web/live/editor_live/index.html.heex:949
+#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:946
+#: lib/typster_web/live/editor_live/index.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:923
+#: lib/typster_web/live/editor_live/index.html.heex:926
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:971
-#: lib/typster_web/live/editor_live/index.html.heex:990
-#: lib/typster_web/live/editor_live/index.html.heex:999
+#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:993
+#: lib/typster_web/live/editor_live/index.html.heex:1002
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:677
+#: lib/typster_web/live/editor_live/index.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:711
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:71
-#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:694
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:700
+#: lib/typster_web/live/editor_live/index.html.heex:703
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:699
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -827,38 +827,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:660
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:661
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:647
+#: lib/typster_web/live/editor_live/index.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:619
-#: lib/typster_web/live/editor_live/index.html.heex:620
+#: lib/typster_web/live/editor_live/index.html.heex:622
+#: lib/typster_web/live/editor_live/index.html.heex:623
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1986,17 +1986,17 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:226
+#: lib/typster_web/live/editor_live/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
@@ -2006,40 +2006,40 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:263
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:354
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:523
-#: lib/typster_web/live/editor_live/index.ex:569
-#: lib/typster_web/live/editor_live/index.ex:730
+#: lib/typster_web/live/editor_live/index.ex:532
+#: lib/typster_web/live/editor_live/index.ex:578
+#: lib/typster_web/live/editor_live/index.ex:739
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,24 +2049,24 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:667
+#: lib/typster_web/live/editor_live/index.ex:676
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:645
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
 
-#: lib/typster_web/live/editor_live/index.html.heex:284
+#: lib/typster_web/live/editor_live/index.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Pinned"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
@@ -2082,7 +2082,7 @@ msgid "editor.tree.pin"
 msgstr "Pin file"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:514
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
@@ -2092,19 +2092,19 @@ msgstr "Pinned"
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] "%{count} section"
 msgstr[1] "%{count} sections"
 
-#: lib/typster_web/live/editor_live/index.html.heex:235
+#: lib/typster_web/live/editor_live/index.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "New folder"
 
-#: lib/typster_web/live/editor_live/index.html.heex:337
+#: lib/typster_web/live/editor_live/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "folder name"
@@ -2114,130 +2114,130 @@ msgstr "folder name"
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
 
-#: lib/typster_web/live/editor_live/index.html.heex:527
+#: lib/typster_web/live/editor_live/index.html.heex:530
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:824
+#: lib/typster_web/live/editor_live/index.ex:833
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
 
-#: lib/typster_web/live/editor_live/index.html.heex:448
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Your templates"
 
-#: lib/typster_web/live/editor_live/index.html.heex:474
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Remove this template?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:494
+#: lib/typster_web/live/editor_live/index.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Upload a file to reuse"
 
-#: lib/typster_web/live/editor_live/index.html.heex:464
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:467
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:875
+#: lib/typster_web/live/editor_live/index.ex:884
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1307
-#: lib/typster_web/live/editor_live/index.html.heex:675
-#: lib/typster_web/live/editor_live/index.html.heex:883
+#: lib/typster_web/live/editor_live/index.ex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:678
+#: lib/typster_web/live/editor_live/index.html.heex:886
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1309
+#: lib/typster_web/live/editor_live/index.ex:1318
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1313
+#: lib/typster_web/live/editor_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:789
+#: lib/typster_web/live/editor_live/index.html.heex:792
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Clear log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:795
+#: lib/typster_web/live/editor_live/index.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Close panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:771
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "Jump to first"
 
-#: lib/typster_web/live/editor_live/index.html.heex:746
-#: lib/typster_web/live/editor_live/index.html.heex:885
+#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:888
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Compile log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:803
+#: lib/typster_web/live/editor_live/index.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "No compiles yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:816
+#: lib/typster_web/live/editor_live/index.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "No problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:755
+#: lib/typster_web/live/editor_live/index.html.heex:758
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:876
+#: lib/typster_web/live/editor_live/index.html.heex:879
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Toggle compile panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:776
+#: lib/typster_web/live/editor_live/index.html.heex:779
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Off"
 
-#: lib/typster_web/live/editor_live/index.html.heex:774
+#: lib/typster_web/live/editor_live/index.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:929
+#: lib/typster_web/live/editor_live/index.ex:938
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:916
+#: lib/typster_web/live/editor_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
 
-#: lib/typster_web/live/editor_live/index.html.heex:160
+#: lib/typster_web/live/editor_live/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr "Account"
 
-#: lib/typster_web/live/editor_live/index.html.heex:176
+#: lib/typster_web/live/editor_live/index.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr "Appearance"
@@ -2247,12 +2247,12 @@ msgstr "Appearance"
 msgid "editor.topbar.back"
 msgstr "Back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr "Collaborators"
 
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr "Failed"
@@ -2262,12 +2262,12 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:1001
+#: lib/typster_web/live/editor_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
 
-#: lib/typster_web/live/editor_live/index.html.heex:149
+#: lib/typster_web/live/editor_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr "Language"
@@ -2287,263 +2287,263 @@ msgstr "Switch project"
 msgid "editor.topbar.branch"
 msgstr "Branch"
 
-#: lib/typster_web/live/editor_live/index.html.heex:855
+#: lib/typster_web/live/editor_live/index.html.heex:858
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr "Compile times (last 12 runs)"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1027
+#: lib/typster_web/live/editor_live/index.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr "Close"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1441
+#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1444
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Copy"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1482
+#: lib/typster_web/live/editor_live/index.html.heex:1485
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Done"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1254
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Allow downloads"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1252
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Visitors can download the compiled PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1267
+#: lib/typster_web/live/editor_live/index.html.heex:1270
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Expires in 30 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1268
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Auto-revokes the link after the set period."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1271
+#: lib/typster_web/live/editor_live/index.html.heex:1274
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Password-protect"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1272
+#: lib/typster_web/live/editor_live/index.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Visitor must enter a passphrase before opening."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1262
+#: lib/typster_web/live/editor_live/index.html.heex:1265
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Require sign-in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1266
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Visitors must sign in with a Typster account."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1324
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Components"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1338
+#: lib/typster_web/live/editor_live/index.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Visitor can edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1328
+#: lib/typster_web/live/editor_live/index.html.heex:1331
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "File tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1319
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Visitors can read & open your project on any plan. Upgrade to let them edit live in their browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1318
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Embed is free — interactive sandbox is Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1333
+#: lib/typster_web/live/editor_live/index.html.heex:1336
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Compiled preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1467
+#: lib/typster_web/live/editor_live/index.html.heex:1470
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Download PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1473
+#: lib/typster_web/live/editor_live/index.html.heex:1476
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Exports the document compiled in your browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1451
+#: lib/typster_web/live/editor_live/index.html.heex:1454
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Last successful compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1459
+#: lib/typster_web/live/editor_live/index.html.heex:1462
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Includes embedded fonts. Re-export to refresh."
 
-#: lib/typster_web/live/editor_live/index.ex:359
+#: lib/typster_web/live/editor_live/index.ex:368
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Could not send that invite."
 
-#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:365
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Invited %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1479
+#: lib/typster_web/live/editor_live/index.html.heex:1482
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "Learn about permissions →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Link activity"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1245
+#: lib/typster_web/live/editor_live/index.html.heex:1248
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Advanced"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1137
+#: lib/typster_web/live/editor_live/index.html.heex:1140
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr "Share link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1166
+#: lib/typster_web/live/editor_live/index.html.heex:1169
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr "Anyone with this link can…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1163
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr "Rotate key"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1154
+#: lib/typster_web/live/editor_live/index.html.heex:1157
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr "Rotating the key revokes the current link instantly."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1073
+#: lib/typster_web/live/editor_live/index.html.heex:1076
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr "Add by email…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1060
+#: lib/typster_web/live/editor_live/index.html.heex:1063
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr "Invite people"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1086
+#: lib/typster_web/live/editor_live/index.html.heex:1089
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
 
-#: lib/typster_web/live/editor_live/index.ex:1074
+#: lib/typster_web/live/editor_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1118
+#: lib/typster_web/live/editor_live/index.html.heex:1121
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr "Pending"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1125
+#: lib/typster_web/live/editor_live/index.html.heex:1128
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr "Remove"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1083
+#: lib/typster_web/live/editor_live/index.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr "Send invite"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1091
+#: lib/typster_web/live/editor_live/index.html.heex:1094
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr "People with access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1101
+#: lib/typster_web/live/editor_live/index.html.heex:1104
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr "you"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1240
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "careful"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1241
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1239
+#: lib/typster_web/live/editor_live/index.html.heex:1242
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Read + write everything and manage the link. Same as Owner."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1185
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr "Compiled output only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1183
+#: lib/typster_web/live/editor_live/index.html.heex:1186
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr "Hides the source. Shows the latest successful compile."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1184
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr "PDF only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1173
+#: lib/typster_web/live/editor_live/index.html.heex:1176
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr "Read"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1174
+#: lib/typster_web/live/editor_live/index.html.heex:1177
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr "See realtime source and the rendered preview. No editing."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1208
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Write — specific files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1216
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2573,20 +2573,20 @@ msgstr "This link isn't valid"
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1072
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.ex:1081
+#: lib/typster_web/live/editor_live/index.html.heex:1082
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
-#: lib/typster_web/live/editor_live/index.ex:1070
-#: lib/typster_web/live/editor_live/index.html.heex:1107
+#: lib/typster_web/live/editor_live/index.ex:1079
+#: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
-#: lib/typster_web/live/editor_live/index.ex:1071
-#: lib/typster_web/live/editor_live/index.html.heex:1080
+#: lib/typster_web/live/editor_live/index.ex:1080
+#: lib/typster_web/live/editor_live/index.html.heex:1083
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Viewer"
@@ -2606,77 +2606,77 @@ msgstr "Compiled output"
 msgid "share.scope.read"
 msgstr "Read-only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1294
+#: lib/typster_web/live/editor_live/index.html.heex:1297
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Link created"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1290
+#: lib/typster_web/live/editor_live/index.html.heex:1293
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Active editors now"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1286
+#: lib/typster_web/live/editor_live/index.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Opens last 7 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1019
+#: lib/typster_web/live/editor_live/index.html.heex:1022
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr "Invite collaborators, share a link, embed the project, or download the PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1040
+#: lib/typster_web/live/editor_live/index.html.heex:1043
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr "Embed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1041
+#: lib/typster_web/live/editor_live/index.html.heex:1044
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr "Export PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1039
+#: lib/typster_web/live/editor_live/index.html.heex:1042
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1038
+#: lib/typster_web/live/editor_live/index.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr "People"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1017
+#: lib/typster_web/live/editor_live/index.html.heex:1020
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1168
+#: lib/typster_web/live/editor_live/index.ex:1177
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1304
+#: lib/typster_web/live/editor_live/index.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Real-time opens, active editors, and locations — with Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1303
+#: lib/typster_web/live/editor_live/index.html.heex:1306
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "See who opens your link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1258
+#: lib/typster_web/live/editor_live/index.html.heex:1261
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Unlock with Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1226
+#: lib/typster_web/live/editor_live/index.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Free links are read-only or fully editable. Upgrade to scope writes."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1225
+#: lib/typster_web/live/editor_live/index.html.heex:1228
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Per-file write access is Pro"
@@ -2696,63 +2696,63 @@ msgstr "That invite link is invalid or has expired."
 msgid "share.public.powered_by"
 msgstr "Powered by"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1357
+#: lib/typster_web/live/editor_live/index.html.heex:1360
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr "Always"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1359
+#: lib/typster_web/live/editor_live/index.html.heex:1362
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr "Hidden"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1358
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr "On edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1344
+#: lib/typster_web/live/editor_live/index.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr "Hide Typster footer"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1395
-#: lib/typster_web/live/editor_live/index.html.heex:1405
+#: lib/typster_web/live/editor_live/index.html.heex:1398
+#: lib/typster_web/live/editor_live/index.html.heex:1408
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr "Live preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1351
+#: lib/typster_web/live/editor_live/index.html.heex:1354
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr "Save CTA"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1365
+#: lib/typster_web/live/editor_live/index.html.heex:1368
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr "Theme"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr "Auto"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1373
+#: lib/typster_web/live/editor_live/index.html.heex:1376
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr "Dark"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1372
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr "Light"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1379
+#: lib/typster_web/live/editor_live/index.html.heex:1382
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr "Width"
 
-#: lib/typster_web/live/editor_live/index.ex:1115
+#: lib/typster_web/live/editor_live/index.ex:1124
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// soon™ — still cooking 🍳  grab the iframe for now"
@@ -2766,3 +2766,8 @@ msgstr "Shared"
 #, elixir-autogen, elixir-format
 msgid "share.invite.wrong_account"
 msgstr "Plot twist — this invite's addressed to a different email. Log in as the invited account to claim it."
+
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#, elixir-autogen, elixir-format
+msgid "editor.share_owner_only"
+msgstr "Owner-only — sharing is their call."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr "Войти"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:197
+#: lib/typster_web/live/editor_live/index.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Выйти"
@@ -134,122 +134,122 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:408
+#: lib/typster_web/live/editor_live/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:110
+#: lib/typster_web/live/editor_live/index.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:716
-#: lib/typster_web/live/editor_live/index.html.heex:717
+#: lib/typster_web/live/editor_live/index.html.heex:719
+#: lib/typster_web/live/editor_live/index.html.heex:720
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:220
-#: lib/typster_web/live/editor_live/index.html.heex:293
+#: lib/typster_web/live/editor_live/index.html.heex:223
+#: lib/typster_web/live/editor_live/index.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:700
+#: lib/typster_web/live/editor_live/index.ex:709
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:697
+#: lib/typster_web/live/editor_live/index.ex:706
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:401
+#: lib/typster_web/live/editor_live/index.ex:410
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:731
+#: lib/typster_web/live/editor_live/index.ex:740
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:558
-#: lib/typster_web/live/editor_live/index.ex:582
-#: lib/typster_web/live/editor_live/index.ex:874
+#: lib/typster_web/live/editor_live/index.ex:567
+#: lib/typster_web/live/editor_live/index.ex:591
+#: lib/typster_web/live/editor_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:243
+#: lib/typster_web/live/editor_live/index.html.heex:246
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:534
+#: lib/typster_web/live/editor_live/index.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:298
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:669
+#: lib/typster_web/live/editor_live/index.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:732
+#: lib/typster_web/live/editor_live/index.html.heex:735
 #: lib/typster_web/live/shared_project_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:808
+#: lib/typster_web/live/editor_live/index.ex:817
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:806
+#: lib/typster_web/live/editor_live/index.ex:815
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:807
+#: lib/typster_web/live/editor_live/index.ex:816
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:413
-#: lib/typster_web/live/editor_live/index.html.heex:442
+#: lib/typster_web/live/editor_live/index.html.heex:416
+#: lib/typster_web/live/editor_live/index.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:182
+#: lib/typster_web/live/editor_live/index.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Темная тема"
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:179
+#: lib/typster_web/live/editor_live/index.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Светлая тема"
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Как в системе"
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:139
+#: lib/typster_web/live/editor_live/index.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Переключить тему"
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr "Мои проекты"
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:190
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Проекты"
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Настройки"
@@ -519,157 +519,157 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:100
-#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:103
+#: lib/typster_web/live/editor_live/index.html.heex:689
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:79
-#: lib/typster_web/live/editor_live/index.html.heex:682
+#: lib/typster_web/live/editor_live/index.html.heex:82
+#: lib/typster_web/live/editor_live/index.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:213
-#: lib/typster_web/live/editor_live/index.html.heex:214
+#: lib/typster_web/live/editor_live/index.html.heex:216
+#: lib/typster_web/live/editor_live/index.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:543
-#: lib/typster_web/live/editor_live/index.html.heex:544
+#: lib/typster_web/live/editor_live/index.html.heex:546
+#: lib/typster_web/live/editor_live/index.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:562
-#: lib/typster_web/live/editor_live/index.html.heex:563
+#: lib/typster_web/live/editor_live/index.html.heex:565
+#: lib/typster_web/live/editor_live/index.html.heex:566
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:609
-#: lib/typster_web/live/editor_live/index.html.heex:610
+#: lib/typster_web/live/editor_live/index.html.heex:612
+#: lib/typster_web/live/editor_live/index.html.heex:613
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:552
-#: lib/typster_web/live/editor_live/index.html.heex:553
+#: lib/typster_web/live/editor_live/index.html.heex:555
+#: lib/typster_web/live/editor_live/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:590
-#: lib/typster_web/live/editor_live/index.html.heex:591
+#: lib/typster_web/live/editor_live/index.html.heex:593
+#: lib/typster_web/live/editor_live/index.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:571
-#: lib/typster_web/live/editor_live/index.html.heex:572
+#: lib/typster_web/live/editor_live/index.html.heex:574
+#: lib/typster_web/live/editor_live/index.html.heex:575
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:581
-#: lib/typster_web/live/editor_live/index.html.heex:582
+#: lib/typster_web/live/editor_live/index.html.heex:584
+#: lib/typster_web/live/editor_live/index.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:599
-#: lib/typster_web/live/editor_live/index.html.heex:600
+#: lib/typster_web/live/editor_live/index.html.heex:602
+#: lib/typster_web/live/editor_live/index.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:385
+#: lib/typster_web/live/editor_live/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:392
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:918
-#: lib/typster_web/live/editor_live/index.html.heex:926
-#: lib/typster_web/live/editor_live/index.html.heex:935
+#: lib/typster_web/live/editor_live/index.html.heex:921
+#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:938
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:970
-#: lib/typster_web/live/editor_live/index.html.heex:978
-#: lib/typster_web/live/editor_live/index.html.heex:987
+#: lib/typster_web/live/editor_live/index.html.heex:973
+#: lib/typster_web/live/editor_live/index.html.heex:981
+#: lib/typster_web/live/editor_live/index.html.heex:990
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:953
+#: lib/typster_web/live/editor_live/index.html.heex:956
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:975
+#: lib/typster_web/live/editor_live/index.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:910
+#: lib/typster_web/live/editor_live/index.html.heex:913
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:919
-#: lib/typster_web/live/editor_live/index.html.heex:943
-#: lib/typster_web/live/editor_live/index.html.heex:949
+#: lib/typster_web/live/editor_live/index.html.heex:922
+#: lib/typster_web/live/editor_live/index.html.heex:946
+#: lib/typster_web/live/editor_live/index.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:923
+#: lib/typster_web/live/editor_live/index.html.heex:926
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:971
-#: lib/typster_web/live/editor_live/index.html.heex:990
-#: lib/typster_web/live/editor_live/index.html.heex:999
+#: lib/typster_web/live/editor_live/index.html.heex:974
+#: lib/typster_web/live/editor_live/index.html.heex:993
+#: lib/typster_web/live/editor_live/index.html.heex:1002
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:677
+#: lib/typster_web/live/editor_live/index.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:708
+#: lib/typster_web/live/editor_live/index.html.heex:711
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:71
-#: lib/typster_web/live/editor_live/index.html.heex:73
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.html.heex:691
+#: lib/typster_web/live/editor_live/index.html.heex:694
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:700
+#: lib/typster_web/live/editor_live/index.html.heex:703
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:696
+#: lib/typster_web/live/editor_live/index.html.heex:699
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -833,38 +833,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:660
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:649
+#: lib/typster_web/live/editor_live/index.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:661
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:647
+#: lib/typster_web/live/editor_live/index.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:646
+#: lib/typster_web/live/editor_live/index.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:619
-#: lib/typster_web/live/editor_live/index.html.heex:620
+#: lib/typster_web/live/editor_live/index.html.heex:622
+#: lib/typster_web/live/editor_live/index.html.heex:623
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1992,17 +1992,17 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:226
+#: lib/typster_web/live/editor_live/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
@@ -2012,40 +2012,40 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:260
+#: lib/typster_web/live/editor_live/index.html.heex:263
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:259
+#: lib/typster_web/live/editor_live/index.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:258
+#: lib/typster_web/live/editor_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:351
+#: lib/typster_web/live/editor_live/index.html.heex:354
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:338
+#: lib/typster_web/live/editor_live/index.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:523
-#: lib/typster_web/live/editor_live/index.ex:569
-#: lib/typster_web/live/editor_live/index.ex:730
+#: lib/typster_web/live/editor_live/index.ex:532
+#: lib/typster_web/live/editor_live/index.ex:578
+#: lib/typster_web/live/editor_live/index.ex:739
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,24 +2055,24 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:667
+#: lib/typster_web/live/editor_live/index.ex:676
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:636
+#: lib/typster_web/live/editor_live/index.ex:645
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:284
+#: lib/typster_web/live/editor_live/index.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:475
-#: lib/typster_web/live/editor_live/index.html.heex:476
+#: lib/typster_web/live/editor_live/index.html.heex:478
+#: lib/typster_web/live/editor_live/index.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
@@ -2088,7 +2088,7 @@ msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:514
+#: lib/typster_web/live/editor_live/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
@@ -2098,7 +2098,7 @@ msgstr "Закреплён"
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:387
+#: lib/typster_web/live/editor_live/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2106,12 +2106,12 @@ msgstr[0] "%{count} раздел"
 msgstr[1] "%{count} раздела"
 msgstr[2] "%{count} разделов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:235
+#: lib/typster_web/live/editor_live/index.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "Новая папка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:337
+#: lib/typster_web/live/editor_live/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "имя папки"
@@ -2121,45 +2121,45 @@ msgstr "имя папки"
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:527
+#: lib/typster_web/live/editor_live/index.html.heex:530
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:824
+#: lib/typster_web/live/editor_live/index.ex:833
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:448
+#: lib/typster_web/live/editor_live/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Ваши шаблоны"
 
-#: lib/typster_web/live/editor_live/index.html.heex:474
+#: lib/typster_web/live/editor_live/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Удалить этот шаблон?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:494
+#: lib/typster_web/live/editor_live/index.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Загрузите файл для повторного использования"
 
-#: lib/typster_web/live/editor_live/index.html.heex:464
-#: lib/typster_web/live/editor_live/index.html.heex:465
+#: lib/typster_web/live/editor_live/index.html.heex:467
+#: lib/typster_web/live/editor_live/index.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:875
+#: lib/typster_web/live/editor_live/index.ex:884
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1307
-#: lib/typster_web/live/editor_live/index.html.heex:675
-#: lib/typster_web/live/editor_live/index.html.heex:883
+#: lib/typster_web/live/editor_live/index.ex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:678
+#: lib/typster_web/live/editor_live/index.html.heex:886
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1309
+#: lib/typster_web/live/editor_live/index.ex:1318
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,78 +2175,78 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1313
+#: lib/typster_web/live/editor_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:789
+#: lib/typster_web/live/editor_live/index.html.heex:792
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Очистить лог"
 
-#: lib/typster_web/live/editor_live/index.html.heex:795
+#: lib/typster_web/live/editor_live/index.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Закрыть панель"
 
-#: lib/typster_web/live/editor_live/index.html.heex:771
+#: lib/typster_web/live/editor_live/index.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "К первой"
 
-#: lib/typster_web/live/editor_live/index.html.heex:746
-#: lib/typster_web/live/editor_live/index.html.heex:885
+#: lib/typster_web/live/editor_live/index.html.heex:749
+#: lib/typster_web/live/editor_live/index.html.heex:888
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Лог компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:803
+#: lib/typster_web/live/editor_live/index.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "Пока нет компиляций"
 
-#: lib/typster_web/live/editor_live/index.html.heex:816
+#: lib/typster_web/live/editor_live/index.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "Нет проблем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:755
+#: lib/typster_web/live/editor_live/index.html.heex:758
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Проблемы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:876
+#: lib/typster_web/live/editor_live/index.html.heex:879
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Показать панель компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:776
+#: lib/typster_web/live/editor_live/index.html.heex:779
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Выкл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:774
+#: lib/typster_web/live/editor_live/index.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:929
+#: lib/typster_web/live/editor_live/index.ex:938
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:916
+#: lib/typster_web/live/editor_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
 
-#: lib/typster_web/live/editor_live/index.html.heex:160
+#: lib/typster_web/live/editor_live/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr "Аккаунт"
 
-#: lib/typster_web/live/editor_live/index.html.heex:176
+#: lib/typster_web/live/editor_live/index.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr "Оформление"
@@ -2256,12 +2256,12 @@ msgstr "Оформление"
 msgid "editor.topbar.back"
 msgstr "Назад"
 
-#: lib/typster_web/live/editor_live/index.html.heex:121
+#: lib/typster_web/live/editor_live/index.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr "Соавторы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:88
+#: lib/typster_web/live/editor_live/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr "Ошибка"
@@ -2271,12 +2271,12 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:1001
+#: lib/typster_web/live/editor_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
 
-#: lib/typster_web/live/editor_live/index.html.heex:149
+#: lib/typster_web/live/editor_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr "Язык"
@@ -2296,263 +2296,263 @@ msgstr "Сменить проект"
 msgid "editor.topbar.branch"
 msgstr "Ветка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:855
+#: lib/typster_web/live/editor_live/index.html.heex:858
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr "Время компиляции (последние 12)"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1027
+#: lib/typster_web/live/editor_live/index.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr "Закрыть"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1150
-#: lib/typster_web/live/editor_live/index.html.heex:1441
+#: lib/typster_web/live/editor_live/index.html.heex:1153
+#: lib/typster_web/live/editor_live/index.html.heex:1444
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Копировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1482
+#: lib/typster_web/live/editor_live/index.html.heex:1485
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1254
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Разрешить скачивание"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1252
+#: lib/typster_web/live/editor_live/index.html.heex:1255
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Посетители могут скачать готовый PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1267
+#: lib/typster_web/live/editor_live/index.html.heex:1270
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Истекает через 30 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1268
+#: lib/typster_web/live/editor_live/index.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Автоматически отзывает ссылку по сроку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1271
+#: lib/typster_web/live/editor_live/index.html.heex:1274
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Пароль"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1272
+#: lib/typster_web/live/editor_live/index.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Посетитель вводит пароль перед открытием."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1262
+#: lib/typster_web/live/editor_live/index.html.heex:1265
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Требовать вход"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1266
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Нужен вход в аккаунт Typster."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1324
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Компоненты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1338
+#: lib/typster_web/live/editor_live/index.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Гость может править"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1328
+#: lib/typster_web/live/editor_live/index.html.heex:1331
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "Дерево файлов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1319
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Гости могут читать и открывать проект на любом тарифе. Обновитесь до Pro, чтобы они правили прямо в браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1318
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Встраивание бесплатно — интерактивная песочница в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1333
+#: lib/typster_web/live/editor_live/index.html.heex:1336
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1467
+#: lib/typster_web/live/editor_live/index.html.heex:1470
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Скачать PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1473
+#: lib/typster_web/live/editor_live/index.html.heex:1476
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Экспортирует документ, собранный в вашем браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1451
+#: lib/typster_web/live/editor_live/index.html.heex:1454
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Последний успешный результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1459
+#: lib/typster_web/live/editor_live/index.html.heex:1462
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
 
-#: lib/typster_web/live/editor_live/index.ex:359
+#: lib/typster_web/live/editor_live/index.ex:368
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Не удалось отправить приглашение."
 
-#: lib/typster_web/live/editor_live/index.ex:356
+#: lib/typster_web/live/editor_live/index.ex:365
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Приглашён %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1479
+#: lib/typster_web/live/editor_live/index.html.heex:1482
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "О правах доступа →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Активность ссылки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1245
+#: lib/typster_web/live/editor_live/index.html.heex:1248
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Дополнительно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1137
+#: lib/typster_web/live/editor_live/index.html.heex:1140
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1166
+#: lib/typster_web/live/editor_live/index.html.heex:1169
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr "Любой по ссылке может…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1163
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr "Сменить ключ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1154
+#: lib/typster_web/live/editor_live/index.html.heex:1157
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr "Смена ключа мгновенно отзывает текущую ссылку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1073
+#: lib/typster_web/live/editor_live/index.html.heex:1076
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr "Добавить по email…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1060
+#: lib/typster_web/live/editor_live/index.html.heex:1063
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr "Пригласить людей"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1086
+#: lib/typster_web/live/editor_live/index.html.heex:1089
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
 
-#: lib/typster_web/live/editor_live/index.ex:1074
+#: lib/typster_web/live/editor_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1118
+#: lib/typster_web/live/editor_live/index.html.heex:1121
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr "Ожидает"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1125
+#: lib/typster_web/live/editor_live/index.html.heex:1128
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr "Удалить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1083
+#: lib/typster_web/live/editor_live/index.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr "Отправить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1091
+#: lib/typster_web/live/editor_live/index.html.heex:1094
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr "Есть доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1101
+#: lib/typster_web/live/editor_live/index.html.heex:1104
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr "вы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1240
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "осторожно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1241
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1239
+#: lib/typster_web/live/editor_live/index.html.heex:1242
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Чтение и запись всего, управление ссылкой. Как у владельца."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1182
+#: lib/typster_web/live/editor_live/index.html.heex:1185
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1183
+#: lib/typster_web/live/editor_live/index.html.heex:1186
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr "Скрывает исходник. Показывает последний успешный результат."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1184
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr "только PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1173
+#: lib/typster_web/live/editor_live/index.html.heex:1176
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr "Чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1174
+#: lib/typster_web/live/editor_live/index.html.heex:1177
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr "Видит исходник и превью в реальном времени. Без правок."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1208
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Запись — выбранные файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1216
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2582,20 +2582,20 @@ msgstr "Ссылка недействительна"
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1072
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.ex:1081
+#: lib/typster_web/live/editor_live/index.html.heex:1082
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
-#: lib/typster_web/live/editor_live/index.ex:1070
-#: lib/typster_web/live/editor_live/index.html.heex:1107
+#: lib/typster_web/live/editor_live/index.ex:1079
+#: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
-#: lib/typster_web/live/editor_live/index.ex:1071
-#: lib/typster_web/live/editor_live/index.html.heex:1080
+#: lib/typster_web/live/editor_live/index.ex:1080
+#: lib/typster_web/live/editor_live/index.html.heex:1083
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Читатель"
@@ -2615,77 +2615,77 @@ msgstr "Только результат"
 msgid "share.scope.read"
 msgstr "Только чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1294
+#: lib/typster_web/live/editor_live/index.html.heex:1297
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Ссылка создана"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1290
+#: lib/typster_web/live/editor_live/index.html.heex:1293
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Сейчас редактируют"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1286
+#: lib/typster_web/live/editor_live/index.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Открытий за 7 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1019
+#: lib/typster_web/live/editor_live/index.html.heex:1022
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr "Пригласите соавторов, поделитесь ссылкой, встройте проект или скачайте PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1040
+#: lib/typster_web/live/editor_live/index.html.heex:1043
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr "Встроить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1041
+#: lib/typster_web/live/editor_live/index.html.heex:1044
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr "Экспорт PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1039
+#: lib/typster_web/live/editor_live/index.html.heex:1042
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1038
+#: lib/typster_web/live/editor_live/index.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr "Люди"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1017
+#: lib/typster_web/live/editor_live/index.html.heex:1020
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1168
+#: lib/typster_web/live/editor_live/index.ex:1177
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1304
+#: lib/typster_web/live/editor_live/index.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Открытия, активные редакторы и геолокация — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1303
+#: lib/typster_web/live/editor_live/index.html.heex:1306
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "Кто открывает вашу ссылку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1258
+#: lib/typster_web/live/editor_live/index.html.heex:1261
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Открыть в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1226
+#: lib/typster_web/live/editor_live/index.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Бесплатные ссылки — только чтение или полный доступ. Точечная запись — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1225
+#: lib/typster_web/live/editor_live/index.html.heex:1228
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Пофайловая запись — в Pro"
@@ -2705,63 +2705,63 @@ msgstr "Эта ссылка-приглашение недействительн�
 msgid "share.public.powered_by"
 msgstr "Работает на"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1357
+#: lib/typster_web/live/editor_live/index.html.heex:1360
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr "Всегда"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1359
+#: lib/typster_web/live/editor_live/index.html.heex:1362
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr "Скрыта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1358
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr "При правке"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1344
+#: lib/typster_web/live/editor_live/index.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr "Скрыть подпись Typster"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1395
-#: lib/typster_web/live/editor_live/index.html.heex:1405
+#: lib/typster_web/live/editor_live/index.html.heex:1398
+#: lib/typster_web/live/editor_live/index.html.heex:1408
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr "Живой предпросмотр"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1351
+#: lib/typster_web/live/editor_live/index.html.heex:1354
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr "Кнопка «Сохранить»"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1365
+#: lib/typster_web/live/editor_live/index.html.heex:1368
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr "Тема"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr "Авто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1373
+#: lib/typster_web/live/editor_live/index.html.heex:1376
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr "Тёмная"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1372
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr "Светлая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1379
+#: lib/typster_web/live/editor_live/index.html.heex:1382
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr "Ширина"
 
-#: lib/typster_web/live/editor_live/index.ex:1115
+#: lib/typster_web/live/editor_live/index.ex:1124
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// скоро™ — ещё готовим 🍳  пока бери iframe"
@@ -2775,3 +2775,8 @@ msgstr "Общий"
 #, elixir-autogen, elixir-format
 msgid "share.invite.wrong_account"
 msgstr "Сюжетный поворот — приглашение оформлено на другой адрес. Войдите под приглашённым аккаунтом, чтобы забрать проект."
+
+#: lib/typster_web/live/editor_live/index.html.heex:74
+#, elixir-autogen, elixir-format
+msgid "editor.share_owner_only"
+msgstr "Только владелец — делиться решает он."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -53,7 +53,7 @@ msgstr "Вход…"
 msgid "auth.sign_up"
 msgstr "Создать аккаунт"
 
-#: lib/typster_web/live/project_live/index.html.heex:157
+#: lib/typster_web/live/project_live/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "common.cancel"
 msgstr "Не сейчас"
@@ -72,7 +72,7 @@ msgstr "Создано %{date}"
 msgid "common.email"
 msgstr "Email"
 
-#: lib/typster_web/live/project_live/index.html.heex:106
+#: lib/typster_web/live/project_live/index.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "common.open"
 msgstr "Открыть"
@@ -363,22 +363,22 @@ msgstr[0] "%{count} проект"
 msgstr[1] "%{count} проекта"
 msgstr[2] "%{count} проектов"
 
-#: lib/typster_web/live/project_live/index.html.heex:160
+#: lib/typster_web/live/project_live/index.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "projects.create"
 msgstr "Создать проект"
 
-#: lib/typster_web/live/project_live/index.html.heex:95
+#: lib/typster_web/live/project_live/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "projects.delete.confirm"
 msgstr "Удалить проект? Отката не будет."
 
-#: lib/typster_web/live/project_live/index.html.heex:97
+#: lib/typster_web/live/project_live/index.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "projects.delete.label"
 msgstr "Удалить проект"
 
-#: lib/typster_web/live/project_live/index.html.heex:141
+#: lib/typster_web/live/project_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "projects.dialog.description"
 msgstr "Назови коротко, чтобы будущий ты сразу понял."
@@ -393,23 +393,23 @@ msgstr "Проектов пока нет. Чистый лист, слегка п
 msgid "projects.index.subtitle"
 msgstr "Открой существующий проект или начни новый. Документ сам себя не соберет."
 
-#: lib/typster_web/live/project_live/index.ex:18
+#: lib/typster_web/live/project_live/index.ex:24
 #, elixir-autogen, elixir-format
 msgid "projects.index.title"
 msgstr "Проекты"
 
-#: lib/typster_web/live/project_live/index.html.heex:146
+#: lib/typster_web/live/project_live/index.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "projects.name.label"
 msgstr "Название проекта"
 
-#: lib/typster_web/live/project_live/index.html.heex:151
+#: lib/typster_web/live/project_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "projects.name.placeholder"
 msgstr "Диплом без паники"
 
 #: lib/typster_web/live/project_live/index.html.heex:17
-#: lib/typster_web/live/project_live/index.html.heex:140
+#: lib/typster_web/live/project_live/index.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "projects.new"
 msgstr "Новый проект"
@@ -709,7 +709,7 @@ msgstr "Светлая, тёмная или как в системе."
 msgid "settings.appearance.title"
 msgstr "Внешний вид"
 
-#: lib/typster_web/live/project_live/index.ex:127
+#: lib/typster_web/live/project_live/index.ex:144
 #, elixir-autogen, elixir-format
 msgid "1 day ago"
 msgid_plural "%{count} days ago"
@@ -717,7 +717,7 @@ msgstr[0] "%{count} день назад"
 msgstr[1] "%{count} дня назад"
 msgstr[2] "%{count} дней назад"
 
-#: lib/typster_web/live/project_live/index.html.heex:74
+#: lib/typster_web/live/project_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "1 file"
 msgid_plural "%{count} files"
@@ -725,7 +725,7 @@ msgstr[0] "%{count} файл"
 msgstr[1] "%{count} файла"
 msgstr[2] "%{count} файлов"
 
-#: lib/typster_web/live/project_live/index.ex:126
+#: lib/typster_web/live/project_live/index.ex:143
 #, elixir-autogen, elixir-format
 msgid "1 hour ago"
 msgid_plural "%{count} hours ago"
@@ -733,7 +733,7 @@ msgstr[0] "%{count} час назад"
 msgstr[1] "%{count} часа назад"
 msgstr[2] "%{count} часов назад"
 
-#: lib/typster_web/live/project_live/index.ex:125
+#: lib/typster_web/live/project_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "1 minute ago"
 msgid_plural "%{count} minutes ago"
@@ -771,43 +771,43 @@ msgstr "проекты"
 msgid "projects.heading_lead"
 msgstr "Ваши"
 
-#: lib/typster_web/live/project_live/index.html.heex:122
+#: lib/typster_web/live/project_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "projects.import.soon"
 msgstr "Импорт скоро появится"
 
-#: lib/typster_web/live/project_live/index.html.heex:128
+#: lib/typster_web/live/project_live/index.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "projects.import.sub"
 msgstr "Перетащите или вставьте ссылку на GitHub"
 
-#: lib/typster_web/live/project_live/index.html.heex:127
+#: lib/typster_web/live/project_live/index.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "projects.import.title"
 msgstr "Импорт .zip или git-репозитория"
 
-#: lib/typster_web/live/project_live/index.html.heex:74
+#: lib/typster_web/live/project_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "projects.row.edited"
 msgstr "Изменён"
 
-#: lib/typster_web/live/project_live/index.html.heex:86
-#: lib/typster_web/live/project_live/index.html.heex:87
+#: lib/typster_web/live/project_live/index.html.heex:91
+#: lib/typster_web/live/project_live/index.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "projects.star_soon"
 msgstr "Избранное скоро появится"
 
-#: lib/typster_web/live/project_live/index.html.heex:118
+#: lib/typster_web/live/project_live/index.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "projects.template.sub"
 msgstr "IEEE, диссертация, резюме, счёт, слайды"
 
-#: lib/typster_web/live/project_live/index.html.heex:117
+#: lib/typster_web/live/project_live/index.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "projects.template.title"
 msgstr "Начать с шаблона"
 
-#: lib/typster_web/live/project_live/index.ex:124
+#: lib/typster_web/live/project_live/index.ex:141
 #, elixir-autogen, elixir-format
 msgid "time.just_now"
 msgstr "только что"
@@ -2157,7 +2157,7 @@ msgstr "Создать файл из этого шаблона"
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1308
+#: lib/typster_web/live/editor_live/index.ex:1307
 #: lib/typster_web/live/editor_live/index.html.heex:675
 #: lib/typster_web/live/editor_live/index.html.heex:883
 #, elixir-autogen, elixir-format
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1310
+#: lib/typster_web/live/editor_live/index.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,7 +2175,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1314
+#: lib/typster_web/live/editor_live/index.ex:1313
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2660,7 +2660,7 @@ msgstr "Люди"
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1169
+#: lib/typster_web/live/editor_live/index.ex:1168
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
@@ -2695,7 +2695,7 @@ msgstr "Пофайловая запись — в Pro"
 msgid "share.invite.accepted"
 msgstr "Готово — добро пожаловать в проект."
 
-#: lib/typster_web/controllers/invite_controller.ex:23
+#: lib/typster_web/controllers/invite_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "share.invite.invalid"
 msgstr "Эта ссылка-приглашение недействительна или истекла."
@@ -2765,3 +2765,13 @@ msgstr "Ширина"
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// скоро™ — ещё готовим 🍳  пока бери iframe"
+
+#: lib/typster_web/live/project_live/index.html.heex:75
+#, elixir-autogen, elixir-format
+msgid "projects.row.shared"
+msgstr "Общий"
+
+#: lib/typster_web/controllers/invite_controller.ex:23
+#, elixir-autogen, elixir-format
+msgid "share.invite.wrong_account"
+msgstr "Сюжетный поворот — приглашение оформлено на другой адрес. Войдите под приглашённым аккаунтом, чтобы забрать проект."

--- a/test/typster/files_test.exs
+++ b/test/typster/files_test.exs
@@ -157,7 +157,11 @@ defmodule Typster.FilesTest do
     setup do
       owner = Typster.AccountsFixtures.user_scope_fixture()
       project = project_fixture(owner)
-      member = Typster.AccountsFixtures.user_scope_fixture()
+
+      member =
+        Typster.Accounts.Scope.for_user(
+          Typster.AccountsFixtures.user_fixture(%{email: "g@example.com"})
+        )
 
       {:ok, invite} =
         Typster.Sharing.invite_collaborator(owner, project.id, "g@example.com", :editor)

--- a/test/typster/projects_test.exs
+++ b/test/typster/projects_test.exs
@@ -44,7 +44,7 @@ defmodule Typster.ProjectsTest do
     setup do
       owner = user_scope_fixture()
       project = project_fixture(owner)
-      member = user_scope_fixture()
+      member = Scope.for_user(user_fixture(%{email: "guest@example.com"}))
       stranger = user_scope_fixture()
       {:ok, invite} = Sharing.invite_collaborator(owner, project.id, "guest@example.com", :editor)
       %{owner: owner, project: project, member: member, stranger: stranger, invite: invite}

--- a/test/typster/sharing_test.exs
+++ b/test/typster/sharing_test.exs
@@ -2,7 +2,7 @@ defmodule Typster.SharingTest do
   use Typster.DataCase, async: true
 
   import Swoosh.TestAssertions
-  import Typster.AccountsFixtures, only: [user_scope_fixture: 0]
+  import Typster.AccountsFixtures, only: [user_scope_fixture: 0, user_fixture: 1]
   import Typster.ProjectsFixtures, only: [project_fixture: 1]
 
   alias Typster.Accounts.Scope
@@ -27,6 +27,10 @@ defmodule Typster.SharingTest do
       0 -> :ok
     end
   end
+
+  # A confirmed user on `email`, wrapped in a scope — for invite-acceptance
+  # tests where the invitee's account email must match the invited address.
+  defp scope_for_email(email), do: Scope.for_user(user_fixture(%{email: email}))
 
   describe "get_or_create_link/2" do
     test "creates a link with a token and default read scope", %{scope: scope, project: project} do
@@ -223,7 +227,7 @@ defmodule Typster.SharingTest do
   describe "accept_invite/2 (bearer)" do
     test "links the invitee, marks accepted, preloads project", %{scope: scope, project: project} do
       {:ok, invite} = Sharing.invite_collaborator(scope, project.id, "i@example.com", :editor)
-      invitee = user_scope_fixture()
+      invitee = scope_for_email("i@example.com")
 
       assert {:ok, accepted} = Sharing.accept_invite(invitee, invite.id)
       assert accepted.status == :accepted
@@ -231,13 +235,38 @@ defmodule Typster.SharingTest do
       assert accepted.project.id == project.id
     end
 
-    test "is idempotent on re-accept", %{scope: scope, project: project} do
+    test "is idempotent on re-accept by the same user", %{scope: scope, project: project} do
       {:ok, invite} = Sharing.invite_collaborator(scope, project.id, "j@example.com", :viewer)
-      invitee = user_scope_fixture()
+      invitee = scope_for_email("j@example.com")
 
       assert {:ok, _} = Sharing.accept_invite(invitee, invite.id)
       assert {:ok, again} = Sharing.accept_invite(invitee, invite.id)
       assert again.status == :accepted
+    end
+
+    test "rejects a user whose email differs from the invite (incl. the owner)", %{
+      scope: scope,
+      project: project
+    } do
+      {:ok, invite} = Sharing.invite_collaborator(scope, project.id, "real@example.com", :editor)
+      intruder = scope_for_email("someone-else@example.com")
+
+      assert {:error, :forbidden} = Sharing.accept_invite(intruder, invite.id)
+      # The owner clicking their own invite link must not claim it either.
+      assert {:error, :forbidden} = Sharing.accept_invite(scope, invite.id)
+
+      # The row is untouched: still pending, still unlinked.
+      reloaded = Typster.Repo.get(Collaborator, invite.id)
+      assert reloaded.status == :pending
+      assert is_nil(reloaded.user_id)
+    end
+
+    test "matches the invite email case-insensitively", %{scope: scope, project: project} do
+      {:ok, invite} = Sharing.invite_collaborator(scope, project.id, "Mixed@Example.com", :editor)
+      invitee = scope_for_email("mixed@example.com")
+
+      assert {:ok, accepted} = Sharing.accept_invite(invitee, invite.id)
+      assert accepted.user_id == invitee.user.id
     end
 
     test "returns :not_found for an unknown id", %{scope: scope} do
@@ -251,6 +280,60 @@ defmodule Typster.SharingTest do
     test "returns :not_found when no user is in scope", %{scope: scope, project: project} do
       {:ok, invite} = Sharing.invite_collaborator(scope, project.id, "k@example.com", :viewer)
       assert {:error, :not_found} = Sharing.accept_invite(%Scope{user: nil}, invite.id)
+    end
+  end
+
+  describe "link_invites_for_user/1" do
+    test "links a pending email invite to the matching user and accepts it", %{
+      scope: scope,
+      project: project
+    } do
+      {:ok, invite} =
+        Sharing.invite_collaborator(scope, project.id, "pending@example.com", :editor)
+
+      invitee = scope_for_email("pending@example.com")
+
+      assert Sharing.link_invites_for_user(invitee) == 1
+
+      linked = Typster.Repo.get(Collaborator, invite.id)
+      assert linked.user_id == invitee.user.id
+      assert linked.status == :accepted
+    end
+
+    test "self-heals a row mis-linked to another account", %{scope: scope, project: project} do
+      {:ok, invite} =
+        Sharing.invite_collaborator(scope, project.id, "victim@example.com", :editor)
+
+      # Simulate the bug: the invite got bound to the wrong account (the owner).
+      Collaborator
+      |> Typster.Repo.get(invite.id)
+      |> Collaborator.accept_changeset(scope.user.id)
+      |> Typster.Repo.update!()
+
+      invitee = scope_for_email("victim@example.com")
+      assert Sharing.link_invites_for_user(invitee) == 1
+
+      healed = Typster.Repo.get(Collaborator, invite.id)
+      assert healed.user_id == invitee.user.id
+    end
+
+    test "ignores invites addressed to other emails", %{scope: scope, project: project} do
+      {:ok, _} = Sharing.invite_collaborator(scope, project.id, "theirs@example.com", :editor)
+      stranger = scope_for_email("mine@example.com")
+
+      assert Sharing.link_invites_for_user(stranger) == 0
+    end
+
+    test "is idempotent (no-op once already linked)", %{scope: scope, project: project} do
+      {:ok, _} = Sharing.invite_collaborator(scope, project.id, "again@example.com", :viewer)
+      invitee = scope_for_email("again@example.com")
+
+      assert Sharing.link_invites_for_user(invitee) == 1
+      assert Sharing.link_invites_for_user(invitee) == 0
+    end
+
+    test "returns 0 for a scope with no user" do
+      assert Sharing.link_invites_for_user(%Scope{user: nil}) == 0
     end
   end
 

--- a/test/typster_web/controllers/invite_controller_test.exs
+++ b/test/typster_web/controllers/invite_controller_test.exs
@@ -6,10 +6,14 @@ defmodule TypsterWeb.InviteControllerTest do
 
   alias Typster.Sharing
 
-  defp invite(_context) do
+  defp invite(context) do
     owner = user_scope_fixture()
     project = project_fixture(owner)
-    {:ok, collab} = Sharing.invite_collaborator(owner, project.id, "guest@example.com", :viewer)
+    # Invites are now bound to the invited email, so address it to the logged-in
+    # user when there is one (authenticated cases); fall back to a guest address
+    # for the unauthenticated case, which never reaches acceptance anyway.
+    email = (context[:user] && context.user.email) || "guest@example.com"
+    {:ok, collab} = Sharing.invite_collaborator(owner, project.id, email, :viewer)
     %{project: project, collab: collab}
   end
 

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -462,7 +462,7 @@ defmodule TypsterWeb.EditorLiveTest do
       {:ok, invite} =
         Typster.Sharing.invite_collaborator(owner_scope, project.id, "c@x.com", :editor)
 
-      collaborator = Typster.AccountsFixtures.user_fixture()
+      collaborator = Typster.AccountsFixtures.user_fixture(%{email: "c@x.com"})
 
       {:ok, _} =
         Typster.Sharing.accept_invite(Typster.Accounts.Scope.for_user(collaborator), invite.id)

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -480,10 +480,32 @@ defmodule TypsterWeb.EditorLiveTest do
       assert has_element?(view, "#create-main-file-button")
     end
 
-    test "the Share button is owner-only",
+    test "the Share button shows for all but is inactive for collaborators",
          %{conn: owner_conn, collab_conn: collab_conn, project: project} do
-      assert has_element?(open_editor(owner_conn, project), ".ts-tb__share")
-      refute has_element?(open_editor(collab_conn, project), ".ts-tb__share")
+      owner_view = open_editor(owner_conn, project)
+      collab_view = open_editor(collab_conn, project)
+
+      # Owner: an active Share button.
+      assert has_element?(owner_view, ".ts-tb__share")
+      refute has_element?(owner_view, ".ts-tb__share.is-inactive")
+
+      # Collaborator: the button is present (consistent top bar) but inert.
+      assert has_element?(collab_view, ".ts-tb__share.is-inactive")
+      assert has_element?(collab_view, ".ts-tb__share[disabled]")
+    end
+
+    test "a non-owner's share mutation is a no-op server-side",
+         %{collab_conn: conn, user: owner, project: project} do
+      view = open_editor(conn, project)
+      owner_scope = Typster.Accounts.Scope.for_user(owner)
+      before = Typster.Sharing.list_collaborators(owner_scope, project.id)
+
+      # A crafted event the disabled button can't send must no-op, not invite.
+      render_hook(view, "share_invite", %{
+        "invite" => %{"email" => "intruder@example.com", "role" => "editor"}
+      })
+
+      assert Typster.Sharing.list_collaborators(owner_scope, project.id) == before
     end
   end
 end

--- a/test/typster_web/live/project_live_test.exs
+++ b/test/typster_web/live/project_live_test.exs
@@ -89,4 +89,48 @@ defmodule TypsterWeb.ProjectLiveTest do
     assert has_element?(view, "#project-files")
     assert has_element?(view, "#project-files li", "diagram.png")
   end
+
+  describe "projects shared with the current user" do
+    setup %{conn: conn} do
+      owner = Typster.AccountsFixtures.user_fixture()
+      member = Typster.AccountsFixtures.user_fixture()
+      owner_scope = Typster.Accounts.Scope.for_user(owner)
+      shared = project_fixture(owner, %{name: "Shared With Me"})
+      mine = project_fixture(member, %{name: "My Own Project"})
+      # Invite the member by email only — no accept-link click. Visiting their
+      # project list should be enough to surface it.
+      {:ok, _} =
+        Typster.Sharing.invite_collaborator(owner_scope, shared.id, member.email, :editor)
+
+      %{conn: log_in_user(conn, member), shared: shared, mine: mine}
+    end
+
+    test "appears in the list, badged as Shared, after visiting /projects", %{
+      conn: conn,
+      shared: shared,
+      mine: mine
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      assert has_element?(view, "##{dom_id(shared)} .ts-list__title", "Shared With Me")
+      assert has_element?(view, "##{dom_id(shared)} .ts-shared-badge")
+      # The user's own project carries no Shared badge.
+      assert has_element?(view, "##{dom_id(mine)} .ts-list__title", "My Own Project")
+      refute has_element?(view, "##{dom_id(mine)} .ts-shared-badge")
+    end
+
+    test "offers no delete button on a project the user doesn't own", %{
+      conn: conn,
+      shared: shared,
+      mine: mine
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      refute has_element?(view, "#delete-project-#{shared.id}")
+      assert has_element?(view, "#delete-project-#{mine.id}")
+    end
+  end
+
+  # LiveView streams prefix the DOM id with the stream name (`projects-<id>`).
+  defp dom_id(project), do: "projects-#{project.id}"
 end


### PR DESCRIPTION
**Bug (reported):** a@a.com shares a project with b@a.com, but b@a.com's project list stays empty.

## Root cause (found in the DB)

`accept_invite/2` linked an invite to **whoever was logged in** (`scope.user.id`) with **no check that their email matched the invited address**. So when the *owner* opened b@a.com's `/invites/:id` link, the invite got bound to the owner's account. `list_projects` matches collaborators by `user_id` + `accepted`, so b@a.com — the real invitee — matched nothing and saw 0 projects.

Confirmed in `typster_dev`: the `b@a.com` collaborator row on project "an" had `user_id` = **a@a.com's** id. (A second collaborator, `c@a.com`, was linked correctly and *did* see the project — which is what narrowed it down.)

## Fix

**Backend (`Typster.Sharing`)**
- `accept_invite/2` now only links an invite when the user's account email matches the invited email (case-insensitive); otherwise `{:error, :forbidden}`. Closes the hole that let the owner (or anyone authenticated) claim someone else's invite. Flattened to a `with` to keep nesting ≤2 (Credo).
- New `link_invites_for_user/1`: claims every invite addressed to the user's email and marks it accepted — so **"shared with me" works the moment you're logged in**, no accept-link click required. The invite *email* is the source of truth, so it also **self-heals** rows mis-linked to another account (idempotent `UPDATE`).
- `InviteController` handles `:forbidden` with a clear flash.

**GUI (`ProjectLive.Index`)**
- `mount` calls `link_invites_for_user/1` (connected only) so shared projects appear on visit.
- A **"Shared"** badge marks projects you don't own; the **Delete** button is now owner-only (and `delete` is crash-proof server-side — a crafted event from a non-owner no-ops instead of raising on the owner-only `get_project!`).

## Validation

- Healed the reported dev row; `b@a.com` now sees project "an". (It self-healed the instant the dev server live-reloaded the mount change and `/projects` remounted — end-to-end proof on real data.)
- New tests: `accept_invite` email guard (incl. the owner) + case-insensitive match; `link_invites_for_user` (link pending / self-heal / ignore other emails / idempotent / nil-scope); index shows the shared project + badge and hides delete for non-owners.
- Updated 4 existing suites that accepted invites with mismatched emails — exactly the hole this closes.
- `258 tests, 0 failures`; `mix credo` clean; `mix format` clean.

i18n: `projects.row.shared` + `share.invite.wrong_account` (en + ru, house voice).

Independent of #116 (embed/Pro) — separate concern, separate branch off `main`.