### PR TITLE
fix(preview): resolve Typst imports from subdirectory files

### DIFF
--- a/assets/e2e/typst_imports.spec.mjs
+++ b/assets/e2e/typst_imports.spec.mjs
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test"
+
+// Regression guard for #121: the preview worker used to flatten the active
+// buffer to the project root ("/main.typ"), so a `.typ` file living in a
+// subdirectory lost its directory and a relative `#import "sibling.typ"` failed
+// with "failed to load file (access denied) … outside of project root".
+//
+// We drive the real worker the same way the editor does (postMessage a compile
+// job) and assert the rendered/errored outcome — no DB or login required.
+test.describe("Typst local imports", () => {
+  async function compile(page, project, content) {
+    return page.evaluate(
+      ([project, content]) =>
+        new Promise((resolve) => {
+          const worker = new Worker("/assets/js/typst_worker_impl.js", { type: "module" })
+          let timer
+          const done = (value) => {
+            clearTimeout(timer)
+            worker.terminate()
+            resolve(value)
+          }
+          timer = setTimeout(() => done({ ok: false, message: "timeout" }), 40_000)
+          worker.onmessage = (event) => {
+            const { type, data } = event.data
+            if (type === "render") done({ ok: true })
+            else if (type === "error") done({ ok: false, message: (data && data.message) || "error" })
+          }
+          worker.onerror = (err) => done({ ok: false, message: String(err.message || err) })
+          worker.postMessage({ type: "compile", content, project })
+        }),
+      [project, content]
+    )
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+  })
+
+  test("a subdirectory file resolves a relative import to its sibling", async ({ page }) => {
+    test.setTimeout(60_000)
+    const buffer = '#import "macros.typ": foo\n#foo()'
+    const result = await compile(
+      page,
+      {
+        mainPath: "chapters/ch1.typ",
+        sources: [
+          { path: "chapters/ch1.typ", content: buffer },
+          { path: "chapters/macros.typ", content: "#let foo() = [from macros]" }
+        ]
+      },
+      buffer
+    )
+    expect(result).toEqual({ ok: true })
+  })
+
+  test("a flat root import still compiles with the default entrypoint", async ({ page }) => {
+    test.setTimeout(60_000)
+    const result = await compile(
+      page,
+      { sources: [{ path: "utils.typ", content: "#let hi() = [hi]" }] },
+      '#import "utils.typ": hi\n#hi()'
+    )
+    expect(result).toEqual({ ok: true })
+  })
+})

