### PR TITLE
fix(build): run assets.setup before compile so colocated hooks survive

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,7 @@
       }
     }
   },
-  "postCreateCommand": "mix deps.get && mix assets.setup && mix ecto.setup",
+  "postCreateCommand": "mix setup",
   "remoteUser": "root",
   "remoteEnv": {
     "MIX_ENV": "dev",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL%20v3-blue)](./LICENSE)
 [![Pixi](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)
 [![Dev Containers](https://img.shields.io/badge/dev_containers-supported-0078D4?logo=docker)](https://containers.dev)
-[![Phoenix LiveView](https://img.shields.io/badge/Phoenix_LiveView-1.1.28-FD4F00?logo=phoenixframework)](https://hexdocs.pm/phoenix_live_view)
+[![Phoenix LiveView](https://img.shields.io/badge/Phoenix_LiveView-1.1.30-FD4F00?logo=phoenixframework)](https://hexdocs.pm/phoenix_live_view)
 
 **The [Typst](https://typst.app) editor for writing that ships.**
 
@@ -31,7 +31,7 @@ Typst is a modern LaTeX alternative — a markup-based language for producing be
 | Frontend | Bun 1.3 · Tailwind CSS · salad_ui components |
 | Database | PostgreSQL 16 (Ecto) |
 | Object storage | MinIO (S3-compatible) |
-| Background jobs | Oban 2.17 |
+| Background jobs | Oban 2.22 |
 | Testing | ExUnit · Playwright (browser E2E) |
 | Dev environment | Pixi · prek · Docker Compose |
 

--- a/mix.exs
+++ b/mix.exs
@@ -114,7 +114,7 @@ defmodule Typster.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build"],
+      setup: ["deps.get", "assets.setup", "ecto.setup", "assets.build"],
       "ecto.setup": ["ecto.create", "ecto.migrate", &migrate_pro/1, "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", &migrate_pro/1, "test"],


### PR DESCRIPTION
## What
Reorders the `mix setup` alias to run `assets.setup` (bun install) **before** the first project compile, fixes the Dev Container `postCreateCommand`, and refreshes two stale README version markers.

## Why
On a fresh checkout, `mix setup` failed at `bun js`:

```
error: Could not resolve: "phoenix-colocated/typster"
** (Mix) `mix bun js` exited with 1
```

Root cause (reproduced): the `:phoenix_live_view` colocated-hooks compiler writes `assets/node_modules/phoenix-colocated/typster/`, creating `node_modules/` with only that folder. The old order compiled the app first (via `ecto.setup`), then the first `bun install` populated `node_modules` and **pruned** the stray `phoenix-colocated/`. The second `compile` inside `assets.build` is a same-process no-op, so it never regenerated it — and `bun js` couldn't resolve the import.

Running `assets.setup` first means `bun install` populates `node_modules` before the compiler writes into it, so the colocated dir is never pruned.

The Dev Container `postCreateCommand` had the same ordering and additionally never ran `assets.build`; it now just calls `mix setup`