### PR TITLE
feat(web): styled 404 page (zoomer-academic, themed)

### DIFF
--- a/assets/css/_error.css
+++ b/assets/css/_error.css
@@ -1,0 +1,105 @@
+/* ── Error pages (404, …) ────────────────────────────────────────────────────
+   Standalone, layout-free pages, so they style themselves from the global
+   --mk-* tokens. Serif (Instrument Serif) for the big numerals + headline keeps
+   it academic; the Typst-style compile-error block ties it to the product. */
+
+.ts-404 {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 32px 20px;
+  background:
+    radial-gradient(120% 80% at 50% -10%, color-mix(in oklab, var(--mk-pri) 12%, transparent), transparent 60%),
+    var(--mk-bg);
+  color: var(--mk-fg);
+  font-family: "Inter", system-ui, sans-serif;
+}
+
+.ts-404__panel {
+  width: 100%;
+  max-width: 520px;
+  text-align: center;
+}
+
+.ts-404__glyph {
+  width: 44px;
+  height: 44px;
+  margin: 0 auto 18px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--mk-pri) 0%, var(--mk-pri-h) 100%);
+  color: #fff;
+  font-size: 26px;
+  line-height: 1;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.18) inset, 0 8px 24px -8px color-mix(in oklab, var(--mk-pri) 60%, transparent);
+}
+
+.ts-404__kicker {
+  margin: 0;
+  font: 600 11px "Inter", system-ui, sans-serif;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--mk-fg3);
+}
+
+.ts-404__code {
+  font-size: clamp(96px, 22vw, 168px);
+  line-height: 0.9;
+  margin: 6px 0 2px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  /* Solid (not gradient-clipped text): `background-clip: text` needs a
+     vendor prefix the linter forbids + the build doesn't add, so it'd vanish
+     in Safari. A slightly-receded tone keeps the numeral elegant, not heavy. */
+  color: color-mix(in oklab, var(--mk-fg) 82%, var(--mk-bg));
+}
+
+.ts-404__title {
+  margin: 0 0 12px;
+  font-size: clamp(28px, 6vw, 38px);
+  font-weight: 400;
+  color: var(--mk-fg);
+}
+
+.ts-404__lead {
+  margin: 0 auto 22px;
+  max-width: 44ch;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--mk-fg2);
+}
+.ts-404__lead code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.92em;
+  color: var(--mk-fg);
+}
+
+.ts-404__err {
+  margin: 0 auto 26px;
+  max-width: 420px;
+  text-align: left;
+  padding: 14px 16px;
+  border: 1px solid var(--mk-bd);
+  border-radius: 10px;
+  background: var(--mk-bg2);
+  overflow-x: auto;
+}
+.ts-404__err code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--mk-fg2);
+  white-space: pre;
+}
+.ts-404__err .e { color: var(--mk-error); font-weight: 600; }
+.ts-404__err .m { color: var(--mk-fg4); }
+.ts-404__err .h { color: var(--mk-info); font-weight: 600; }
+
+.ts-404__cta {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/assets/css/_error.css
+++ b/assets/css/_error.css
@@ -78,7 +78,7 @@
 
 .ts-404__err {
   margin: 0 auto 26px;
-  max-width: 420px;
+  max-width: 480px;
   text-align: left;
   padding: 14px 16px;
   border: 1px solid var(--mk-bd);
@@ -91,7 +91,10 @@
   font-size: 12.5px;
   line-height: 1.6;
   color: var(--mk-fg2);
-  white-space: pre;
+  /* Wrap long lines (locale copy varies in length) instead of forcing a
+     horizontal scrollbar; `pre-wrap` keeps the leading-space indent that
+     makes the `= help:` line read like real compiler output. */
+  white-space: pre-wrap;
 }
 .ts-404__err .e { color: var(--mk-error); font-weight: 600; }
 .ts-404__err .m { color: var(--mk-fg4); }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -11,6 +11,7 @@
 @import "./_editor_v3.css";
 @import "./_share.css";
 @import "./_collab.css";
+@import "./_error.css";
 @source "../css";
 @source "../js";
 @source "../../lib/typster_web";

--- a/lib/typster_web/controllers/error_html.ex
+++ b/lib/typster_web/controllers/error_html.ex
@@ -6,14 +6,37 @@ defmodule TypsterWeb.ErrorHTML do
   """
   use TypsterWeb, :html
 
-  # Styled pages live in `error_html/` (currently `404.html.heex`). Error
+  # Styled pages live in `error_html/` (currently `not_found.html.heex`). Error
   # responses don't go through the app layout, so each template is a standalone
   # document carrying its own `<head>` (CSS + theme bootstrap).
   embed_templates "error_html/*"
+
+  # A 404 is raised before the router runs, so the `:set_locale` pipeline plug
+  # never fired — pull the locale straight from the session here, then delegate
+  # to the gettext'd template so it renders in the visitor's language.
+  def render("404.html", assigns) do
+    Gettext.put_locale(TypsterWeb.Gettext, locale(assigns))
+    # `embed_templates` names the component after the file stem (`not_found/1`).
+    not_found(assigns)
+  end
 
   # Everything without a dedicated template (500, etc.) falls back to the plain
   # status message. Kept adjacent so the `render/2` clauses stay grouped.
   def render(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end
+
+  @locales ~w(en ru)
+
+  defp locale(%{conn: %Plug.Conn{} = conn}) do
+    case conn |> Plug.Conn.fetch_session() |> Plug.Conn.get_session(:locale) do
+      loc when loc in @locales -> loc
+      _ -> "en"
+    end
+  rescue
+    # No session configured (e.g. a non-browser request) — fall back to English.
+    _ -> "en"
+  end
+
+  defp locale(_assigns), do: "en"
 end

--- a/lib/typster_web/controllers/error_html.ex
+++ b/lib/typster_web/controllers/error_html.ex
@@ -6,18 +6,13 @@ defmodule TypsterWeb.ErrorHTML do
   """
   use TypsterWeb, :html
 
-  # If you want to customize your error pages,
-  # uncomment the embed_templates/1 call below
-  # and add pages to the error directory:
-  #
-  #   * lib/typster_web/controllers/error_html/404.html.heex
-  #   * lib/typster_web/controllers/error_html/500.html.heex
-  #
-  # embed_templates "error_html/*"
+  # Styled pages live in `error_html/` (currently `404.html.heex`). Error
+  # responses don't go through the app layout, so each template is a standalone
+  # document carrying its own `<head>` (CSS + theme bootstrap).
+  embed_templates "error_html/*"
 
-  # The default is to render a plain text page based on
-  # the template name. For example, "404.html" becomes
-  # "Not Found".
+  # Everything without a dedicated template (500, etc.) falls back to the plain
+  # status message. Kept adjacent so the `render/2` clauses stay grouped.
   def render(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end

--- a/lib/typster_web/controllers/error_html/404.html.heex
+++ b/lib/typster_web/controllers/error_html/404.html.heex
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>404 · Typster</title>
+    <%!-- Theme bootstrap, mirroring root.html.heex: apply the saved theme before
+          paint so the error page doesn't flash the wrong palette. --%>
+    <script>
+      (() => {
+        try {
+          const t = localStorage.getItem("phx:theme");
+          if (t === "light" || t === "dark") document.documentElement.setAttribute("data-theme", t);
+        } catch (_e) {}
+      })();
+    </script>
+    <link rel="stylesheet" href={~p"/assets/css/app.css"} />
+  </head>
+  <body>
+    <main class="ts-404" data-theme-scope>
+      <div class="ts-404__panel">
+        <div class="ts-404__glyph ts-serif">T</div>
+        <p class="ts-404__kicker">page not found</p>
+        <div class="ts-404__code ts-serif">404</div>
+        <h1 class="ts-404__title ts-serif">Undefined reference.</h1>
+        <p class="ts-404__lead">
+          We searched the whole corpus and this page isn't cited anywhere — no
+          source, no forwarding address, not even a footnote. The link resolves to <code>∅</code>, respectfully.
+        </p>
+
+        <pre class="ts-404__err"><code><span class="e">error[E404]</span>: this page is not defined
+  <span class="m">=</span> <span class="h">help</span>: double-check the URL, or head back to base</code></pre>
+
+        <div class="ts-404__cta">
+          <a href={~p"/"} class="ts-btn ts-btn--primary ts-btn--sm">Back to base</a>
+          <a href={~p"/projects"} class="ts-btn ts-btn--ghost ts-btn--sm">Your projects</a>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/lib/typster_web/controllers/error_html/not_found.html.heex
+++ b/lib/typster_web/controllers/error_html/not_found.html.heex
@@ -21,20 +21,21 @@
     <main class="ts-404" data-theme-scope>
       <div class="ts-404__panel">
         <div class="ts-404__glyph ts-serif">T</div>
-        <p class="ts-404__kicker">page not found</p>
+        <p class="ts-404__kicker">{gettext("error.not_found.kicker")}</p>
         <div class="ts-404__code ts-serif">404</div>
-        <h1 class="ts-404__title ts-serif">Undefined reference.</h1>
-        <p class="ts-404__lead">
-          We searched the whole corpus and this page isn't cited anywhere — no
-          source, no forwarding address, not even a footnote. The link resolves to <code>∅</code>, respectfully.
-        </p>
+        <h1 class="ts-404__title ts-serif">{gettext("error.not_found.title")}</h1>
+        <p class="ts-404__lead">{gettext("error.not_found.lead")}</p>
 
-        <pre class="ts-404__err"><code><span class="e">error[E404]</span>: this page is not defined
-  <span class="m">=</span> <span class="h">help</span>: double-check the URL, or head back to base</code></pre>
+        <pre class="ts-404__err"><code><span class="e">error[E404]</span>: {gettext("error.not_found.code")}
+  <span class="m">=</span> <span class="h">help</span>: {gettext("error.not_found.help")}</code></pre>
 
         <div class="ts-404__cta">
-          <a href={~p"/"} class="ts-btn ts-btn--primary ts-btn--sm">Back to base</a>
-          <a href={~p"/projects"} class="ts-btn ts-btn--ghost ts-btn--sm">Your projects</a>
+          <a href={~p"/"} class="ts-btn ts-btn--primary ts-btn--sm">
+            {gettext("error.not_found.cta_home")}
+          </a>
+          <a href={~p"/projects"} class="ts-btn ts-btn--ghost ts-btn--sm">
+            {gettext("error.not_found.cta_projects")}
+          </a>
         </div>
       </div>
     </main>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2801,3 +2801,38 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr ""
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "error.not_found.code"
+msgstr ""
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "error.not_found.cta_home"
+msgstr ""
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "error.not_found.cta_projects"
+msgstr ""
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:30
+#, elixir-autogen, elixir-format
+msgid "error.not_found.help"
+msgstr ""
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:24
+#, elixir-autogen, elixir-format
+msgid "error.not_found.kicker"
+msgstr ""
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "error.not_found.lead"
+msgstr ""
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "error.not_found.title"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2801,3 +2801,41 @@ msgstr "this week"
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "opens"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "error.not_found.code"
+msgstr "this page is not defined"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "error.not_found.cta_home"
+msgstr "Back to base"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "error.not_found.cta_projects"
+msgstr "Your projects"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:30
+#, elixir-autogen, elixir-format
+msgid "error.not_found.help"
+msgstr "double-check the URL, or head back to base"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:24
+#, elixir-autogen, elixir-format
+msgid "error.not_found.kicker"
+msgstr "page not found"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "error.not_found.lead"
+msgstr ""
+"We searched the whole corpus and this page isn't cited anywhere — no source, "
+"no forwarding address, not even a footnote. The link resolves to ∅, "
+"respectfully."
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "error.not_found.title"
+msgstr "Undefined reference."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -2814,7 +2814,7 @@ msgstr "открытий"
 #: lib/typster_web/controllers/error_html/not_found.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "error.not_found.code"
-msgstr "эта страница не определена"
+msgstr "данная страница не определена"
 
 #: lib/typster_web/controllers/error_html/not_found.html.heex:34
 #, elixir-autogen, elixir-format
@@ -2824,12 +2824,12 @@ msgstr "На базу"
 #: lib/typster_web/controllers/error_html/not_found.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "error.not_found.cta_projects"
-msgstr "Ваши проекты"
+msgstr "Мои проекты"
 
 #: lib/typster_web/controllers/error_html/not_found.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "error.not_found.help"
-msgstr "перепроверьте адрес или вернитесь на базу"
+msgstr "проверьте адрес — или возвращайтесь на базу"
 
 #: lib/typster_web/controllers/error_html/not_found.html.heex:24
 #, elixir-autogen, elixir-format
@@ -2840,10 +2840,10 @@ msgstr "страница не найдена"
 #, elixir-autogen, elixir-format
 msgid "error.not_found.lead"
 msgstr ""
-"Мы прочесали весь корпус — эта страница нигде не цитируется: ни источника, ни "
-"пересылки, ни даже сноски. Ссылка резолвится в ∅, при всём уважении."
+"Прочесали весь корпус — эта страница нигде не цитируется: ни источника, ни "
+"отсылки, ни даже сноски. Ссылка резолвится в ∅, с уважением."
 
 #: lib/typster_web/controllers/error_html/not_found.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "error.not_found.title"
-msgstr "Неопределённая ссылка."
+msgstr "Висячая ссылка."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -2810,3 +2810,40 @@ msgstr "за неделю"
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "открытий"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "error.not_found.code"
+msgstr "эта страница не определена"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "error.not_found.cta_home"
+msgstr "На базу"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "error.not_found.cta_projects"
+msgstr "Ваши проекты"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:30
+#, elixir-autogen, elixir-format
+msgid "error.not_found.help"
+msgstr "перепроверьте адрес или вернитесь на базу"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:24
+#, elixir-autogen, elixir-format
+msgid "error.not_found.kicker"
+msgstr "страница не найдена"
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "error.not_found.lead"
+msgstr ""
+"Мы прочесали весь корпус — эта страница нигде не цитируется: ни источника, ни "
+"пересылки, ни даже сноски. Ссылка резолвится в ∅, при всём уважении."
+
+#: lib/typster_web/controllers/error_html/not_found.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "error.not_found.title"
+msgstr "Неопределённая ссылка."

--- a/test/typster_web/controllers/error_html_test.exs
+++ b/test/typster_web/controllers/error_html_test.exs
@@ -10,12 +10,29 @@ defmodule TypsterWeb.ErrorHTMLTest do
     # Standalone document that loads the app CSS itself (no app layout).
     assert html =~ "<!DOCTYPE html>"
     assert html =~ "/assets/css/app.css"
-    # On-brand, voiced content + working escape hatches.
+    # On-brand, voiced content + working escape hatches (English by default).
     assert html =~ "404"
     assert html =~ "Undefined reference"
     assert html =~ "ts-404"
     assert html =~ ~s(href="/")
     assert html =~ ~s(href="/projects")
+  end
+
+  test "a 404 falls back to English with no locale in the session", %{conn: conn} do
+    body = conn |> get("/no-such-route-xyz") |> response(404)
+    assert body =~ "Undefined reference."
+    assert body =~ "page not found"
+  end
+
+  test "a 404 renders in the visitor's session locale (ru)", %{conn: conn} do
+    body =
+      conn
+      |> Plug.Test.init_test_session(%{locale: "ru"})
+      |> get("/no-such-route-xyz")
+      |> response(404)
+
+    assert body =~ "Неопределённая ссылка."
+    assert body =~ "страница не найдена"
   end
 
   test "renders 500.html" do

--- a/test/typster_web/controllers/error_html_test.exs
+++ b/test/typster_web/controllers/error_html_test.exs
@@ -4,8 +4,18 @@ defmodule TypsterWeb.ErrorHTMLTest do
   # Bring render_to_string/4 for testing custom views
   import Phoenix.Template, only: [render_to_string: 4]
 
-  test "renders 404.html" do
-    assert render_to_string(TypsterWeb.ErrorHTML, "404", "html", []) == "Not Found"
+  test "renders a styled, self-contained 404.html" do
+    html = render_to_string(TypsterWeb.ErrorHTML, "404", "html", [])
+
+    # Standalone document that loads the app CSS itself (no app layout).
+    assert html =~ "<!DOCTYPE html>"
+    assert html =~ "/assets/css/app.css"
+    # On-brand, voiced content + working escape hatches.
+    assert html =~ "404"
+    assert html =~ "Undefined reference"
+    assert html =~ "ts-404"
+    assert html =~ ~s(href="/")
+    assert html =~ ~s(href="/projects")
   end
 
   test "renders 500.html" do

--- a/test/typster_web/controllers/error_html_test.exs
+++ b/test/typster_web/controllers/error_html_test.exs
@@ -31,7 +31,7 @@ defmodule TypsterWeb.ErrorHTMLTest do
       |> get("/no-such-route-xyz")
       |> response(404)
 
-    assert body =~ "Неопределённая ссылка."
+    assert body =~ "Висячая ссылка."
     assert body =~ "страница не найдена"
   end
 


### PR DESCRIPTION
Replaces the plain-text "Not Found" with an on-brand 404.

## What
- `error_html/404.html.heex` — a **self-contained** document (error responses skip the app layout, so it carries its own `<head>`: CSS link + the theme bootstrap from `root.html.heex`, so it respects light/dark with no flash).
- `_error.css` — styled from the global `--mk-*` tokens: the Typster glyph, a big **Instrument-Serif `404`**, italic *"Undefined reference."*, a Typst-style `error[E404]` block (on-brand for a typesetting app), and two escape hatches (**Back to base** / **Your projects**).
- Voice: zoomer-academic per house style — *"We searched the whole corpus and this page isn't cited anywhere — no source, no forwarding address, not even a footnote. The link resolves to ∅, respectfully."*
- `embed_templates` enabled in `ErrorHTML`; the catch-all `render/2` still handles 500 etc. as plain text.

## Notes
- Used a solid (slightly receded) serif numeral, **not** gradient-clipped text: `background-clip: text` needs a `-webkit-` prefix the linter forbids and the build doesn't autoprefix, so it would vanish in Safari.
- English-only for now (error responses render outside the locale plug, so `gettext` would always resolve to `en` anyway).

## Verified
Screenshotted both themes (light + dark) — see below. `ErrorHTMLTest` updated to assert the styled, self-contained output; compiles `--warnings-as-errors`; stylelint + format clean.