--- a/assets/js/embed_boot.js
+++ b/assets/js/embed_boot.js
@@ -23,6 +23,8 @@ function editorOptions(el) {
     language: el.dataset.language || "typst",
     readonly: el.dataset.readonly === "true",
     project: {
+      // Real path of the entry file so subdirectory imports resolve (see hooks.js).
+      mainPath: el.dataset.fileName || "",
       sources: parseJsonDataset(el.dataset.projectSources, []),
       assets: parseJsonDataset(el.dataset.projectAssets, []),
     },

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -24,6 +24,9 @@ function editorOptions(element) {
       color: element.dataset.userColor || ""
     },
     project: {
+      // The active file's real project path — the compiler maps the buffer here
+      // so files in subdirectories keep their directory and relative imports resolve.
+      mainPath: element.dataset.fileName || "",
       sources: parseJsonDataset(element.dataset.projectSources, []),
       assets: parseJsonDataset(element.dataset.projectAssets, [])
     }
@@ -64,9 +67,13 @@ export const CodeMirror = {
     this.diagnosticsHandler = (event) => {
       if (!this.editorInstance) return
       const all = (event.detail && event.detail.diagnostics) || []
+      // Only surface diagnostics for the file open in *this* editor. The worker
+      // labels them by real path now, so match the active path (falling back to
+      // the historical "main.typ" sentinel).
+      const active = (this.mainPath || "main.typ").replace(/^\/+/, "")
       const own = all.filter((d) => {
         const file = d.location && d.location.file
-        return !file || file === "main.typ"
+        return !file || file.replace(/^\/+/, "") === active
       })
       this.editorInstance.setDiagnostics(own)
     }
@@ -79,6 +86,9 @@ export const CodeMirror = {
     const content = parseContent(rawContent)
     const fileId = this.el.dataset.fileId || null
     const options = { ...editorOptions(this.el), ...this.editorCallbacks() }
+    // Track the open file's path so worker diagnostics (now labelled by real
+    // path) can be matched back to this editor.
+    this.mainPath = options.project.mainPath || "main.typ"
 
     if (!container) return
 
@@ -101,11 +111,15 @@ export const CodeMirror = {
       }
     })
 
-    this.handleEvent("file_changed", ({ file_id, content, language }) => {
+    this.handleEvent("file_changed", ({ file_id, content, language, path }) => {
       const newFileId = file_id || null
       const newContent = parseContent(content || "")
       const options = { ...editorOptions(this.el), ...this.editorCallbacks() }
       options.language = language || options.language
+      // The editor element is `phx-update="ignore"`, so its `data-file-name` is
+      // frozen at mount — take the switched-to file's path from the event instead.
+      options.project.mainPath = path || options.project.mainPath
+      this.mainPath = options.project.mainPath || "main.typ"
 
       this.el.style.display = newFileId ? "" : "none"
 

--- a/assets/js/typst_worker_impl.js
+++ b/assets/js/typst_worker_impl.js
@@ -80,17 +80,34 @@ async function ensureInitialized() {
   await $typst.svg({ mainContent: "" }).catch(() => {})
 }
 
+// Map a project-relative path ("chapters/ch1.typ") to the compiler's rooted VFS
+// path. Collapsing leading slashes keeps "/x.typ" and "x.typ" in agreement, and
+// the fallback is the conventional entrypoint when no path is supplied.
+function vfsPath(path) {
+  const clean = String(path || "").replace(/^\/+/, "").trim()
+  return `/${clean || "main.typ"}`
+}
+
+// Mirror the project into the compiler's virtual filesystem and return the VFS
+// path of the entrypoint. The active buffer is mapped at its *real* path rather
+// than a flattened "/main.typ", so files in subdirectories keep their directory
+// and relative `#import`s resolve. The buffer's twin in `sources` (the persisted
+// copy) is skipped so the live, possibly-unsaved buffer wins.
 async function loadSources(content, project) {
-  $typst.setMainFilePath("/main.typ")
-  await $typst.addSource("/main.typ", content || "")
+  const main = vfsPath(project?.mainPath)
+  $typst.setMainFilePath(main)
+  await $typst.addSource(main, content || "")
 
   if (project?.sources) {
     for (const source of project.sources) {
-      if (source.path !== "/main.typ" && source.path !== "main.typ") {
-        await $typst.addSource(`/${source.path}`, source.content || "")
+      const path = vfsPath(source.path)
+      if (path !== main) {
+        await $typst.addSource(path, source.content || "")
       }
     }
   }
+
+  return main
 }
 
 self.onmessage = async function (event) {
@@ -102,10 +119,10 @@ self.onmessage = async function (event) {
       await ensureInitialized()
       if (myId !== latestCompileId) return
 
-      await loadSources(content, project)
+      const main = await loadSources(content, project)
       if (myId !== latestCompileId) return
 
-      const svg = await $typst.svg({ mainFilePath: "/main.typ" })
+      const svg = await $typst.svg({ mainFilePath: main })
       if (myId !== latestCompileId) return
 
       self.postMessage({ type: "render", data: { svg } })
@@ -118,10 +135,10 @@ self.onmessage = async function (event) {
       // error text (sources are re-mapped first in case state was reset).
       let structured = null
       try {
-        await loadSources(content, project)
+        const main = await loadSources(content, project)
         const compiler = await $typst.getCompiler()
         const { diagnostics } = await compiler.compile({
-          mainFilePath: "/main.typ",
+          mainFilePath: main,
           diagnostics: "full"
         })
         structured = structureDiagnostics(diagnostics)
@@ -137,9 +154,9 @@ self.onmessage = async function (event) {
     // not be cancelled by a concurrent live-preview compile.
     try {
       await ensureInitialized()
-      await loadSources(content, project)
+      const main = await loadSources(content, project)
 
-      const pdf = await $typst.pdf({ mainFilePath: "/main.typ" })
+      const pdf = await $typst.pdf({ mainFilePath: main })
       self.postMessage({ type: "pdf", data: { pdf, requestId } }, [pdf.buffer])
     } catch (error) {
       self.postMessage({ type: "pdf-error", data: { message: formatError(error), requestId } })

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -657,12 +657,7 @@ defmodule TypsterWeb.EditorLive.Index do
        socket
        |> assign(:content, content)
        |> assign(:editor_language, editor_language(next_file))
-       |> push_event("file_changed", %{
-         file_id: next_file && next_file.id,
-         path: next_file && next_file.path,
-         content: content,
-         language: editor_language(next_file)
-       })
+       |> push_event("file_changed", file_changed_event(next_file, content))
        |> push_event("content_updated", %{content: content})}
     else
       {:noreply, socket}
@@ -1391,6 +1386,17 @@ defmodule TypsterWeb.EditorLive.Index do
 
     num = Enum.map_join(2..level, ".", &Map.get(counters, &1, 1))
     {num, counters}
+  end
+
+  # Build the `file_changed` payload, tolerating a nil file (e.g. the last open
+  # tab was just closed) so the nil-guards stay out of the calling handler.
+  defp file_changed_event(file, content) do
+    %{
+      file_id: file && file.id,
+      path: file && file.path,
+      content: content,
+      language: editor_language(file)
+    }
   end
 
   defp project_sources(file_tree) do

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -406,6 +406,7 @@ defmodule TypsterWeb.EditorLive.Index do
        |> assign(:save_status, "saved")
        |> push_event("file_changed", %{
          file_id: file_id,
+         path: file.path,
          content: file.content || "",
          language: editor_language(file)
        })
@@ -441,6 +442,7 @@ defmodule TypsterWeb.EditorLive.Index do
            |> assign(:editor_language, editor_language(file))
            |> push_event("file_changed", %{
              file_id: file.id,
+             path: file.path,
              content: file.content || "",
              language: editor_language(file)
            })
@@ -657,6 +659,7 @@ defmodule TypsterWeb.EditorLive.Index do
        |> assign(:editor_language, editor_language(next_file))
        |> push_event("file_changed", %{
          file_id: next_file && next_file.id,
+         path: next_file && next_file.path,
          content: content,
          language: editor_language(next_file)
        })
@@ -732,6 +735,7 @@ defmodule TypsterWeb.EditorLive.Index do
          |> assign(:editor_language, editor_language(file))
          |> push_event("file_changed", %{
            file_id: file.id,
+           path: file.path,
            content: content,
            language: editor_language(file)
          })

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -115,6 +115,7 @@ defmodule TypsterWeb.SharedProjectLive do
             phx-update="ignore"
             data-content={@content}
             data-file-id={@entry && @entry.id}
+            data-file-name={@entry && @entry.path}
             data-readonly={to_string(!@editable?)}
             data-language={@language}
             data-project-sources={Jason.encode!(@project_sources)}
@@ -131,6 +132,7 @@ defmodule TypsterWeb.SharedProjectLive do
               phx-update="ignore"
               data-content={@content}
               data-file-id=""
+              data-file-name={@entry && @entry.path}
               data-readonly="true"
               data-language={@language}
               data-project-sources={Jason.encode!(@project_sources)}


### PR DESCRIPTION
Closes #121.

## Problem

A `#import "..."` from a `.typ` file living in a **subdirectory** failed in the live preview with `failed to load file (access denied) ... cannot read file outside of project root`. Flat (root-level) imports worked; anything under `chapters/`, `lib/`, ... broke.

## Root cause

The preview worker hardcoded the active buffer to the project root as `/main.typ` and never received the file's real path, so a relative `#import "macros.typ"` from `chapters/ch1.typ` resolved to `/macros.typ` instead of `/chapters/macros.typ`.

## Fix

Thread the active file's **real project path** to the worker and map the buffer there (default `/main.typ` when absent), so files keep their directory and relative imports resolve.

- **`typst_worker_impl.js`** — `vfsPath()` normalises paths; `loadSources()` maps the buffer at its real path, skips its persisted twin in `sources` (live buffer wins), and returns the entrypoint used for `svg`/`pdf`/diagnostics.
- **`hooks.js`** — passes `data-file-name` as `project.mainPath`; threads `path` through the `file_changed` event (the element is `phx-update="ignore"`, so its dataset is frozen at mount); matches in-editor diagnostics against the active path (the worker now labels them by real path).
- **`editor_live/index.ex`** — includes `path: file.path` in `file_changed` pushes.
- **`embed_boot.js`** + **`shared_project_live.ex`** — same wiring for the shared/embed preview.

## Verification — driving the real worker

| case | before | after |
|---|---|---|
| flat root import | ✅ | ✅ |
| **subdir relative import** | ❌ access-denied | ✅ renders |
| absolute import from a subdir file | — | ✅ renders |

- New `assets/e2e/typst_imports.spec.mjs` drives the worker exactly as the editor does (no DB/login) — 2 passing specs guarding the regression.
- `mix precommit` green: compile (warnings-as-errors), format, sobelow, **273 tests, 0 failures**.