### PR TITLE
fix: design-parity gaps and API hardening from the v3.1 handoff

### DIFF
--- a/assets/css/_editor_topbar.css
+++ b/assets/css/_editor_topbar.css
@@ -108,6 +108,16 @@
 .ts-tb__seg.is-active { color: var(--mk-fg); font: 600 12.5px var(--tb-mono); }
 .ts-tb__sep { color: var(--mk-fg3); }
 
+/* Symbol crumb (nearest heading above the cursor) — informational, not a link */
+.ts-tb__seg--sym {
+  color: var(--mk-fg3);
+  cursor: default;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ts-tb__seg--sym:hover { background: none; color: var(--mk-fg3); }
+
 /* ── Save dot (reuses the SaveStatus hook element) ────────────────────────── */
 .ts-tb .ts-savestat {
   display: inline-flex;

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -1830,7 +1830,7 @@
   padding: 20px;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: safe center;
   gap: 16px;
 }
 .share-public .ts-preview__placeholder {

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -1767,6 +1767,10 @@
   min-width: 0;
   color: var(--text-mute);
 }
+/* Scope pill carries the link's permission tone, mirroring the design's
+   four-tone system: read/full read as a calm neutral ("just looking"),
+   compiled-output reads as success-green, and the writable Pro sandbox is the
+   only one painted in the loud accent ("you can touch this"). */
 .share-public .embed-bar .ro-pill {
   display: inline-flex;
   align-items: center;
@@ -1776,16 +1780,26 @@
   text-transform: uppercase;
   padding: 2px 8px;
   border-radius: 999px;
-  background: color-mix(in oklab, var(--accent) 10%, transparent);
-  color: var(--accent);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-mute);
   white-space: nowrap;
 }
 
+/* Compiled-output-only links: distinct success tone (matches the Link tab's
+   "output" permission card). */
+.share-public .embed-bar .ro-pill--output {
+  background: color-mix(in oklab, var(--green-500) 12%, transparent);
+  border-color: color-mix(in oklab, var(--green-500) 30%, transparent);
+  color: var(--green-500);
+}
+
 /* Pro sandbox: the embedded editor is writable, so flag it with a solid,
-   higher-contrast pill (the read-only pill is a subtle tint by comparison). */
+   higher-contrast accent pill. */
 .share-public .embed-bar .ro-pill--edit {
   background: var(--accent);
-  color: var(--accent-contrast, #fff);
+  border-color: var(--accent);
+  color: var(--accent-text, #fff);
 }
 
 /* real source + preview panes fill the middle (1fr) grid row */

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -1746,13 +1746,18 @@
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); /* read/full: source | preview */
 }
 
-/* /embed/:token — flush, full-viewport, no outer chrome */
+/* /embed/:token — flush, full-viewport, no outer chrome. Pinned with
+   `fixed; inset: 0` rather than `100dvh`: viewport units are unreliable inside
+   an iframe (Firefox leaves dead space below), fixed positioning fills it. */
 .share-public--embed {
   padding: 0;
+  min-height: 0;
+  position: fixed;
+  inset: 0;
 }
 .share-public--embed .embed-comp {
   max-width: none;
-  height: 100dvh;
+  height: 100%;
   border: 0;
   border-radius: 0;
   box-shadow: none;

--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -1884,6 +1884,27 @@
   background: var(--surface);
 }
 
+/* fork-a-copy modal on the public shared view */
+.share-public__fork-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--mk-ink, #0b0b0f) 45%, transparent);
+  backdrop-filter: blur(2px);
+}
+.share-public__fork-overlay .share-public__panel {
+  text-align: left;
+  justify-items: stretch;
+  width: min(380px, calc(100vw - 32px));
+}
+.share-public__fork-overlay h2 {
+  font: 600 16px var(--font-sans);
+  color: var(--text);
+  margin: 0;
+}
+
 /* invalid / expired link panel */
 .share-public--invalid {
   place-items: center;

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -384,7 +384,7 @@
 /* ── Preview pane ─────────────────────────────────────────────────────────── */
 .ts-preview { display: flex; flex-direction: column; min-height: 0; overflow: hidden; background: var(--bg2); }
 .ts-preview__bar { display: flex; align-items: center; gap: 6px; height: 36px; padding: 0 12px; border-bottom: 1px solid var(--bd); background: var(--bg); font: 500 12px 'Inter', system-ui, sans-serif; color: var(--fg2); flex-shrink: 0; }
-.ts-preview__scroll { flex: 1; overflow: auto; padding: 24px; display: flex; flex-direction: column; align-items: center; gap: 12px; }
+.ts-preview__scroll { flex: 1; overflow: auto; padding: 24px; display: flex; flex-direction: column; align-items: safe center; gap: 12px; }
 .ts-preview__placeholder { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 12px; color: var(--fg3); font: 13px 'Inter', system-ui, sans-serif; }
 .ts-preview__ms { font: 11px 'JetBrains Mono', ui-monospace, monospace; color: var(--fg4); }
 

--- a/assets/css/_typster_ui.css
+++ b/assets/css/_typster_ui.css
@@ -411,6 +411,7 @@
 .ts-palette__item .ts-kbd { margin-left: auto; }
 .ts-palette__list button.ts-palette__item { width: 100%; background: transparent; border: 0; text-align: left; font-family: inherit; }
 .ts-palette__item .size-4 { flex-shrink: 0; }
+.ts-palette__dim { color: var(--fg4); font: 500 12px var(--mono, ui-monospace, monospace); }
 .ts-outline__empty { padding: 4px 14px 10px; color: var(--fg4); font: 12px 'Inter', system-ui, sans-serif; }
 
 /* ── Keyboard hints ───────────────────────────────────────────────────────── */

--- a/assets/js/embed_boot.js
+++ b/assets/js/embed_boot.js
@@ -38,7 +38,17 @@ const NOOP_HOOK = { pushEvent() {}, pushEventTo() {}, handleEvent() {}, el: null
 
 // Returns true when it booted an embed page (so the caller skips liveSocket).
 export function bootEmbed() {
-  if (!document.getElementById("typster-embed")) return false
+  const embed = document.getElementById("typster-embed")
+  if (!embed) return false
+
+  // `?theme=light|dark` is rendered onto the embed wrapper, but CodeMirror's
+  // theme extension keys off the document root (which the layout bootstrap
+  // derives from this origin's localStorage — empty inside a visitor's
+  // iframe). Mirror the forced theme up so the editor matches the chrome.
+  const forcedTheme = embed.dataset.theme
+  if (forcedTheme === "light" || forcedTheme === "dark") {
+    document.documentElement.setAttribute("data-theme", forcedTheme)
+  }
 
   const ec = document.getElementById("editor-container")
   let content = ""

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -111,6 +111,7 @@ export const CodeMirror = {
     // Track the open file's path so worker diagnostics (now labelled by real
     // path) can be matched back to this editor.
     this.mainPath = options.project.mainPath || "main.typ"
+    this.collab = options.collab
 
     if (!container) return
 
@@ -128,7 +129,9 @@ export const CodeMirror = {
     }
 
     this.handleEvent("content_updated", ({ content }) => {
-      if (this.editorInstance) {
+      // When collab is on, the Yjs doc owns the buffer; writing here too
+      // double-inserts (and compounds across reloads).
+      if (this.editorInstance && !this.collab) {
         updateEditorContent(this.editorInstance, content)
       }
     })

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -33,15 +33,37 @@ function editorOptions(element) {
   }
 }
 
+// Breadcrumb symbol segment: show the nearest heading above the cursor as the
+// final crumb (`folder / file.typ › Heading`). Pure DOM — tracks every cursor
+// move without a server round-trip.
+function updateCrumbSymbol(outline, line) {
+  const sym = document.getElementById("topbar-symbol")
+  const sep = document.getElementById("topbar-symbol-sep")
+  if (!sym || !sep) return
+
+  let current = null
+  for (const item of outline || []) {
+    if (item.line <= line) current = item
+    else break
+  }
+
+  sym.hidden = sep.hidden = !current
+  if (current) sym.textContent = current.text
+}
+
 export const CodeMirror = {
   editorCallbacks() {
     return {
       onCursor: (line, col) => {
         const el = document.getElementById("status-cursor")
         if (el) el.textContent = `Ln ${line}, Col ${col}`
+        this.lastCursorLine = line
+        updateCrumbSymbol(this.lastOutline, line)
       },
       onOutline: (items) => {
+        this.lastOutline = items
         this.pushEvent("outline_parsed", { items })
+        updateCrumbSymbol(items, this.lastCursorLine || 1)
       }
     }
   },

--- a/assets/js/typst_worker.js
+++ b/assets/js/typst_worker.js
@@ -163,7 +163,11 @@ export function initTypstWorker(hook) {
             if (!svgContainer) {
               svgContainer = document.createElement("div")
               svgContainer.id = "typst-svg-output"
-              svgContainer.style.cssText = "width:100%;overflow:auto;"
+              // No own overflow: the page stack must scroll in its parent
+              // (`.ts-preview__scroll`), which owns the padding + centering.
+              // A second scroll container here put the scrollbar inside the
+              // padding and split it from the pane edge.
+              svgContainer.style.cssText = "width:100%;"
               previewContainer.appendChild(svgContainer)
             }
             svgContainer.style.display = ""

--- a/lib/typster/analytics.ex
+++ b/lib/typster/analytics.ex
@@ -13,6 +13,8 @@ defmodule Typster.Analytics do
   query logic at all. No compile-time reference to `Typster.Pro.*`.
   """
 
+  require Logger
+
   @type summary :: %{
           total: non_neg_integer(),
           last_7d: non_neg_integer(),
@@ -22,12 +24,27 @@ defmodule Typster.Analytics do
 
   @doc "Records one open of the share link `token`. Best-effort; no-op on community."
   @spec record(String.t(), keyword()) :: term()
-  def record(token, opts \\ []) when is_binary(token),
-    do: impl().record(Typster.Repo, token, opts)
+  def record(token, opts \\ []) when is_binary(token) do
+    impl().record(Typster.Repo, token, opts)
+  rescue
+    # Analytics must never take down a public share/embed page — e.g. a Pro
+    # build whose `pro_share_opens` migration hasn't run yet would otherwise
+    # 500 every open. Log and move on; the page is the product, the count isn't.
+    error ->
+      Logger.error("share-open analytics record failed: #{Exception.message(error)}")
+      :error
+  end
 
   @doc "Aggregated open stats for `token` (all zeros on the community build)."
   @spec summary(String.t()) :: summary()
-  def summary(token) when is_binary(token), do: impl().summary(Typster.Repo, token)
+  def summary(token) when is_binary(token) do
+    impl().summary(Typster.Repo, token)
+  rescue
+    # Same guard for the owner-facing Share modal: degrade to zeros, don't crash.
+    error ->
+      Logger.error("share analytics summary failed: #{Exception.message(error)}")
+      %{total: 0, last_7d: 0, last_at: nil, daily: List.duplicate(0, 14)}
+  end
 
   # Runtime dispatch only — mirrors Typster.Features / Typster.Embed.
   @doc false

--- a/lib/typster/assets.ex
+++ b/lib/typster/assets.ex
@@ -95,6 +95,43 @@ defmodule Typster.Assets do
     Asset.changeset(asset, attrs)
   end
 
+  @doc """
+  Copies every asset of `source_project_id` into `target_project_id`,
+  duplicating each S3 object under a fresh key (forks must not share objects —
+  deleting the original would break the copy).
+
+  No scope: authorization is the caller's job (`Typster.Projects.fork_project/3`
+  runs this inside its transaction). Returns `:ok`, or `{:error, reason}` on
+  the first failed S3 copy so the caller can roll the fork back.
+  """
+  def copy_project_assets(source_project_id, target_project_id) do
+    bucket = Application.get_env(:typster, :s3_bucket, "typster-assets")
+
+    from(a in Asset, where: a.project_id == ^source_project_id)
+    |> Repo.all()
+    |> Enum.reduce_while(:ok, fn asset, :ok ->
+      new_key = object_key(target_project_id, asset.filename)
+
+      case ExAws.S3.put_object_copy(bucket, new_key, bucket, asset.object_key)
+           |> ExAws.request() do
+        {:ok, _} ->
+          Repo.insert!(%Asset{
+            project_id: target_project_id,
+            object_key: new_key,
+            content_type: asset.content_type,
+            size: asset.size,
+            filename: asset.filename,
+            inserted_at: DateTime.utc_now(:second)
+          })
+
+          {:cont, :ok}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+  end
+
   def reference_path(%Asset{} = asset), do: "assets/#{asset.filename}"
 
   defp safe_upload_path!(path) do

--- a/lib/typster/features.ex
+++ b/lib/typster/features.ex
@@ -27,6 +27,7 @@ defmodule Typster.Features do
           | :share_embed_sandbox
           | :share_embed_smart_cta
           | :share_embed_unbranded
+          | :share_open_collaboration
 
   @features ~w(
     share_write_scoped
@@ -35,6 +36,7 @@ defmodule Typster.Features do
     share_embed_sandbox
     share_embed_smart_cta
     share_embed_unbranded
+    share_open_collaboration
   )a
 
   @doc "The full catalog of gateable Pro features."

--- a/lib/typster/projects.ex
+++ b/lib/typster/projects.ex
@@ -84,6 +84,69 @@ defmodule Typster.Projects do
     |> Repo.insert()
   end
 
+  @doc """
+  Deep-copies `source` into a brand-new project owned by the scope's user:
+  files (with their folder hierarchy) and assets (duplicating the underlying
+  S3 objects under fresh keys). Collaborators, the share link, and revision
+  history deliberately start clean on the copy.
+
+  Does **not** authorize against `source` — the caller must have already
+  established read access (e.g. via a share-link token in
+  `Typster.Sharing.fork_via_link/3`, or ownership).
+
+  Returns `{:ok, project}`, `{:error, changeset}` for an invalid name, or
+  `{:error, :asset_copy_failed}` when an S3 object copy fails (the whole fork
+  rolls back — no half-copied project is left behind).
+  """
+  def fork_project(%Scope{user: user}, %Project{} = source, attrs) do
+    Repo.transaction(fn ->
+      case %Project{user_id: user.id} |> Project.changeset(attrs) |> Repo.insert() do
+        {:ok, fork} ->
+          copy_files!(source.id, fork.id)
+
+          case Typster.Assets.copy_project_assets(source.id, fork.id) do
+            :ok -> fork
+            {:error, _reason} -> Repo.rollback(:asset_copy_failed)
+          end
+
+        {:error, changeset} ->
+          Repo.rollback(changeset)
+      end
+    end)
+  end
+
+  # Copies every file row, then re-links the parent hierarchy through an
+  # old-id → new-id map. Two passes (insert flat, then set parents) so the
+  # copy never depends on insertion order.
+  defp copy_files!(source_id, fork_id) do
+    files =
+      from(f in Typster.Projects.File,
+        where: f.project_id == ^source_id,
+        order_by: [asc: f.path]
+      )
+      |> Repo.all()
+
+    id_map =
+      Map.new(files, fn f ->
+        copy =
+          Repo.insert!(%Typster.Projects.File{
+            project_id: fork_id,
+            path: f.path,
+            content: f.content,
+            pinned: f.pinned
+          })
+
+        {f.id, copy.id}
+      end)
+
+    for f <- files, f.parent_id != nil do
+      from(c in Typster.Projects.File, where: c.id == ^Map.fetch!(id_map, f.id))
+      |> Repo.update_all(set: [parent_id: Map.fetch!(id_map, f.parent_id)])
+    end
+
+    :ok
+  end
+
   def update_project(%Scope{} = scope, %Project{} = project, attrs) do
     project = get_project!(scope, project.id)
 

--- a/lib/typster/projects.ex
+++ b/lib/typster/projects.ex
@@ -101,18 +101,21 @@ defmodule Typster.Projects do
   def fork_project(%Scope{user: user}, %Project{} = source, attrs) do
     Repo.transaction(fn ->
       case %Project{user_id: user.id} |> Project.changeset(attrs) |> Repo.insert() do
-        {:ok, fork} ->
-          copy_files!(source.id, fork.id)
-
-          case Typster.Assets.copy_project_assets(source.id, fork.id) do
-            :ok -> fork
-            {:error, _reason} -> Repo.rollback(:asset_copy_failed)
-          end
-
-        {:error, changeset} ->
-          Repo.rollback(changeset)
+        {:ok, fork} -> copy_project_contents!(source.id, fork)
+        {:error, changeset} -> Repo.rollback(changeset)
       end
     end)
+  end
+
+  # Inside the fork transaction: copy files, then assets; a failed S3 copy
+  # rolls the whole fork back.
+  defp copy_project_contents!(source_id, fork) do
+    copy_files!(source_id, fork.id)
+
+    case Typster.Assets.copy_project_assets(source_id, fork.id) do
+      :ok -> fork
+      {:error, _reason} -> Repo.rollback(:asset_copy_failed)
+    end
   end
 
   # Copies every file row, then re-links the parent hierarchy through an

--- a/lib/typster/projects/file.ex
+++ b/lib/typster/projects/file.ex
@@ -22,10 +22,55 @@ defmodule Typster.Projects.File do
     file
     |> cast(attrs, [:path, :content, :parent_id])
     |> validate_required([:path, :project_id])
+    |> validate_path()
+    |> validate_parent_in_project()
     |> assoc_constraint(:project)
+    |> assoc_constraint(:parent)
     |> unique_constraint(:path,
       name: :files_project_id_path_index,
       message: "already exists in this project"
     )
+  end
+
+  # Paths are project-relative by contract (the preview VFS, S3 keys, and the
+  # file tree all assume it): reject traversal segments, absolute paths,
+  # backslashes, and empty segments instead of storing them verbatim.
+  defp validate_path(changeset) do
+    validate_change(changeset, :path, fn :path, path ->
+      segments = String.split(path, "/")
+
+      cond do
+        String.starts_with?(path, "/") -> [path: "must be relative"]
+        String.contains?(path, "\\") -> [path: "cannot contain backslashes"]
+        Enum.any?(segments, &(&1 in ["..", "."])) -> [path: "cannot contain traversal segments"]
+        Enum.any?(segments, &(String.trim(&1) == "")) -> [path: "cannot contain empty segments"]
+        true -> []
+      end
+    end)
+  end
+
+  # A parent link must stay inside the same project — `cast` alone accepts any
+  # existing file id (including another project's, or another tenant's), and
+  # the FK cannot tell the difference.
+  defp validate_parent_in_project(changeset) do
+    parent_id = get_change(changeset, :parent_id)
+    project_id = get_field(changeset, :project_id)
+
+    if is_nil(parent_id) or is_nil(project_id) do
+      changeset
+    else
+      import Ecto.Query, only: [from: 2]
+
+      same_project? =
+        Typster.Repo.exists?(
+          from f in __MODULE__, where: f.id == ^parent_id and f.project_id == ^project_id
+        )
+
+      if same_project? do
+        changeset
+      else
+        add_error(changeset, :parent_id, "does not belong to this project")
+      end
+    end
   end
 end

--- a/lib/typster/sharing.ex
+++ b/lib/typster/sharing.ex
@@ -13,6 +13,7 @@ defmodule Typster.Sharing do
   alias Typster.Accounts.User
   alias Typster.Projects
   alias Typster.Repo
+  alias Typster.Sharing.Collaboration
   alias Typster.Sharing.Collaborator
   alias Typster.Sharing.Notifier
   alias Typster.Sharing.ShareLink
@@ -113,6 +114,97 @@ defmodule Typster.Sharing do
     |> where([f], f.project_id == ^project_id)
     |> order_by([f], asc: f.path)
     |> Repo.all()
+  end
+
+  ## Link-authorized fork & join
+
+  @doc """
+  PUBLIC (token): clones the link's project for the signed-in visitor.
+
+  The token **plus** the link's `allow_fork` policy authorize the copy — no
+  project-level access is required (that is the whole point: the visitor is a
+  stranger). Free feature; available on every plan.
+
+  Returns `{:ok, project}`, `{:error, changeset}` for a bad name,
+  `{:error, :forbidden}` when the owner has not enabled copying,
+  `{:error, :not_found}` for an unknown token or anonymous visitor.
+  """
+  def fork_via_link(%Scope{user: %User{}} = scope, token, attrs) when is_binary(token) do
+    case get_link_by_token(token) do
+      nil -> {:error, :not_found}
+      %ShareLink{allow_fork: true} = link -> Projects.fork_project(scope, link.project, attrs)
+      %ShareLink{} -> {:error, :forbidden}
+    end
+  end
+
+  def fork_via_link(_scope, _token, _attrs), do: {:error, :not_found}
+
+  @doc """
+  PUBLIC (token): joins the signed-in visitor as an accepted collaborator on
+  the link's project.
+
+  Whether a link may hand out seats is decided by
+  `Typster.Sharing.Collaboration` — the Pro-only policy (the link's `open_edit`
+  flag **and** the **owner's** `:share_open_collaboration` entitlement; the
+  sharer's plan decides, exactly like the embed sandbox). The open-core build
+  always denies. Idempotent: re-joining is a no-op success, and a prior
+  email invite is simply accepted in place — keeping the role the owner chose
+  there rather than force-promoting to `:editor`.
+
+  Returns `{:ok, collaborator}`, `{:ok, :owner}` when the visitor already owns
+  the project, `{:error, :forbidden}` when the policy or entitlement is off,
+  `{:error, :not_found}` for an unknown token or anonymous visitor.
+  """
+  def join_via_link(%Scope{user: %User{} = user}, token) when is_binary(token) do
+    case get_link_by_token(token) do
+      nil ->
+        {:error, :not_found}
+
+      %ShareLink{} = link ->
+        cond do
+          link.project.user_id == user.id ->
+            {:ok, :owner}
+
+          not Collaboration.open_edit?(owner_scope(link), link) ->
+            {:error, :forbidden}
+
+          true ->
+            upsert_link_collaborator(link.project_id, user)
+        end
+    end
+  end
+
+  def join_via_link(_scope, _token), do: {:error, :not_found}
+
+  # Reuses a prior invite row (matched by account or email, so we never trip
+  # the [project_id, email] unique index) and accepts it; otherwise inserts a
+  # fresh accepted :editor row.
+  defp upsert_link_collaborator(project_id, user) do
+    email = String.downcase(user.email)
+
+    existing =
+      Repo.one(
+        from(c in Collaborator,
+          where:
+            c.project_id == ^project_id and
+              (c.user_id == ^user.id or fragment("lower(?)", c.email) == ^email),
+          limit: 1
+        )
+      )
+
+    case existing do
+      %Collaborator{status: :accepted, user_id: user_id} = collaborator
+      when user_id == user.id ->
+        {:ok, collaborator}
+
+      %Collaborator{} = collaborator ->
+        collaborator |> Collaborator.accept_changeset(user.id) |> Repo.update()
+
+      nil ->
+        %Collaborator{project_id: project_id, user_id: user.id, status: :accepted}
+        |> Collaborator.changeset(%{email: user.email, role: :editor})
+        |> Repo.insert()
+    end
   end
 
   ## Collaborators

--- a/lib/typster/sharing/collaboration.ex
+++ b/lib/typster/sharing/collaboration.ex
@@ -1,0 +1,41 @@
+defmodule Typster.Sharing.Collaboration do
+  @moduledoc """
+  Dispatch point for the open-collaboration policy ("anyone with the link
+  becomes an editor") — **not** the policy itself. Auto-joining visitors as
+  collaborators is a paid capability, so the actual rule lives in the closed
+  `Typster.Pro.Collaboration`. This module only routes to it.
+
+  The open-core build carries **none** of that logic: with the Pro code absent
+  it falls back to `Typster.Sharing.Collaboration.Free`, which denies every
+  join. A community deployment therefore cannot auto-join a visitor at all —
+  there is no host-side flag to flip, because the rule doesn't exist in the
+  host. No compile-time reference to `Typster.Pro.*` (mirrors `Typster.Embed`).
+  """
+
+  alias Typster.Accounts.Scope
+  alias Typster.Sharing.ShareLink
+
+  @doc """
+  True when `link` may hand a collaborator seat to a visitor, per the active
+  implementation (`Typster.Pro.Collaboration` when compiled in, otherwise the
+  always-deny `Typster.Sharing.Collaboration.Free`). `owner_scope` is the
+  **sharer's** scope — their plan pays for the seats.
+  """
+  @spec open_edit?(Scope.t() | nil, ShareLink.t()) :: boolean()
+  def open_edit?(owner_scope, %ShareLink{} = link), do: impl().open_edit?(owner_scope, link)
+
+  # Runtime dispatch only — never a compile-time mention of Typster.Pro.*.
+  # The `cond` shape (rather than `if`) is deliberate for the same reason as
+  # `Typster.Embed.impl/0`: the opaque first branch keeps the compiler from
+  # flagging `Typster.Pro.Collaboration` as undefined in the open-core build.
+  # An explicit `:collaboration_impl` override lets tests inject a fake impl.
+  @doc false
+  @spec impl() :: module()
+  def impl do
+    cond do
+      mod = Application.get_env(:typster, :collaboration_impl) -> mod
+      Code.ensure_loaded?(Typster.Pro.Collaboration) -> Typster.Pro.Collaboration
+      true -> Typster.Sharing.Collaboration.Free
+    end
+  end
+end

--- a/lib/typster/sharing/collaboration/free.ex
+++ b/lib/typster/sharing/collaboration/free.ex
@@ -1,0 +1,12 @@
+defmodule Typster.Sharing.Collaboration.Free do
+  @moduledoc """
+  Open-core open-collaboration policy: every auto-join is denied.
+
+  The community fallback for `Typster.Sharing.Collaboration` when the Pro code
+  is not compiled in. A link owner whose account is nominally `:pro` still gets
+  `false` here — correct, because the capability cannot run without the Pro
+  implementation (mirrors `Typster.Features.Free`).
+  """
+
+  def open_edit?(_owner_scope, _link), do: false
+end

--- a/lib/typster/sharing/share_link.ex
+++ b/lib/typster/sharing/share_link.ex
@@ -3,8 +3,13 @@ defmodule Typster.Sharing.ShareLink do
   A public share link for a project.
 
   One link exists per project. The `token` and `project_id` are set
-  programmatically (never cast from user params); only `scope` and
-  `allow_download` are user-editable.
+  programmatically (never cast from user params); only `scope`,
+  `allow_download`, `allow_fork`, and `open_edit` are user-editable.
+
+  `allow_fork` lets any signed-in visitor clone the project under their own
+  account. `open_edit` auto-joins visitors as accepted `:editor` collaborators
+  — a Pro capability, additionally gated by the **owner's** entitlement at
+  join time (see `Typster.Sharing.join_via_link/2`). Both default to off.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -17,6 +22,8 @@ defmodule Typster.Sharing.ShareLink do
           token: String.t() | nil,
           scope: :read | :output | :full,
           allow_download: boolean(),
+          allow_fork: boolean(),
+          open_edit: boolean(),
           project_id: binary() | nil,
           project: Typster.Projects.Project.t() | Ecto.Association.NotLoaded.t() | nil,
           inserted_at: DateTime.t() | nil,
@@ -27,6 +34,8 @@ defmodule Typster.Sharing.ShareLink do
     field :token, :string
     field :scope, Ecto.Enum, values: [:read, :output, :full], default: :read
     field :allow_download, :boolean, default: true
+    field :allow_fork, :boolean, default: false
+    field :open_edit, :boolean, default: false
     belongs_to :project, Typster.Projects.Project
     timestamps(type: :utc_datetime)
   end
@@ -39,8 +48,8 @@ defmodule Typster.Sharing.ShareLink do
   """
   def changeset(share_link, attrs) do
     share_link
-    |> cast(attrs, [:scope, :allow_download])
-    |> validate_required([:scope, :allow_download])
+    |> cast(attrs, [:scope, :allow_download, :allow_fork, :open_edit])
+    |> validate_required([:scope, :allow_download, :allow_fork, :open_edit])
   end
 
   @doc """

--- a/lib/typster_web/controllers/user_session_controller.ex
+++ b/lib/typster_web/controllers/user_session_controller.ex
@@ -5,11 +5,11 @@ defmodule TypsterWeb.UserSessionController do
   alias TypsterWeb.UserAuth
 
   def create(conn, %{"_action" => "confirmed"} = params) do
-    create(conn, params, "User confirmed successfully.")
+    create(conn, params, gettext("auth.flash.confirmed"))
   end
 
   def create(conn, params) do
-    create(conn, params, "Welcome back!")
+    create(conn, params, gettext("auth.flash.welcome_back"))
   end
 
   # magic link login
@@ -24,7 +24,7 @@ defmodule TypsterWeb.UserSessionController do
 
       _ ->
         conn
-        |> put_flash(:error, "The link is invalid or it has expired.")
+        |> put_flash(:error, gettext("auth.flash.link_invalid"))
         |> redirect(to: ~p"/users/log-in")
     end
   end
@@ -42,7 +42,7 @@ defmodule TypsterWeb.UserSessionController do
     conn
     |> put_flash(
       :info,
-      "If your email is in our system, you will receive instructions for logging in shortly."
+      gettext("auth.flash.magic_link_sent")
     )
     |> redirect(to: ~p"/users/log-in")
   end
@@ -58,7 +58,7 @@ defmodule TypsterWeb.UserSessionController do
     else
       # In order to prevent user enumeration attacks, don't disclose whether the email is registered.
       conn
-      |> put_flash(:error, "Invalid email or password")
+      |> put_flash(:error, gettext("auth.flash.invalid_credentials"))
       |> put_flash(:email, String.slice(email, 0, 160))
       |> redirect(to: ~p"/users/log-in")
     end
@@ -74,12 +74,12 @@ defmodule TypsterWeb.UserSessionController do
 
     conn
     |> put_session(:user_return_to, ~p"/users/settings")
-    |> create(params, "Password updated successfully!")
+    |> create(params, gettext("auth.flash.password_updated"))
   end
 
   def delete(conn, _params) do
     conn
-    |> put_flash(:info, "Logged out successfully.")
+    |> put_flash(:info, gettext("auth.flash.logged_out"))
     |> UserAuth.log_out_user()
   end
 end

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -265,7 +265,7 @@ defmodule TypsterWeb.EditorLive.Index do
   # a non-owner no-ops here instead of reaching `Sharing.*` (which would raise on
   # the owner-only `Projects.get_project!`). Must precede the specific handlers.
   def handle_event(event, _params, %{assigns: %{owner?: false}} = socket)
-      when event in ~w(share_scope share_rotate share_toggle_download share_invite share_remove_collab) do
+      when event in ~w(share_scope share_rotate share_toggle_download share_toggle_fork share_toggle_open_edit share_invite share_remove_collab) do
     {:noreply, socket}
   end
 
@@ -318,6 +318,27 @@ defmodule TypsterWeb.EditorLive.Index do
     case socket.assigns.share_link do
       nil -> {:noreply, socket}
       link -> {:noreply, update_share_link(socket, %{allow_download: !link.allow_download})}
+    end
+  end
+
+  @impl true
+  def handle_event("share_toggle_fork", _params, socket) do
+    case socket.assigns.share_link do
+      nil -> {:noreply, socket}
+      link -> {:noreply, update_share_link(socket, %{allow_fork: !link.allow_fork})}
+    end
+  end
+
+  # The flag can be flipped by any owner, but it only has effect when the
+  # owner's plan carries :share_open_collaboration (the join path re-checks via
+  # Typster.Sharing.Collaboration) — so Free owners just see the locked row.
+  @impl true
+  def handle_event("share_toggle_open_edit", _params, socket) do
+    with link when not is_nil(link) <- socket.assigns.share_link,
+         true <- Features.can?(socket.assigns.current_scope, :share_open_collaboration) do
+      {:noreply, update_share_link(socket, %{open_edit: !link.open_edit})}
+    else
+      _ -> {:noreply, socket}
     end
   end
 

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -549,7 +549,7 @@ defmodule TypsterWeb.EditorLive.Index do
 
         socket
         |> assign(creating?: false, new_kind: :file, new_file_name: "", new_file_suggestions: [])
-        |> create_text_file(path, default_file_content(path))
+        |> create_text_file(path, default_file_content(path, socket.assigns.file_tree))
     end
   end
 
@@ -588,7 +588,9 @@ defmodule TypsterWeb.EditorLive.Index do
          |> put_flash(:error, gettext("editor.flash.file_exists"))}
 
       true ->
-        content = socket.assigns.template_content || default_file_content(path)
+        content =
+          socket.assigns.template_content || default_file_content(path, socket.assigns.file_tree)
+
         create_text_file(assign(socket, :template_content, nil), path, content)
     end
   end
@@ -759,27 +761,30 @@ defmodule TypsterWeb.EditorLive.Index do
     Enum.any?(changeset.errors, fn {field, _} -> field == :path end)
   end
 
-  defp default_file_content(path) do
-    case path |> Path.extname() |> String.downcase() do
-      ".typ" ->
-        """
-        = Introduction
-
-        Welcome to Typster. Start writing — the preview updates as you type.
-
-        You can mix *bold*, _italic_, and `raw` text, drop into math like
-        $E = m c^2$, or add a list:
-
-        - First point
-        - Second point
-        """
-
-      ".md" ->
-        "# Introduction\n\nStart writing in Markdown.\n"
-
-      _ ->
-        ""
+  # Starter content for a brand-new file. The welcome blurb is reserved for the
+  # project's very first Typst file — every later file (more .typ, .md, .bib …)
+  # opens empty, so we never prepend "welcome" boilerplate to chapter two.
+  defp default_file_content(path, file_tree) do
+    if Files.typst_file?(path) and not Enum.any?(file_tree, &Files.typst_file?/1) do
+      starter_typ()
+    else
+      ""
     end
+  end
+
+  # First-run document. Localized and lightly playful (the zoomer-academic house
+  # voice); the Typst markup stays put while the prose is translated.
+  defp starter_typ do
+    """
+    = #{gettext("editor.starter.heading")}
+
+    #{gettext("editor.starter.intro")}
+
+    #{gettext("editor.starter.body")}
+
+    - #{gettext("editor.starter.point1")}
+    - #{gettext("editor.starter.point2")}
+    """
   end
 
   # Glyph + color bucket for the live file-type chip in the inline create row.

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -73,6 +73,7 @@ defmodule TypsterWeb.EditorLive.Index do
      |> assign(:share_collaborators, [])
      |> assign(:invite_form, to_form(%{"email" => "", "role" => "editor"}, as: :invite))
      |> stream(:outline, [])
+     |> assign(:outline_items, [])
      |> assign(:outline_count, 0)
      |> assign(:page_title, project.name)
      |> allow_upload(:asset,
@@ -224,6 +225,9 @@ defmodule TypsterWeb.EditorLive.Index do
     {:noreply,
      socket
      |> assign(:outline_count, length(outline))
+     # Plain copy of the stream: the ⌘K palette needs an enumerable to filter
+     # headings (streams aren't), and a document's outline is small.
+     |> assign(:outline_items, outline)
      |> stream(:outline, outline, reset: true)}
   end
 
@@ -813,6 +817,10 @@ defmodule TypsterWeb.EditorLive.Index do
 
   defp palette_files(file_tree, query) do
     Enum.filter(file_tree, &(Files.editable_file?(&1) and palette_match?(query, &1.path)))
+  end
+
+  defp palette_headings(outline_items, query) do
+    Enum.filter(outline_items, &palette_match?(query, &1.text))
   end
 
   defp save_status_label("saved"), do: gettext("editor.status.saved")

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -761,30 +761,13 @@ defmodule TypsterWeb.EditorLive.Index do
     Enum.any?(changeset.errors, fn {field, _} -> field == :path end)
   end
 
-  # Starter content for a brand-new file. The welcome blurb is reserved for the
-  # project's very first Typst file — every later file (more .typ, .md, .bib …)
-  # opens empty, so we never prepend "welcome" boilerplate to chapter two.
+  # Welcome doc for the project's first Typst file only; later files open empty
   defp default_file_content(path, file_tree) do
     if Files.typst_file?(path) and not Enum.any?(file_tree, &Files.typst_file?/1) do
-      starter_typ()
+      gettext("editor.starter.doc")
     else
       ""
     end
-  end
-
-  # First-run document. Localized and lightly playful (the zoomer-academic house
-  # voice); the Typst markup stays put while the prose is translated.
-  defp starter_typ do
-    """
-    = #{gettext("editor.starter.heading")}
-
-    #{gettext("editor.starter.intro")}
-
-    #{gettext("editor.starter.body")}
-
-    - #{gettext("editor.starter.point1")}
-    - #{gettext("editor.starter.point2")}
-    """
   end
 
   # Glyph + color bucket for the live file-type chip in the inline create row.

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -762,10 +762,20 @@ defmodule TypsterWeb.EditorLive.Index do
   defp default_file_content(path) do
     case path |> Path.extname() |> String.downcase() do
       ".typ" ->
-        "#set page(margin: 2cm)\n\n= Introduction\n\nHello from Typster!"
+        """
+        = Introduction
 
-      ".tex" ->
-        "\\documentclass{article}\n\n\\begin{document}\n\n\\section{Introduction}\n\n\\end{document}\n"
+        Welcome to Typster. Start writing — the preview updates as you type.
+
+        You can mix *bold*, _italic_, and `raw` text, drop into math like
+        $E = m c^2$, or add a list:
+
+        - First point
+        - Second point
+        """
+
+      ".md" ->
+        "# Introduction\n\nStart writing in Markdown.\n"
 
       _ ->
         ""

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -15,7 +15,24 @@ defmodule TypsterWeb.EditorLive.Index do
   @impl true
   def mount(%{"id" => project_id}, _session, socket) do
     scope = socket.assigns.current_scope
-    project = Projects.get_editable_project!(scope, project_id)
+
+    # Non-bang lookup: strangers hitting a project URL they can't edit get a
+    # friendly redirect, not a 500. One generic message for "doesn't exist"
+    # and "no access" — the response must not leak which one it was.
+    case Projects.get_editable_project(scope, project_id) do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, gettext("editor.project_unavailable"))
+         |> push_navigate(to: ~p"/projects")}
+
+      project ->
+        mount_project(socket, scope, project)
+    end
+  end
+
+  defp mount_project(socket, scope, project) do
+    project_id = project.id
     file_tree = Files.get_file_tree(scope, project_id)
     assets = Assets.list_assets(scope, project_id)
     main_file = initial_file(file_tree)

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -36,6 +36,11 @@
           <span class={["ts-tb__seg", seg.last && "is-active"]}>{seg.name}</span>
           <span :if={!seg.last} class="ts-tb__sep">/</span>
         </span>
+        <%!-- Current symbol (nearest heading above the cursor) — populated
+              client-side by the CodeMirror hook, so it tracks every cursor
+              move without a server round-trip. --%>
+        <span id="topbar-symbol-sep" class="ts-tb__sep" hidden>›</span>
+        <span id="topbar-symbol" class="ts-tb__seg ts-tb__seg--sym" hidden></span>
         <div
           id="save-status"
           phx-hook="SaveStatus"
@@ -969,6 +974,26 @@
         >
           <.icon name="hero-document" class="size-4" />
           <span>{file.path}</span>
+        </button>
+
+        <div
+          :if={palette_headings(@outline_items, @palette_query) != []}
+          class="ts-palette__group"
+        >
+          {gettext("editor.palette.headings")}
+        </div>
+        <button
+          :for={heading <- palette_headings(@outline_items, @palette_query)}
+          type="button"
+          class="ts-palette__item"
+          phx-click={
+            JS.dispatch("phx:editor-command", detail: %{cmd: "goto", line: heading.line})
+            |> JS.push("close_palette")
+          }
+        >
+          <.icon name="hero-hashtag" class="size-4" />
+          <span :if={heading.num != ""} class="ts-palette__dim">{heading.num}</span>
+          <span>{heading.text}</span>
         </button>
 
         <div

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -1290,6 +1290,40 @@
               </div>
               <div class="switch"></div>
             </div>
+            <div
+              id="share-toggle-fork"
+              class={["toggle-row", @share_link && @share_link.allow_fork && "on"]}
+              phx-click="share_toggle_fork"
+            >
+              <div class="meta">
+                <div class="h">{gettext("share.adv.fork")}</div>
+                <div class="d">{gettext("share.adv.fork_sub")}</div>
+              </div>
+              <div class="switch"></div>
+            </div>
+            <%= if Features.can?(@current_scope, :share_open_collaboration) do %>
+              <div
+                id="share-toggle-open-edit"
+                class={["toggle-row", @share_link && @share_link.open_edit && "on"]}
+                phx-click="share_toggle_open_edit"
+              >
+                <div class="meta">
+                  <div class="h">{gettext("share.adv.open_edit")}</div>
+                  <div class="d">{gettext("share.adv.open_edit_sub")}</div>
+                </div>
+                <div class="switch"></div>
+              </div>
+            <% else %>
+              <div class="toggle-row" id="share-toggle-open-edit-locked">
+                <div class="meta">
+                  <div class="h">
+                    {gettext("share.adv.open_edit")} <span class="pro-badge">PRO</span>
+                  </div>
+                  <div class="d">{gettext("share.adv.open_edit_sub")}</div>
+                </div>
+                <div class="ic"><.icon name="hero-lock-closed" class="size-3.5" /></div>
+              </div>
+            <% end %>
             <div :if={!Features.can?(@current_scope, :share_advanced_link)} class="locked-section">
               <button type="button" class="lock-shield">
                 <.icon name="hero-lock-closed" class="size-3" /> {gettext("share.upgrade.unlock")}

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -100,7 +100,7 @@ defmodule TypsterWeb.SharedProjectLive do
           <span class="slug truncate">{@project.name}</span>
           <span :if={@entry} class="file truncate">· {@entry.path}</span>
           <span class="spacer"></span>
-          <span class={["ro-pill", @editable? && "ro-pill--edit"]}>
+          <span class={["ro-pill", scope_pill_tone(@scope_kind), @editable? && "ro-pill--edit"]}>
             <.icon
               name={if(@editable?, do: "hero-pencil-square", else: "hero-eye")}
               class="size-3"
@@ -194,6 +194,11 @@ defmodule TypsterWeb.SharedProjectLive do
   defp scope_label(:output), do: gettext("share.scope.output")
   defp scope_label(:full), do: gettext("share.scope.full")
   defp scope_label(_), do: gettext("share.scope.read")
+
+  # The "compiled output only" scope gets its own success tone in the bar pill;
+  # read/full share the neutral baseline. (Overridden by --edit on Pro sandboxes.)
+  defp scope_pill_tone(:output), do: "ro-pill--output"
+  defp scope_pill_tone(_), do: nil
 
   defp entry_file(files) do
     Enum.find(files, &(&1.path == "main.typ")) ||

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -29,10 +29,21 @@ defmodule TypsterWeb.SharedProjectLive do
         files = Sharing.files_for_link(link)
         entry = pick_entry(files, params["file"])
         embed? = socket.assigns.live_action == :embed
-        # The owner's plan — not the visitor's — decides the embed capabilities.
-        # Only resolve it for the embed (the `/p/:slug` page is always read-only).
-        owner_scope = if embed?, do: Sharing.owner_scope(link), else: nil
+        # The owner's plan — not the visitor's — decides the embed capabilities
+        # and whether `open_edit` may hand out collaborator seats. Resolve it
+        # only when a policy actually needs it.
+        owner_scope =
+          if embed? or link.open_edit, do: Sharing.owner_scope(link), else: nil
+
         policy = Embed.policy(owner_scope, params)
+
+        # Join/fork actions live on the `/p/:slug` page only: the embed renders
+        # statically inside third-party iframes (no LiveView socket to push
+        # events over), so it keeps its plain-anchor CTA instead.
+        can_join? =
+          not embed? and Typster.Sharing.Collaboration.open_edit?(owner_scope, link)
+
+        can_fork? = not embed? and link.allow_fork
 
         # Count this open once per page load — on the dead render, which happens
         # exactly once for both the embed (socket-less) and the `/p` view (whose
@@ -54,6 +65,11 @@ defmodule TypsterWeb.SharedProjectLive do
          |> assign(:content, (entry && entry.content) || "")
          |> assign(:language, entry_language(entry))
          |> assign(:project_sources, project_sources(files))
+         |> assign(:can_join?, can_join?)
+         |> assign(:can_fork?, can_fork?)
+         |> assign(:fork_open?, false)
+         |> assign(:notice, nil)
+         |> assign(:fork_form, to_form(%{"name" => copy_name(link.project.name)}, as: :fork))
          |> assign(:page_title, link.project.name)}
     end
   end
@@ -100,12 +116,85 @@ defmodule TypsterWeb.SharedProjectLive do
           <span class="slug truncate">{@project.name}</span>
           <span :if={@entry} class="file truncate">· {@entry.path}</span>
           <span class="spacer"></span>
+          <%= if @can_fork? do %>
+            <%= if @current_scope && @current_scope.user do %>
+              <button
+                type="button"
+                id="shared-fork-open"
+                class="ts-btn ts-btn--ghost ts-btn--sm"
+                phx-click="open_fork"
+              >
+                <.icon name="hero-document-duplicate" class="size-3.5" /> {gettext("share.join.fork")}
+              </button>
+            <% else %>
+              <.link
+                navigate={~p"/users/log-in"}
+                id="shared-fork-login"
+                class="ts-btn ts-btn--ghost ts-btn--sm"
+              >
+                <.icon name="hero-document-duplicate" class="size-3.5" /> {gettext("share.join.fork")}
+              </.link>
+            <% end %>
+          <% end %>
+          <%= if @can_join? do %>
+            <%= if @current_scope && @current_scope.user do %>
+              <button
+                type="button"
+                id="shared-join"
+                class="ts-btn ts-btn--primary ts-btn--sm"
+                phx-click="join"
+              >
+                <.icon name="hero-pencil-square" class="size-3.5" /> {gettext("share.join.edit")}
+              </button>
+            <% else %>
+              <.link
+                navigate={~p"/users/log-in"}
+                id="shared-join-login"
+                class="ts-btn ts-btn--primary ts-btn--sm"
+              >
+                <.icon name="hero-pencil-square" class="size-3.5" /> {gettext("share.join.edit")}
+              </.link>
+            <% end %>
+          <% end %>
           <span class={["ro-pill", scope_pill_tone(@scope_kind), @editable? && "ro-pill--edit"]}>
             <.icon
               name={if(@editable?, do: "hero-pencil-square", else: "hero-eye")}
               class="size-3"
             /> {if(@editable?, do: gettext("share.scope.sandbox"), else: scope_label(@scope_kind))}
           </span>
+        </div>
+
+        <div :if={@notice} id="shared-notice" class="embed-bar" role="alert">
+          <.icon name="hero-exclamation-triangle" class="size-3.5" />
+          <span class="truncate">{@notice}</span>
+        </div>
+
+        <div
+          :if={@fork_open?}
+          class="share-public__fork-overlay"
+          phx-window-keydown="close_fork"
+          phx-key="escape"
+        >
+          <div class="share-public__panel">
+            <h2>{gettext("share.join.fork_title")}</h2>
+            <p>{gettext("share.join.fork_sub")}</p>
+            <.form for={@fork_form} id="shared-fork-form" phx-submit="fork">
+              <.input
+                field={@fork_form[:name]}
+                type="text"
+                label={gettext("share.join.fork_name")}
+                autofocus
+              />
+              <div style="display:flex; gap:8px; margin-top:12px; justify-content:flex-end;">
+                <button type="button" class="ts-btn ts-btn--ghost ts-btn--sm" phx-click="close_fork">
+                  {gettext("share.join.fork_cancel")}
+                </button>
+                <button type="submit" class="ts-btn ts-btn--primary ts-btn--sm">
+                  {gettext("share.join.fork_confirm")}
+                </button>
+              </div>
+            </.form>
+          </div>
         </div>
 
         <section :if={show_source?(@scope_kind)} class="embed-source">
@@ -158,20 +247,39 @@ defmodule TypsterWeb.SharedProjectLive do
             {gettext("share.public.powered_by")} <strong class="ts-serif">Typster</strong>
           </span>
           <span class="spacer"></span>
+          <%!-- Plain anchors, not `navigate`: the embed renders without a
+                LiveView socket, and inside a third-party iframe our session
+                cookie is blocked anyway — these must escape to a new
+                top-level window on our origin. --%>
           <%= case @cta_mode do %>
             <% :none -> %>
             <% :signup -> %>
-              <.link navigate={~p"/users/register"} class="embed-foot__cta">
+              <a
+                href={~p"/users/register"}
+                target={@embed? && "_blank"}
+                rel={@embed? && "noopener"}
+                class="embed-foot__cta"
+              >
                 {gettext("share.embed.cta_signup")}
-              </.link>
+              </a>
             <% :fork -> %>
-              <.link navigate={~p"/projects/#{@project.id}/edit"} class="embed-foot__cta">
+              <a
+                href={~p"/projects/#{@project.id}/edit"}
+                target={@embed? && "_blank"}
+                rel={@embed? && "noopener"}
+                class="embed-foot__cta"
+              >
                 {gettext("share.embed.cta_fork")}
-              </.link>
+              </a>
             <% _ -> %>
-              <.link navigate={~p"/projects/#{@project.id}/edit"} class="embed-foot__cta">
+              <a
+                href={~p"/projects/#{@project.id}/edit"}
+                target={@embed? && "_blank"}
+                rel={@embed? && "noopener"}
+                class="embed-foot__cta"
+              >
                 {gettext("share.public.open_in_typster")}
-              </.link>
+              </a>
           <% end %>
         </div>
       </div>
@@ -179,12 +287,61 @@ defmodule TypsterWeb.SharedProjectLive do
     """
   end
 
+  @impl true
+  def handle_event("open_fork", _params, %{assigns: %{can_fork?: true}} = socket) do
+    {:noreply, assign(socket, :fork_open?, true)}
+  end
+
+  def handle_event("close_fork", _params, socket) do
+    {:noreply, assign(socket, :fork_open?, false)}
+  end
+
+  def handle_event(
+        "fork",
+        %{"fork" => %{"name" => name}},
+        %{assigns: %{can_fork?: true}} = socket
+      ) do
+    scope = socket.assigns.current_scope
+
+    case Sharing.fork_via_link(scope, socket.assigns.link.token, %{name: name}) do
+      {:ok, project} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("share.join.forked", name: project.name))
+         |> push_navigate(to: ~p"/projects/#{project.id}/edit")}
+
+      {:error, %Ecto.Changeset{}} ->
+        {:noreply,
+         socket
+         |> assign(:fork_form, to_form(%{"name" => name}, as: :fork))
+         |> assign(:notice, gettext("share.join.fork_invalid_name"))}
+
+      {:error, _reason} ->
+        {:noreply,
+         socket
+         |> assign(:fork_open?, false)
+         |> assign(:notice, gettext("share.join.fork_failed"))}
+    end
+  end
+
+  def handle_event("join", _params, %{assigns: %{can_join?: true}} = socket) do
+    scope = socket.assigns.current_scope
+
+    case Sharing.join_via_link(scope, socket.assigns.link.token) do
+      {:ok, _collaborator_or_owner} ->
+        {:noreply, push_navigate(socket, to: ~p"/projects/#{socket.assigns.project.id}/edit")}
+
+      {:error, _reason} ->
+        {:noreply, assign(socket, :notice, gettext("share.join.join_failed"))}
+    end
+  end
+
   # The public/embed view reuses the editor's client hooks (CodeMirror, Preview),
   # which push compile/outline/save events back to the LiveView. This view is
   # read-only and compiles entirely client-side, so there is no server state to
   # update — we accept and ignore them. Without this clause, the first
   # `update_preview` push would crash the LiveView (undefined handle_event/3).
-  @impl true
+  # It also swallows join/fork clicks whose policy guard above didn't match.
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
   # ── helpers ──────────────────────────────────────────────────────────────
@@ -208,6 +365,8 @@ defmodule TypsterWeb.SharedProjectLive do
 
   defp entry_language(nil), do: "typst"
   defp entry_language(%{path: path}), do: Files.editor_language(path)
+
+  defp copy_name(name), do: gettext("share.join.copy_of", name: name)
 
   defp project_sources(files) do
     files

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -26,52 +26,56 @@ defmodule TypsterWeb.SharedProjectLive do
          assign(socket, link: nil, project: nil, page_title: gettext("share.public.invalid"))}
 
       link ->
-        files = Sharing.files_for_link(link)
-        entry = pick_entry(files, params["file"])
-        embed? = socket.assigns.live_action == :embed
-        # The owner's plan — not the visitor's — decides the embed capabilities
-        # and whether `open_edit` may hand out collaborator seats. Resolve it
-        # only when a policy actually needs it.
-        owner_scope =
-          if embed? or link.open_edit, do: Sharing.owner_scope(link), else: nil
-
-        policy = Embed.policy(owner_scope, params)
-
-        # Join/fork actions live on the `/p/:slug` page only: the embed renders
-        # statically inside third-party iframes (no LiveView socket to push
-        # events over), so it keeps its plain-anchor CTA instead.
-        can_join? =
-          not embed? and Typster.Sharing.Collaboration.open_edit?(owner_scope, link)
-
-        can_fork? = not embed? and link.allow_fork
-
-        # Count this open once per page load — on the dead render, which happens
-        # exactly once for both the embed (socket-less) and the `/p` view (whose
-        # connected mount we skip). No-op unless the Pro analytics code is present.
-        if not connected?(socket), do: Typster.Analytics.record(link.token)
-
-        {:ok,
-         socket
-         |> assign(:link, link)
-         |> assign(:project, link.project)
-         |> assign(:scope_kind, link.scope)
-         |> assign(:embed?, embed?)
-         |> assign(:embed_theme, embed_theme(params["theme"]))
-         |> assign(:show_preview?, params["preview"] != "0")
-         |> assign(:editable?, policy.editable)
-         |> assign(:unbranded?, policy.unbranded)
-         |> assign(:cta_mode, policy.cta.mode)
-         |> assign(:entry, entry)
-         |> assign(:content, (entry && entry.content) || "")
-         |> assign(:language, entry_language(entry))
-         |> assign(:project_sources, project_sources(files))
-         |> assign(:can_join?, can_join?)
-         |> assign(:can_fork?, can_fork?)
-         |> assign(:fork_open?, false)
-         |> assign(:notice, nil)
-         |> assign(:fork_form, to_form(%{"name" => copy_name(link.project.name)}, as: :fork))
-         |> assign(:page_title, link.project.name)}
+        mount_link(socket, link, params)
     end
+  end
+
+  defp mount_link(socket, link, params) do
+    files = Sharing.files_for_link(link)
+    entry = pick_entry(files, params["file"])
+    embed? = socket.assigns.live_action == :embed
+    # The owner's plan — not the visitor's — decides the embed capabilities
+    # and whether `open_edit` may hand out collaborator seats. Resolve it
+    # only when a policy actually needs it.
+    owner_scope =
+      if embed? or link.open_edit, do: Sharing.owner_scope(link), else: nil
+
+    policy = Embed.policy(owner_scope, params)
+
+    # Join/fork actions live on the `/p/:slug` page only: the embed renders
+    # statically inside third-party iframes (no LiveView socket to push
+    # events over), so it keeps its plain-anchor CTA instead.
+    can_join? =
+      not embed? and Typster.Sharing.Collaboration.open_edit?(owner_scope, link)
+
+    can_fork? = not embed? and link.allow_fork
+
+    # Count this open once per page load — on the dead render, which happens
+    # exactly once for both the embed (socket-less) and the `/p` view (whose
+    # connected mount we skip). No-op unless the Pro analytics code is present.
+    if not connected?(socket), do: Typster.Analytics.record(link.token)
+
+    {:ok,
+     socket
+     |> assign(:link, link)
+     |> assign(:project, link.project)
+     |> assign(:scope_kind, link.scope)
+     |> assign(:embed?, embed?)
+     |> assign(:embed_theme, embed_theme(params["theme"]))
+     |> assign(:show_preview?, params["preview"] != "0")
+     |> assign(:editable?, policy.editable)
+     |> assign(:unbranded?, policy.unbranded)
+     |> assign(:cta_mode, policy.cta.mode)
+     |> assign(:entry, entry)
+     |> assign(:content, (entry && entry.content) || "")
+     |> assign(:language, entry_language(entry))
+     |> assign(:project_sources, project_sources(files))
+     |> assign(:can_join?, can_join?)
+     |> assign(:can_fork?, can_fork?)
+     |> assign(:fork_open?, false)
+     |> assign(:notice, nil)
+     |> assign(:fork_form, to_form(%{"name" => copy_name(link.project.name)}, as: :fork))
+     |> assign(:page_title, link.project.name)}
   end
 
   # The embed honors `?theme=light|dark` (anything else inherits the host theme).

--- a/lib/typster_web/user_auth.ex
+++ b/lib/typster_web/user_auth.ex
@@ -4,6 +4,7 @@ defmodule TypsterWeb.UserAuth do
   """
 
   use TypsterWeb, :verified_routes
+  use Gettext, backend: TypsterWeb.Gettext
 
   import Plug.Conn
   import Phoenix.Controller
@@ -257,7 +258,7 @@ defmodule TypsterWeb.UserAuth do
     else
       socket =
         socket
-        |> Phoenix.LiveView.put_flash(:error, "You must log in to access this page.")
+        |> Phoenix.LiveView.put_flash(:error, gettext("auth.flash.login_required"))
         |> Phoenix.LiveView.redirect(to: ~p"/users/log-in")
 
       {:halt, socket}
@@ -272,7 +273,7 @@ defmodule TypsterWeb.UserAuth do
     else
       socket =
         socket
-        |> Phoenix.LiveView.put_flash(:error, "You must re-authenticate to access this page.")
+        |> Phoenix.LiveView.put_flash(:error, gettext("auth.flash.reauth_required"))
         |> Phoenix.LiveView.redirect(to: ~p"/users/log-in")
 
       {:halt, socket}
@@ -306,7 +307,7 @@ defmodule TypsterWeb.UserAuth do
       conn
     else
       conn
-      |> put_flash(:error, "You must log in to access this page.")
+      |> put_flash(:error, gettext("auth.flash.login_required"))
       |> maybe_store_return_to()
       |> redirect(to: ~p"/users/log-in")
       |> halt()

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -156,29 +156,29 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:738
+#: lib/typster_web/live/editor_live/index.ex:755
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:735
+#: lib/typster_web/live/editor_live/index.ex:752
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:440
+#: lib/typster_web/live/editor_live/index.ex:457
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:770
+#: lib/typster_web/live/editor_live/index.ex:787
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:598
-#: lib/typster_web/live/editor_live/index.ex:624
-#: lib/typster_web/live/editor_live/index.ex:913
+#: lib/typster_web/live/editor_live/index.ex:615
+#: lib/typster_web/live/editor_live/index.ex:641
+#: lib/typster_web/live/editor_live/index.ex:930
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:236
+#: lib/typster_web/live/shared_project_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:847
+#: lib/typster_web/live/editor_live/index.ex:864
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:845
+#: lib/typster_web/live/editor_live/index.ex:862
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:846
+#: lib/typster_web/live/editor_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -2037,9 +2037,9 @@ msgstr ""
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:563
-#: lib/typster_web/live/editor_live/index.ex:609
-#: lib/typster_web/live/editor_live/index.ex:769
+#: lib/typster_web/live/editor_live/index.ex:580
+#: lib/typster_web/live/editor_live/index.ex:626
+#: lib/typster_web/live/editor_live/index.ex:786
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,12 +2049,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:705
+#: lib/typster_web/live/editor_live/index.ex:722
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:678
+#: lib/typster_web/live/editor_live/index.ex:695
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:863
+#: lib/typster_web/live/editor_live/index.ex:880
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2145,12 +2145,12 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:914
+#: lib/typster_web/live/editor_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1389
+#: lib/typster_web/live/editor_live/index.ex:1406
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1391
+#: lib/typster_web/live/editor_live/index.ex:1408
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1395
+#: lib/typster_web/live/editor_live/index.ex:1412
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2222,12 +2222,12 @@ msgstr ""
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:968
+#: lib/typster_web/live/editor_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:955
+#: lib/typster_web/live/editor_live/index.ex:972
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1040
+#: lib/typster_web/live/editor_live/index.ex:1057
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
@@ -2398,12 +2398,12 @@ msgstr ""
 msgid "share.export.meta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:397
+#: lib/typster_web/live/editor_live/index.ex:414
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:394
+#: lib/typster_web/live/editor_live/index.ex:411
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr ""
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "share.people.invite_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1156
+#: lib/typster_web/live/editor_live/index.ex:1173
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr ""
@@ -2538,17 +2538,17 @@ msgstr ""
 msgid "share.perm.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:96
+#: lib/typster_web/live/shared_project_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr ""
@@ -2558,50 +2558,50 @@ msgstr ""
 msgid "share.public.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:95
+#: lib/typster_web/live/shared_project_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:94
+#: lib/typster_web/live/shared_project_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:277
+#: lib/typster_web/live/shared_project_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1154
+#: lib/typster_web/live/editor_live/index.ex:1171
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1152
+#: lib/typster_web/live/editor_live/index.ex:1169
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1153
+#: lib/typster_web/live/editor_live/index.ex:1170
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:344
+#: lib/typster_web/live/shared_project_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:343
+#: lib/typster_web/live/shared_project_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:345
+#: lib/typster_web/live/shared_project_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr ""
@@ -2651,7 +2651,7 @@ msgstr ""
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1250
+#: lib/typster_web/live/editor_live/index.ex:1267
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
@@ -2691,7 +2691,7 @@ msgstr ""
 msgid "share.invite.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:243
+#: lib/typster_web/live/shared_project_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr ""
@@ -2752,7 +2752,7 @@ msgstr ""
 msgid "share.embed.width"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1197
+#: lib/typster_web/live/editor_live/index.ex:1214
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr ""
@@ -2772,32 +2772,32 @@ msgstr ""
 msgid "editor.share_owner_only"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:268
+#: lib/typster_web/live/shared_project_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:259
+#: lib/typster_web/live/shared_project_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:159
+#: lib/typster_web/live/shared_project_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1081
+#: lib/typster_web/live/editor_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1083
+#: lib/typster_web/live/editor_live/index.ex:1100
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1082
+#: lib/typster_web/live/editor_live/index.ex:1099
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr ""
@@ -2888,7 +2888,7 @@ msgstr ""
 msgid "auth.flash.welcome_back"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:788
+#: lib/typster_web/live/editor_live/index.ex:805
 #, elixir-autogen, elixir-format
 msgid "editor.starter.doc"
 msgstr ""
@@ -2915,64 +2915,69 @@ msgstr ""
 msgid "share.adv.open_edit_sub"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:361
+#: lib/typster_web/live/shared_project_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "share.join.copy_of"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:147
 #: lib/typster_web/live/shared_project_live.ex:151
+#: lib/typster_web/live/shared_project_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "share.join.edit"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:127
-#: lib/typster_web/live/shared_project_live.ex:133
+#: lib/typster_web/live/shared_project_live.ex:131
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.join.fork"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:186
+#: lib/typster_web/live/shared_project_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_cancel"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:189
+#: lib/typster_web/live/shared_project_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_confirm"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:315
+#: lib/typster_web/live/shared_project_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_failed"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:309
+#: lib/typster_web/live/shared_project_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_invalid_name"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:181
+#: lib/typster_web/live/shared_project_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_name"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:176
+#: lib/typster_web/live/shared_project_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_sub"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:175
+#: lib/typster_web/live/shared_project_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_title"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:302
+#: lib/typster_web/live/shared_project_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "share.join.forked"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:327
+#: lib/typster_web/live/shared_project_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "share.join.join_failed"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:26
+#, elixir-autogen, elixir-format
+msgid "editor.project_unavailable"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -156,12 +156,12 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:715
+#: lib/typster_web/live/editor_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:712
+#: lib/typster_web/live/editor_live/index.ex:714
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
@@ -171,14 +171,14 @@ msgstr ""
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:747
+#: lib/typster_web/live/editor_live/index.ex:749
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:577
-#: lib/typster_web/live/editor_live/index.ex:601
-#: lib/typster_web/live/editor_live/index.ex:894
+#: lib/typster_web/live/editor_live/index.ex:603
+#: lib/typster_web/live/editor_live/index.ex:909
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -209,17 +209,17 @@ msgstr ""
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:828
+#: lib/typster_web/live/editor_live/index.ex:843
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:826
+#: lib/typster_web/live/editor_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:827
+#: lib/typster_web/live/editor_live/index.ex:842
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -2039,7 +2039,7 @@ msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:542
 #: lib/typster_web/live/editor_live/index.ex:588
-#: lib/typster_web/live/editor_live/index.ex:746
+#: lib/typster_web/live/editor_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,12 +2049,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:682
+#: lib/typster_web/live/editor_live/index.ex:684
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:655
+#: lib/typster_web/live/editor_live/index.ex:657
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:844
+#: lib/typster_web/live/editor_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2145,12 +2145,12 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:895
+#: lib/typster_web/live/editor_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1370
+#: lib/typster_web/live/editor_live/index.ex:1385
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1372
+#: lib/typster_web/live/editor_live/index.ex:1387
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1376
+#: lib/typster_web/live/editor_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2222,12 +2222,12 @@ msgstr ""
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:949
+#: lib/typster_web/live/editor_live/index.ex:964
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:936
+#: lib/typster_web/live/editor_live/index.ex:951
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1021
+#: lib/typster_web/live/editor_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "share.people.invite_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1137
+#: lib/typster_web/live/editor_live/index.ex:1152
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr ""
@@ -2538,12 +2538,12 @@ msgstr ""
 msgid "share.perm.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr ""
@@ -2573,19 +2573,19 @@ msgstr ""
 msgid "share.public.open_in_typster"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1135
+#: lib/typster_web/live/editor_live/index.ex:1150
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1133
+#: lib/typster_web/live/editor_live/index.ex:1148
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
@@ -2651,7 +2651,7 @@ msgstr ""
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1231
+#: lib/typster_web/live/editor_live/index.ex:1246
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
@@ -2752,7 +2752,7 @@ msgstr ""
 msgid "share.embed.width"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1178
+#: lib/typster_web/live/editor_live/index.ex:1193
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr ""
@@ -2787,17 +2787,17 @@ msgstr ""
 msgid "share.scope.sandbox"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1062
+#: lib/typster_web/live/editor_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1064
+#: lib/typster_web/live/editor_live/index.ex:1079
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1063
+#: lib/typster_web/live/editor_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr ""
@@ -2886,4 +2886,29 @@ msgstr ""
 #: lib/typster_web/controllers/user_session_controller.ex:12
 #, elixir-autogen, elixir-format
 msgid "auth.flash.welcome_back"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:783
+#, elixir-autogen, elixir-format
+msgid "editor.starter.body"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:779
+#, elixir-autogen, elixir-format
+msgid "editor.starter.heading"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:781
+#, elixir-autogen, elixir-format
+msgid "editor.starter.intro"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:785
+#, elixir-autogen, elixir-format
+msgid "editor.starter.point1"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.ex:786
+#, elixir-autogen, elixir-format
+msgid "editor.starter.point2"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -156,29 +156,29 @@ msgstr ""
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:717
+#: lib/typster_web/live/editor_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:714
+#: lib/typster_web/live/editor_live/index.ex:735
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:419
+#: lib/typster_web/live/editor_live/index.ex:440
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:749
+#: lib/typster_web/live/editor_live/index.ex:770
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:577
-#: lib/typster_web/live/editor_live/index.ex:603
-#: lib/typster_web/live/editor_live/index.ex:898
+#: lib/typster_web/live/editor_live/index.ex:598
+#: lib/typster_web/live/editor_live/index.ex:624
+#: lib/typster_web/live/editor_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:151
+#: lib/typster_web/live/shared_project_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:832
+#: lib/typster_web/live/editor_live/index.ex:847
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:830
+#: lib/typster_web/live/editor_live/index.ex:845
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:831
+#: lib/typster_web/live/editor_live/index.ex:846
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -2037,9 +2037,9 @@ msgstr ""
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:542
-#: lib/typster_web/live/editor_live/index.ex:588
-#: lib/typster_web/live/editor_live/index.ex:748
+#: lib/typster_web/live/editor_live/index.ex:563
+#: lib/typster_web/live/editor_live/index.ex:609
+#: lib/typster_web/live/editor_live/index.ex:769
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
@@ -2049,12 +2049,12 @@ msgstr ""
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:684
+#: lib/typster_web/live/editor_live/index.ex:705
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:657
+#: lib/typster_web/live/editor_live/index.ex:678
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:848
+#: lib/typster_web/live/editor_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2145,12 +2145,12 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:899
+#: lib/typster_web/live/editor_live/index.ex:914
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1374
+#: lib/typster_web/live/editor_live/index.ex:1389
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1376
+#: lib/typster_web/live/editor_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1380
+#: lib/typster_web/live/editor_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2222,12 +2222,12 @@ msgstr ""
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:953
+#: lib/typster_web/live/editor_live/index.ex:968
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:940
+#: lib/typster_web/live/editor_live/index.ex:955
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1025
+#: lib/typster_web/live/editor_live/index.ex:1040
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
@@ -2298,12 +2298,12 @@ msgid "common.close"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:1181
-#: lib/typster_web/live/editor_live/index.html.heex:1478
+#: lib/typster_web/live/editor_live/index.html.heex:1512
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1519
+#: lib/typster_web/live/editor_live/index.html.heex:1553
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr ""
@@ -2318,102 +2318,102 @@ msgstr ""
 msgid "share.adv.download_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1304
+#: lib/typster_web/live/editor_live/index.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1305
+#: lib/typster_web/live/editor_live/index.html.heex:1339
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1342
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1309
+#: lib/typster_web/live/editor_live/index.html.heex:1343
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1299
+#: lib/typster_web/live/editor_live/index.html.heex:1333
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1300
+#: lib/typster_web/live/editor_live/index.html.heex:1334
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1361
+#: lib/typster_web/live/editor_live/index.html.heex:1395
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1375
+#: lib/typster_web/live/editor_live/index.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1365
+#: lib/typster_web/live/editor_live/index.html.heex:1399
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1353
+#: lib/typster_web/live/editor_live/index.html.heex:1387
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1352
+#: lib/typster_web/live/editor_live/index.html.heex:1386
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1404
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1504
+#: lib/typster_web/live/editor_live/index.html.heex:1538
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1510
+#: lib/typster_web/live/editor_live/index.html.heex:1544
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1488
+#: lib/typster_web/live/editor_live/index.html.heex:1522
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1496
+#: lib/typster_web/live/editor_live/index.html.heex:1530
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:376
+#: lib/typster_web/live/editor_live/index.ex:397
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:373
+#: lib/typster_web/live/editor_live/index.ex:394
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1516
+#: lib/typster_web/live/editor_live/index.html.heex:1550
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1350
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr ""
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "share.people.invite_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1141
+#: lib/typster_web/live/editor_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr ""
@@ -2538,17 +2538,17 @@ msgstr ""
 msgid "share.perm.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:80
+#: lib/typster_web/live/shared_project_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr ""
@@ -2558,65 +2558,65 @@ msgstr ""
 msgid "share.public.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:79
+#: lib/typster_web/live/shared_project_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:78
+#: lib/typster_web/live/shared_project_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:173
+#: lib/typster_web/live/shared_project_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1139
+#: lib/typster_web/live/editor_live/index.ex:1154
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1137
+#: lib/typster_web/live/editor_live/index.ex:1152
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1138
+#: lib/typster_web/live/editor_live/index.ex:1153
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:195
+#: lib/typster_web/live/shared_project_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:196
+#: lib/typster_web/live/shared_project_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1331
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1323
+#: lib/typster_web/live/editor_live/index.html.heex:1357
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr ""
@@ -2651,22 +2651,22 @@ msgstr ""
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1235
+#: lib/typster_web/live/editor_live/index.ex:1250
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1341
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1295
+#: lib/typster_web/live/editor_live/index.html.heex:1329
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr ""
@@ -2691,68 +2691,68 @@ msgstr ""
 msgid "share.invite.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:158
+#: lib/typster_web/live/shared_project_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1394
+#: lib/typster_web/live/editor_live/index.html.heex:1428
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1396
+#: lib/typster_web/live/editor_live/index.html.heex:1430
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1395
+#: lib/typster_web/live/editor_live/index.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1381
+#: lib/typster_web/live/editor_live/index.html.heex:1415
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1432
-#: lib/typster_web/live/editor_live/index.html.heex:1442
+#: lib/typster_web/live/editor_live/index.html.heex:1466
+#: lib/typster_web/live/editor_live/index.html.heex:1476
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1388
+#: lib/typster_web/live/editor_live/index.html.heex:1422
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1402
+#: lib/typster_web/live/editor_live/index.html.heex:1436
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1408
+#: lib/typster_web/live/editor_live/index.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1410
+#: lib/typster_web/live/editor_live/index.html.heex:1444
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1409
+#: lib/typster_web/live/editor_live/index.html.heex:1443
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1416
+#: lib/typster_web/live/editor_live/index.html.heex:1450
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1182
+#: lib/typster_web/live/editor_live/index.ex:1197
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr ""
@@ -2772,32 +2772,32 @@ msgstr ""
 msgid "editor.share_owner_only"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:169
+#: lib/typster_web/live/shared_project_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:165
+#: lib/typster_web/live/shared_project_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:107
+#: lib/typster_web/live/shared_project_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1066
+#: lib/typster_web/live/editor_live/index.ex:1081
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1068
+#: lib/typster_web/live/editor_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1082
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr ""
@@ -2888,7 +2888,91 @@ msgstr ""
 msgid "auth.flash.welcome_back"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:773
+#: lib/typster_web/live/editor_live/index.ex:788
 #, elixir-autogen, elixir-format
 msgid "editor.starter.doc"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1299
+#, elixir-autogen, elixir-format
+msgid "share.adv.fork"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1300
+#, elixir-autogen, elixir-format
+msgid "share.adv.fork_sub"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1311
+#: lib/typster_web/live/editor_live/index.html.heex:1320
+#, elixir-autogen, elixir-format
+msgid "share.adv.open_edit"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:1312
+#: lib/typster_web/live/editor_live/index.html.heex:1322
+#, elixir-autogen, elixir-format
+msgid "share.adv.open_edit_sub"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:361
+#, elixir-autogen, elixir-format
+msgid "share.join.copy_of"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:147
+#: lib/typster_web/live/shared_project_live.ex:151
+#, elixir-autogen, elixir-format
+msgid "share.join.edit"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:127
+#: lib/typster_web/live/shared_project_live.ex:133
+#, elixir-autogen, elixir-format
+msgid "share.join.fork"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:186
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_cancel"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:189
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_confirm"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:315
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_failed"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_invalid_name"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_name"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:176
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_sub"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:175
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_title"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:302
+#, elixir-autogen, elixir-format
+msgid "share.join.forked"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:327
+#, elixir-autogen, elixir-format
+msgid "share.join.join_failed"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -35,7 +35,7 @@ msgstr ""
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:200
+#: lib/typster_web/live/editor_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr ""
@@ -134,122 +134,122 @@ msgstr ""
 msgid "confirmation.welcome"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:416
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:113
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:722
-#: lib/typster_web/live/editor_live/index.html.heex:723
+#: lib/typster_web/live/editor_live/index.html.heex:727
+#: lib/typster_web/live/editor_live/index.html.heex:728
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:223
-#: lib/typster_web/live/editor_live/index.html.heex:296
+#: lib/typster_web/live/editor_live/index.html.heex:228
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:713
+#: lib/typster_web/live/editor_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:710
+#: lib/typster_web/live/editor_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:414
+#: lib/typster_web/live/editor_live/index.ex:419
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:744
+#: lib/typster_web/live/editor_live/index.ex:747
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:571
-#: lib/typster_web/live/editor_live/index.ex:595
-#: lib/typster_web/live/editor_live/index.ex:887
+#: lib/typster_web/live/editor_live/index.ex:577
+#: lib/typster_web/live/editor_live/index.ex:601
+#: lib/typster_web/live/editor_live/index.ex:894
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:246
+#: lib/typster_web/live/editor_live/index.html.heex:251
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
+#: lib/typster_web/live/editor_live/index.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:738
-#: lib/typster_web/live/shared_project_live.ex:149
+#: lib/typster_web/live/editor_live/index.html.heex:743
+#: lib/typster_web/live/shared_project_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:821
+#: lib/typster_web/live/editor_live/index.ex:828
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:819
+#: lib/typster_web/live/editor_live/index.ex:826
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:820
+#: lib/typster_web/live/editor_live/index.ex:827
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:416
-#: lib/typster_web/live/editor_live/index.html.heex:445
+#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:182
+#: lib/typster_web/live/editor_live/index.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:188
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:142
+#: lib/typster_web/live/editor_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr ""
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr ""
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr ""
@@ -517,157 +517,157 @@ msgstr ""
 msgid "settings.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
-#: lib/typster_web/live/editor_live/index.html.heex:692
+#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:697
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:82
-#: lib/typster_web/live/editor_live/index.html.heex:688
+#: lib/typster_web/live/editor_live/index.html.heex:87
+#: lib/typster_web/live/editor_live/index.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:216
-#: lib/typster_web/live/editor_live/index.html.heex:217
+#: lib/typster_web/live/editor_live/index.html.heex:221
+#: lib/typster_web/live/editor_live/index.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
-#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:565
-#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
-#: lib/typster_web/live/editor_live/index.html.heex:613
+#: lib/typster_web/live/editor_live/index.html.heex:617
+#: lib/typster_web/live/editor_live/index.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
-#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:593
-#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:574
-#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:579
+#: lib/typster_web/live/editor_live/index.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:584
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:603
+#: lib/typster_web/live/editor_live/index.html.heex:607
+#: lib/typster_web/live/editor_live/index.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:924
-#: lib/typster_web/live/editor_live/index.html.heex:932
-#: lib/typster_web/live/editor_live/index.html.heex:941
+#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:937
+#: lib/typster_web/live/editor_live/index.html.heex:946
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:976
-#: lib/typster_web/live/editor_live/index.html.heex:984
-#: lib/typster_web/live/editor_live/index.html.heex:993
+#: lib/typster_web/live/editor_live/index.html.heex:1001
+#: lib/typster_web/live/editor_live/index.html.heex:1009
+#: lib/typster_web/live/editor_live/index.html.heex:1018
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:959
+#: lib/typster_web/live/editor_live/index.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:981
+#: lib/typster_web/live/editor_live/index.html.heex:1006
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:916
+#: lib/typster_web/live/editor_live/index.html.heex:921
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:925
-#: lib/typster_web/live/editor_live/index.html.heex:949
-#: lib/typster_web/live/editor_live/index.html.heex:955
+#: lib/typster_web/live/editor_live/index.html.heex:930
+#: lib/typster_web/live/editor_live/index.html.heex:954
+#: lib/typster_web/live/editor_live/index.html.heex:960
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:977
-#: lib/typster_web/live/editor_live/index.html.heex:996
-#: lib/typster_web/live/editor_live/index.html.heex:1005
+#: lib/typster_web/live/editor_live/index.html.heex:1002
+#: lib/typster_web/live/editor_live/index.html.heex:1021
+#: lib/typster_web/live/editor_live/index.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:683
+#: lib/typster_web/live/editor_live/index.html.heex:688
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:714
+#: lib/typster_web/live/editor_live/index.html.heex:719
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
-#: lib/typster_web/live/editor_live/index.html.heex:76
+#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:697
+#: lib/typster_web/live/editor_live/index.html.heex:702
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:706
+#: lib/typster_web/live/editor_live/index.html.heex:711
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:702
+#: lib/typster_web/live/editor_live/index.html.heex:707
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr ""
@@ -827,38 +827,38 @@ msgstr ""
 msgid "auth.oauth.soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:666
+#: lib/typster_web/live/editor_live/index.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:622
-#: lib/typster_web/live/editor_live/index.html.heex:623
+#: lib/typster_web/live/editor_live/index.html.heex:627
+#: lib/typster_web/live/editor_live/index.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr ""
@@ -1986,17 +1986,17 @@ msgstr ""
 msgid "editor.view.flat"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr ""
@@ -2006,67 +2006,67 @@ msgstr ""
 msgid "editor.view.smart"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:263
+#: lib/typster_web/live/editor_live/index.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:262
+#: lib/typster_web/live/editor_live/index.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:341
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:536
-#: lib/typster_web/live/editor_live/index.ex:582
-#: lib/typster_web/live/editor_live/index.ex:743
+#: lib/typster_web/live/editor_live/index.ex:542
+#: lib/typster_web/live/editor_live/index.ex:588
+#: lib/typster_web/live/editor_live/index.ex:746
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:57
+#: lib/typster_web/live/editor_live/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:680
+#: lib/typster_web/live/editor_live/index.ex:682
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:649
+#: lib/typster_web/live/editor_live/index.ex:655
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:478
-#: lib/typster_web/live/editor_live/index.html.heex:479
+#: lib/typster_web/live/editor_live/index.html.heex:483
+#: lib/typster_web/live/editor_live/index.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr ""
@@ -2082,7 +2082,7 @@ msgid "editor.tree.pin"
 msgstr ""
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr ""
@@ -2092,19 +2092,19 @@ msgstr ""
 msgid "editor.tree.unpin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr ""
@@ -2114,130 +2114,130 @@ msgstr ""
 msgid "editor.breadcrumb"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:530
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:837
+#: lib/typster_web/live/editor_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:482
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:497
+#: lib/typster_web/live/editor_live/index.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:467
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:472
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:888
+#: lib/typster_web/live/editor_live/index.ex:895
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1363
-#: lib/typster_web/live/editor_live/index.html.heex:681
-#: lib/typster_web/live/editor_live/index.html.heex:889
+#: lib/typster_web/live/editor_live/index.ex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1365
+#: lib/typster_web/live/editor_live/index.ex:1372
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1369
+#: lib/typster_web/live/editor_live/index.ex:1376
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:795
+#: lib/typster_web/live/editor_live/index.html.heex:800
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:801
+#: lib/typster_web/live/editor_live/index.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:777
+#: lib/typster_web/live/editor_live/index.html.heex:782
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:752
-#: lib/typster_web/live/editor_live/index.html.heex:891
+#: lib/typster_web/live/editor_live/index.html.heex:757
+#: lib/typster_web/live/editor_live/index.html.heex:896
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:809
+#: lib/typster_web/live/editor_live/index.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:822
+#: lib/typster_web/live/editor_live/index.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:761
+#: lib/typster_web/live/editor_live/index.html.heex:766
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:882
+#: lib/typster_web/live/editor_live/index.html.heex:887
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:782
+#: lib/typster_web/live/editor_live/index.html.heex:787
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:780
+#: lib/typster_web/live/editor_live/index.html.heex:785
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:942
+#: lib/typster_web/live/editor_live/index.ex:949
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:929
+#: lib/typster_web/live/editor_live/index.ex:936
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:163
+#: lib/typster_web/live/editor_live/index.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:179
+#: lib/typster_web/live/editor_live/index.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr ""
@@ -2247,12 +2247,12 @@ msgstr ""
 msgid "editor.topbar.back"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:124
+#: lib/typster_web/live/editor_live/index.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr ""
@@ -2262,17 +2262,17 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1014
+#: lib/typster_web/live/editor_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:152
+#: lib/typster_web/live/editor_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:60
+#: lib/typster_web/live/editor_live/index.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.omni_placeholder"
 msgstr ""
@@ -2282,268 +2282,268 @@ msgstr ""
 msgid "editor.topbar.switch_project"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:49
+#: lib/typster_web/live/editor_live/index.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.branch"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:861
+#: lib/typster_web/live/editor_live/index.html.heex:866
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1033
+#: lib/typster_web/live/editor_live/index.html.heex:1058
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1156
-#: lib/typster_web/live/editor_live/index.html.heex:1453
+#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1478
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1494
+#: lib/typster_web/live/editor_live/index.html.heex:1519
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1304
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1280
+#: lib/typster_web/live/editor_live/index.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1284
+#: lib/typster_web/live/editor_live/index.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1274
+#: lib/typster_web/live/editor_live/index.html.heex:1299
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1275
+#: lib/typster_web/live/editor_live/index.html.heex:1300
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1336
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1350
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1328
+#: lib/typster_web/live/editor_live/index.html.heex:1353
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1352
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1345
+#: lib/typster_web/live/editor_live/index.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1479
+#: lib/typster_web/live/editor_live/index.html.heex:1504
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1485
+#: lib/typster_web/live/editor_live/index.html.heex:1510
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1463
+#: lib/typster_web/live/editor_live/index.html.heex:1488
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1471
+#: lib/typster_web/live/editor_live/index.html.heex:1496
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:372
+#: lib/typster_web/live/editor_live/index.ex:376
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:369
+#: lib/typster_web/live/editor_live/index.ex:373
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1491
+#: lib/typster_web/live/editor_live/index.html.heex:1516
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1291
+#: lib/typster_web/live/editor_live/index.html.heex:1316
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1257
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1143
+#: lib/typster_web/live/editor_live/index.html.heex:1168
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1178
+#: lib/typster_web/live/editor_live/index.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1166
+#: lib/typster_web/live/editor_live/index.html.heex:1191
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1185
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.html.heex:1104
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1066
+#: lib/typster_web/live/editor_live/index.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1092
+#: lib/typster_web/live/editor_live/index.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1137
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1124
+#: lib/typster_web/live/editor_live/index.html.heex:1149
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1131
+#: lib/typster_web/live/editor_live/index.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1089
+#: lib/typster_web/live/editor_live/index.html.heex:1114
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1097
+#: lib/typster_web/live/editor_live/index.html.heex:1122
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1107
+#: lib/typster_web/live/editor_live/index.html.heex:1132
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1249
+#: lib/typster_web/live/editor_live/index.html.heex:1274
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1276
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1194
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1195
+#: lib/typster_web/live/editor_live/index.html.heex:1220
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1193
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1185
+#: lib/typster_web/live/editor_live/index.html.heex:1210
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1186
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1220
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1253
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1123
+#: lib/typster_web/live/editor_live/index.ex:1130
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1123
+#: lib/typster_web/live/editor_live/index.ex:1130
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr ""
@@ -2568,115 +2568,115 @@ msgstr ""
 msgid "share.public.invalid_title"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:171
+#: lib/typster_web/live/shared_project_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1128
-#: lib/typster_web/live/editor_live/index.html.heex:1085
+#: lib/typster_web/live/editor_live/index.ex:1135
+#: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1126
-#: lib/typster_web/live/editor_live/index.html.heex:1113
+#: lib/typster_web/live/editor_live/index.ex:1133
+#: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1127
-#: lib/typster_web/live/editor_live/index.html.heex:1086
+#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:193
+#: lib/typster_web/live/shared_project_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:192
+#: lib/typster_web/live/shared_project_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1306
+#: lib/typster_web/live/editor_live/index.html.heex:1331
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1302
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1298
+#: lib/typster_web/live/editor_live/index.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1025
+#: lib/typster_web/live/editor_live/index.html.heex:1050
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1046
+#: lib/typster_web/live/editor_live/index.html.heex:1071
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1047
+#: lib/typster_web/live/editor_live/index.html.heex:1072
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1045
+#: lib/typster_web/live/editor_live/index.html.heex:1070
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1044
+#: lib/typster_web/live/editor_live/index.html.heex:1069
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1023
+#: lib/typster_web/live/editor_live/index.html.heex:1048
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1224
+#: lib/typster_web/live/editor_live/index.ex:1231
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1340
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1270
+#: lib/typster_web/live/editor_live/index.html.heex:1295
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr ""
@@ -2691,68 +2691,68 @@ msgstr ""
 msgid "share.invite.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:156
+#: lib/typster_web/live/shared_project_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1369
+#: lib/typster_web/live/editor_live/index.html.heex:1394
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1396
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1395
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1356
+#: lib/typster_web/live/editor_live/index.html.heex:1381
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1407
-#: lib/typster_web/live/editor_live/index.html.heex:1417
+#: lib/typster_web/live/editor_live/index.html.heex:1432
+#: lib/typster_web/live/editor_live/index.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1363
+#: lib/typster_web/live/editor_live/index.html.heex:1388
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1377
+#: lib/typster_web/live/editor_live/index.html.heex:1402
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1383
+#: lib/typster_web/live/editor_live/index.html.heex:1408
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1385
+#: lib/typster_web/live/editor_live/index.html.heex:1410
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1384
+#: lib/typster_web/live/editor_live/index.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:1391
+#: lib/typster_web/live/editor_live/index.html.heex:1416
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1171
+#: lib/typster_web/live/editor_live/index.ex:1178
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr ""
@@ -2767,17 +2767,17 @@ msgstr ""
 msgid "share.invite.wrong_account"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "editor.share_owner_only"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:167
+#: lib/typster_web/live/shared_project_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:163
+#: lib/typster_web/live/shared_project_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr ""
@@ -2787,17 +2787,17 @@ msgstr ""
 msgid "share.scope.sandbox"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1055
+#: lib/typster_web/live/editor_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1057
+#: lib/typster_web/live/editor_live/index.ex:1064
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1056
+#: lib/typster_web/live/editor_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr ""
@@ -2835,4 +2835,55 @@ msgstr ""
 #: lib/typster_web/controllers/error_html/not_found.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "error.not_found.title"
+msgstr ""
+
+#: lib/typster_web/live/editor_live/index.html.heex:983
+#, elixir-autogen, elixir-format
+msgid "editor.palette.headings"
+msgstr ""
+
+#: lib/typster_web/controllers/user_session_controller.ex:8
+#, elixir-autogen, elixir-format
+msgid "auth.flash.confirmed"
+msgstr ""
+
+#: lib/typster_web/controllers/user_session_controller.ex:61
+#, elixir-autogen, elixir-format
+msgid "auth.flash.invalid_credentials"
+msgstr ""
+
+#: lib/typster_web/controllers/user_session_controller.ex:27
+#, elixir-autogen, elixir-format
+msgid "auth.flash.link_invalid"
+msgstr ""
+
+#: lib/typster_web/controllers/user_session_controller.ex:82
+#, elixir-autogen, elixir-format
+msgid "auth.flash.logged_out"
+msgstr ""
+
+#: lib/typster_web/user_auth.ex:261
+#: lib/typster_web/user_auth.ex:310
+#, elixir-autogen, elixir-format
+msgid "auth.flash.login_required"
+msgstr ""
+
+#: lib/typster_web/controllers/user_session_controller.ex:45
+#, elixir-autogen, elixir-format
+msgid "auth.flash.magic_link_sent"
+msgstr ""
+
+#: lib/typster_web/controllers/user_session_controller.ex:77
+#, elixir-autogen, elixir-format
+msgid "auth.flash.password_updated"
+msgstr ""
+
+#: lib/typster_web/user_auth.ex:276
+#, elixir-autogen, elixir-format
+msgid "auth.flash.reauth_required"
+msgstr ""
+
+#: lib/typster_web/controllers/user_session_controller.ex:12
+#, elixir-autogen, elixir-format
+msgid "auth.flash.welcome_back"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -178,7 +178,7 @@ msgstr ""
 
 #: lib/typster_web/live/editor_live/index.ex:577
 #: lib/typster_web/live/editor_live/index.ex:603
-#: lib/typster_web/live/editor_live/index.ex:909
+#: lib/typster_web/live/editor_live/index.ex:898
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr ""
@@ -209,17 +209,17 @@ msgstr ""
 msgid "editor.preview_placeholder"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:843
+#: lib/typster_web/live/editor_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:841
+#: lib/typster_web/live/editor_live/index.ex:830
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:842
+#: lib/typster_web/live/editor_live/index.ex:831
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr ""
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "editor.tab.close"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:859
+#: lib/typster_web/live/editor_live/index.ex:848
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr ""
@@ -2145,12 +2145,12 @@ msgstr ""
 msgid "editor.tpl.use"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:910
+#: lib/typster_web/live/editor_live/index.ex:899
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1385
+#: lib/typster_web/live/editor_live/index.ex:1374
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1387
+#: lib/typster_web/live/editor_live/index.ex:1376
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/typster_web/live/editor_live/index.ex:1391
+#: lib/typster_web/live/editor_live/index.ex:1380
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr ""
@@ -2222,12 +2222,12 @@ msgstr ""
 msgid "editor.drawer.recompile"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:964
+#: lib/typster_web/live/editor_live/index.ex:953
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:951
+#: lib/typster_web/live/editor_live/index.ex:940
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr ""
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "editor.topbar.forward"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1036
+#: lib/typster_web/live/editor_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr ""
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "share.people.invite_hint"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1152
+#: lib/typster_web/live/editor_live/index.ex:1141
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr ""
@@ -2538,12 +2538,12 @@ msgstr ""
 msgid "share.perm.write_desc"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1145
+#: lib/typster_web/live/editor_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1145
+#: lib/typster_web/live/editor_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr ""
@@ -2573,19 +2573,19 @@ msgstr ""
 msgid "share.public.open_in_typster"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1150
+#: lib/typster_web/live/editor_live/index.ex:1139
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1148
+#: lib/typster_web/live/editor_live/index.ex:1137
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1138
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
@@ -2651,7 +2651,7 @@ msgstr ""
 msgid "share.title"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1246
+#: lib/typster_web/live/editor_live/index.ex:1235
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr ""
@@ -2752,7 +2752,7 @@ msgstr ""
 msgid "share.embed.width"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1193
+#: lib/typster_web/live/editor_live/index.ex:1182
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr ""
@@ -2787,17 +2787,17 @@ msgstr ""
 msgid "share.scope.sandbox"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1077
+#: lib/typster_web/live/editor_live/index.ex:1066
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1079
+#: lib/typster_web/live/editor_live/index.ex:1068
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:1078
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr ""
@@ -2888,27 +2888,7 @@ msgstr ""
 msgid "auth.flash.welcome_back"
 msgstr ""
 
-#: lib/typster_web/live/editor_live/index.ex:783
+#: lib/typster_web/live/editor_live/index.ex:773
 #, elixir-autogen, elixir-format
-msgid "editor.starter.body"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.ex:779
-#, elixir-autogen, elixir-format
-msgid "editor.starter.heading"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.ex:781
-#, elixir-autogen, elixir-format
-msgid "editor.starter.intro"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.ex:785
-#, elixir-autogen, elixir-format
-msgid "editor.starter.point1"
-msgstr ""
-
-#: lib/typster_web/live/editor_live/index.ex:786
-#, elixir-autogen, elixir-format
-msgid "editor.starter.point2"
+msgid "editor.starter.doc"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -156,12 +156,12 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:715
+#: lib/typster_web/live/editor_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:712
+#: lib/typster_web/live/editor_live/index.ex:714
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
@@ -171,14 +171,14 @@ msgstr "Asset is in."
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:747
+#: lib/typster_web/live/editor_live/index.ex:749
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
 #: lib/typster_web/live/editor_live/index.ex:577
-#: lib/typster_web/live/editor_live/index.ex:601
-#: lib/typster_web/live/editor_live/index.ex:894
+#: lib/typster_web/live/editor_live/index.ex:603
+#: lib/typster_web/live/editor_live/index.ex:909
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -209,17 +209,17 @@ msgstr "Preview"
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:828
+#: lib/typster_web/live/editor_live/index.ex:843
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:826
+#: lib/typster_web/live/editor_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:827
+#: lib/typster_web/live/editor_live/index.ex:842
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -2039,7 +2039,7 @@ msgstr "filename"
 
 #: lib/typster_web/live/editor_live/index.ex:542
 #: lib/typster_web/live/editor_live/index.ex:588
-#: lib/typster_web/live/editor_live/index.ex:746
+#: lib/typster_web/live/editor_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,12 +2049,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:682
+#: lib/typster_web/live/editor_live/index.ex:684
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:655
+#: lib/typster_web/live/editor_live/index.ex:657
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2119,7 +2119,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:844
+#: lib/typster_web/live/editor_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2145,12 +2145,12 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:895
+#: lib/typster_web/live/editor_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1370
+#: lib/typster_web/live/editor_live/index.ex:1385
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1372
+#: lib/typster_web/live/editor_live/index.ex:1387
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] "%{count} warning"
 msgstr[1] "%{count} warnings"
 
-#: lib/typster_web/live/editor_live/index.ex:1376
+#: lib/typster_web/live/editor_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2222,12 +2222,12 @@ msgstr "Off"
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:949
+#: lib/typster_web/live/editor_live/index.ex:964
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:936
+#: lib/typster_web/live/editor_live/index.ex:951
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
@@ -2262,7 +2262,7 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:1021
+#: lib/typster_web/live/editor_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
@@ -2458,7 +2458,7 @@ msgstr "Invite people"
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
 
-#: lib/typster_web/live/editor_live/index.ex:1137
+#: lib/typster_web/live/editor_live/index.ex:1152
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
@@ -2538,12 +2538,12 @@ msgstr "Write — specific files"
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2573,19 +2573,19 @@ msgstr "This link isn't valid"
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1135
+#: lib/typster_web/live/editor_live/index.ex:1150
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
-#: lib/typster_web/live/editor_live/index.ex:1133
+#: lib/typster_web/live/editor_live/index.ex:1148
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
@@ -2651,7 +2651,7 @@ msgstr "People"
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1231
+#: lib/typster_web/live/editor_live/index.ex:1246
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
@@ -2752,7 +2752,7 @@ msgstr "Light"
 msgid "share.embed.width"
 msgstr "Width"
 
-#: lib/typster_web/live/editor_live/index.ex:1178
+#: lib/typster_web/live/editor_live/index.ex:1193
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// soon™ — still cooking 🍳  grab the iframe for now"
@@ -2787,17 +2787,17 @@ msgstr "Make your own"
 msgid "share.scope.sandbox"
 msgstr "Sandbox"
 
-#: lib/typster_web/live/editor_live/index.ex:1062
+#: lib/typster_web/live/editor_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Link analytics"
 
-#: lib/typster_web/live/editor_live/index.ex:1064
+#: lib/typster_web/live/editor_live/index.ex:1079
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "this week"
 
-#: lib/typster_web/live/editor_live/index.ex:1063
+#: lib/typster_web/live/editor_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "opens"
@@ -2890,3 +2890,28 @@ msgstr "You must re-authenticate to access this page."
 #, elixir-autogen, elixir-format
 msgid "auth.flash.welcome_back"
 msgstr "Welcome back!"
+
+#: lib/typster_web/live/editor_live/index.ex:783
+#, elixir-autogen, elixir-format
+msgid "editor.starter.body"
+msgstr "Mix *bold*, _italic_, and `raw` text, or flex a little math: $E = m c^2$. Headings, lists, and figures all just work:"
+
+#: lib/typster_web/live/editor_live/index.ex:779
+#, elixir-autogen, elixir-format
+msgid "editor.starter.heading"
+msgstr "Introduction"
+
+#: lib/typster_web/live/editor_live/index.ex:781
+#, elixir-autogen, elixir-format
+msgid "editor.starter.intro"
+msgstr "Welcome to Typster. Your document compiles live — no `latexmk`, no waiting."
+
+#: lib/typster_web/live/editor_live/index.ex:785
+#, elixir-autogen, elixir-format
+msgid "editor.starter.point1"
+msgstr "Start typing here"
+
+#: lib/typster_web/live/editor_live/index.ex:786
+#, elixir-autogen, elixir-format
+msgid "editor.starter.point2"
+msgstr "Delete this once you have real thoughts"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:717
+#: lib/typster_web/live/editor_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:714
+#: lib/typster_web/live/editor_live/index.ex:735
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:419
+#: lib/typster_web/live/editor_live/index.ex:440
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:749
+#: lib/typster_web/live/editor_live/index.ex:770
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:577
-#: lib/typster_web/live/editor_live/index.ex:603
-#: lib/typster_web/live/editor_live/index.ex:898
+#: lib/typster_web/live/editor_live/index.ex:598
+#: lib/typster_web/live/editor_live/index.ex:624
+#: lib/typster_web/live/editor_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr "Preview"
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:151
+#: lib/typster_web/live/shared_project_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:832
+#: lib/typster_web/live/editor_live/index.ex:847
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:830
+#: lib/typster_web/live/editor_live/index.ex:845
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:831
+#: lib/typster_web/live/editor_live/index.ex:846
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -2037,9 +2037,9 @@ msgstr "Appended when you press Enter"
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:542
-#: lib/typster_web/live/editor_live/index.ex:588
-#: lib/typster_web/live/editor_live/index.ex:748
+#: lib/typster_web/live/editor_live/index.ex:563
+#: lib/typster_web/live/editor_live/index.ex:609
+#: lib/typster_web/live/editor_live/index.ex:769
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,12 +2049,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:684
+#: lib/typster_web/live/editor_live/index.ex:705
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:657
+#: lib/typster_web/live/editor_live/index.ex:678
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2119,7 +2119,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:848
+#: lib/typster_web/live/editor_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2145,12 +2145,12 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:899
+#: lib/typster_web/live/editor_live/index.ex:914
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1374
+#: lib/typster_web/live/editor_live/index.ex:1389
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1376
+#: lib/typster_web/live/editor_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] "%{count} warning"
 msgstr[1] "%{count} warnings"
 
-#: lib/typster_web/live/editor_live/index.ex:1380
+#: lib/typster_web/live/editor_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2222,12 +2222,12 @@ msgstr "Off"
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:953
+#: lib/typster_web/live/editor_live/index.ex:968
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:940
+#: lib/typster_web/live/editor_live/index.ex:955
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
@@ -2262,7 +2262,7 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:1025
+#: lib/typster_web/live/editor_live/index.ex:1040
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
@@ -2298,12 +2298,12 @@ msgid "common.close"
 msgstr "Close"
 
 #: lib/typster_web/live/editor_live/index.html.heex:1181
-#: lib/typster_web/live/editor_live/index.html.heex:1478
+#: lib/typster_web/live/editor_live/index.html.heex:1512
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Copy"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1519
+#: lib/typster_web/live/editor_live/index.html.heex:1553
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Done"
@@ -2318,102 +2318,102 @@ msgstr "Allow downloads"
 msgid "share.adv.download_sub"
 msgstr "Visitors can download the compiled PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1304
+#: lib/typster_web/live/editor_live/index.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Expires in 30 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1305
+#: lib/typster_web/live/editor_live/index.html.heex:1339
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Auto-revokes the link after the set period."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1342
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Password-protect"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1309
+#: lib/typster_web/live/editor_live/index.html.heex:1343
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Visitor must enter a passphrase before opening."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1299
+#: lib/typster_web/live/editor_live/index.html.heex:1333
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Require sign-in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1300
+#: lib/typster_web/live/editor_live/index.html.heex:1334
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Visitors must sign in with a Typster account."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1361
+#: lib/typster_web/live/editor_live/index.html.heex:1395
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Components"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1375
+#: lib/typster_web/live/editor_live/index.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Visitor can edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1365
+#: lib/typster_web/live/editor_live/index.html.heex:1399
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "File tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1353
+#: lib/typster_web/live/editor_live/index.html.heex:1387
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Visitors can read & open your project on any plan. Upgrade to let them edit live in their browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1352
+#: lib/typster_web/live/editor_live/index.html.heex:1386
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Embed is free — interactive sandbox is Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1404
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Compiled preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1504
+#: lib/typster_web/live/editor_live/index.html.heex:1538
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Download PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1510
+#: lib/typster_web/live/editor_live/index.html.heex:1544
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Exports the document compiled in your browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1488
+#: lib/typster_web/live/editor_live/index.html.heex:1522
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Last successful compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1496
+#: lib/typster_web/live/editor_live/index.html.heex:1530
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Includes embedded fonts. Re-export to refresh."
 
-#: lib/typster_web/live/editor_live/index.ex:376
+#: lib/typster_web/live/editor_live/index.ex:397
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Could not send that invite."
 
-#: lib/typster_web/live/editor_live/index.ex:373
+#: lib/typster_web/live/editor_live/index.ex:394
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Invited %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1516
+#: lib/typster_web/live/editor_live/index.html.heex:1550
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "Learn about permissions →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1350
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Link activity"
@@ -2458,7 +2458,7 @@ msgstr "Invite people"
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
 
-#: lib/typster_web/live/editor_live/index.ex:1141
+#: lib/typster_web/live/editor_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
@@ -2538,17 +2538,17 @@ msgstr "Write — specific files"
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
 
-#: lib/typster_web/live/shared_project_live.ex:80
+#: lib/typster_web/live/shared_project_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr "Go to Typster"
@@ -2558,65 +2558,65 @@ msgstr "Go to Typster"
 msgid "share.public.invalid"
 msgstr "Invalid link"
 
-#: lib/typster_web/live/shared_project_live.ex:79
+#: lib/typster_web/live/shared_project_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr "The share link may have been rotated or revoked."
 
-#: lib/typster_web/live/shared_project_live.ex:78
+#: lib/typster_web/live/shared_project_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr "This link isn't valid"
 
-#: lib/typster_web/live/shared_project_live.ex:173
+#: lib/typster_web/live/shared_project_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1139
+#: lib/typster_web/live/editor_live/index.ex:1154
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
-#: lib/typster_web/live/editor_live/index.ex:1137
+#: lib/typster_web/live/editor_live/index.ex:1152
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
-#: lib/typster_web/live/editor_live/index.ex:1138
+#: lib/typster_web/live/editor_live/index.ex:1153
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Viewer"
 
-#: lib/typster_web/live/shared_project_live.ex:195
+#: lib/typster_web/live/shared_project_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Compiled output"
 
-#: lib/typster_web/live/shared_project_live.ex:196
+#: lib/typster_web/live/shared_project_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Read-only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1331
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Link created"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Active editors now"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1323
+#: lib/typster_web/live/editor_live/index.html.heex:1357
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Opens last 7 days"
@@ -2651,22 +2651,22 @@ msgstr "People"
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1235
+#: lib/typster_web/live/editor_live/index.ex:1250
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1341
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Real-time opens, active editors, and locations — with Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "See who opens your link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1295
+#: lib/typster_web/live/editor_live/index.html.heex:1329
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Unlock with Pro"
@@ -2691,68 +2691,68 @@ msgstr "You're in — welcome to the project."
 msgid "share.invite.invalid"
 msgstr "That invite link is invalid or has expired."
 
-#: lib/typster_web/live/shared_project_live.ex:158
+#: lib/typster_web/live/shared_project_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Powered by"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1394
+#: lib/typster_web/live/editor_live/index.html.heex:1428
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr "Always"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1396
+#: lib/typster_web/live/editor_live/index.html.heex:1430
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr "Hidden"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1395
+#: lib/typster_web/live/editor_live/index.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr "On edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1381
+#: lib/typster_web/live/editor_live/index.html.heex:1415
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr "Hide Typster footer"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1432
-#: lib/typster_web/live/editor_live/index.html.heex:1442
+#: lib/typster_web/live/editor_live/index.html.heex:1466
+#: lib/typster_web/live/editor_live/index.html.heex:1476
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr "Live preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1388
+#: lib/typster_web/live/editor_live/index.html.heex:1422
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr "Save CTA"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1402
+#: lib/typster_web/live/editor_live/index.html.heex:1436
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr "Theme"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1408
+#: lib/typster_web/live/editor_live/index.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr "Auto"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1410
+#: lib/typster_web/live/editor_live/index.html.heex:1444
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr "Dark"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1409
+#: lib/typster_web/live/editor_live/index.html.heex:1443
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr "Light"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1416
+#: lib/typster_web/live/editor_live/index.html.heex:1450
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr "Width"
 
-#: lib/typster_web/live/editor_live/index.ex:1182
+#: lib/typster_web/live/editor_live/index.ex:1197
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// soon™ — still cooking 🍳  grab the iframe for now"
@@ -2772,32 +2772,32 @@ msgstr "Plot twist — this invite's addressed to a different email. Log in as t
 msgid "editor.share_owner_only"
 msgstr "Owner-only — sharing is their call."
 
-#: lib/typster_web/live/shared_project_live.ex:169
+#: lib/typster_web/live/shared_project_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr "Fork in Typster"
 
-#: lib/typster_web/live/shared_project_live.ex:165
+#: lib/typster_web/live/shared_project_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr "Make your own"
 
-#: lib/typster_web/live/shared_project_live.ex:107
+#: lib/typster_web/live/shared_project_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr "Sandbox"
 
-#: lib/typster_web/live/editor_live/index.ex:1066
+#: lib/typster_web/live/editor_live/index.ex:1081
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Link analytics"
 
-#: lib/typster_web/live/editor_live/index.ex:1068
+#: lib/typster_web/live/editor_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "this week"
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1082
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "opens"
@@ -2891,7 +2891,7 @@ msgstr "You must re-authenticate to access this page."
 msgid "auth.flash.welcome_back"
 msgstr "Welcome back!"
 
-#: lib/typster_web/live/editor_live/index.ex:773
+#: lib/typster_web/live/editor_live/index.ex:788
 #, elixir-autogen, elixir-format
 msgid "editor.starter.doc"
 msgstr ""
@@ -2903,3 +2903,87 @@ msgstr ""
 "\n"
 "- Start typing here\n"
 "- Delete this once you have real thoughts\n"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1299
+#, elixir-autogen, elixir-format
+msgid "share.adv.fork"
+msgstr "Anyone can copy"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1300
+#, elixir-autogen, elixir-format
+msgid "share.adv.fork_sub"
+msgstr "Visitors get a \"Make a copy\" button — the fork lands in their account, your original stays untouched."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1311
+#: lib/typster_web/live/editor_live/index.html.heex:1320
+#, elixir-autogen, elixir-format
+msgid "share.adv.open_edit"
+msgstr "Anyone can edit"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1312
+#: lib/typster_web/live/editor_live/index.html.heex:1322
+#, elixir-autogen, elixir-format
+msgid "share.adv.open_edit_sub"
+msgstr "Visitors with the link join as editors automatically. Big trust energy — enable with intent."
+
+#: lib/typster_web/live/shared_project_live.ex:361
+#, elixir-autogen, elixir-format
+msgid "share.join.copy_of"
+msgstr "%{name} (copy)"
+
+#: lib/typster_web/live/shared_project_live.ex:147
+#: lib/typster_web/live/shared_project_live.ex:151
+#, elixir-autogen, elixir-format
+msgid "share.join.edit"
+msgstr "Edit this project"
+
+#: lib/typster_web/live/shared_project_live.ex:127
+#: lib/typster_web/live/shared_project_live.ex:133
+#, elixir-autogen, elixir-format
+msgid "share.join.fork"
+msgstr "Make a copy"
+
+#: lib/typster_web/live/shared_project_live.ex:186
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_cancel"
+msgstr "Cancel"
+
+#: lib/typster_web/live/shared_project_live.ex:189
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_confirm"
+msgstr "Copy it"
+
+#: lib/typster_web/live/shared_project_live.ex:315
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_failed"
+msgstr "Copying didn't go through. Try again in a moment."
+
+#: lib/typster_web/live/shared_project_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_invalid_name"
+msgstr "That name won't fly — give your copy a proper one."
+
+#: lib/typster_web/live/shared_project_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_name"
+msgstr "Name your copy"
+
+#: lib/typster_web/live/shared_project_live.ex:176
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_sub"
+msgstr "The whole project — files, assets, the lot — lands in your account as your own copy."
+
+#: lib/typster_web/live/shared_project_live.ex:175
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_title"
+msgstr "Copy this project"
+
+#: lib/typster_web/live/shared_project_live.ex:302
+#, elixir-autogen, elixir-format
+msgid "share.join.forked"
+msgstr "%{name} is yours now — happy typesetting."
+
+#: lib/typster_web/live/shared_project_live.ex:327
+#, elixir-autogen, elixir-format
+msgid "share.join.join_failed"
+msgstr "Couldn't add you to the project — the link's policy may have changed."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Download"
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:738
+#: lib/typster_web/live/editor_live/index.ex:755
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:735
+#: lib/typster_web/live/editor_live/index.ex:752
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:440
+#: lib/typster_web/live/editor_live/index.ex:457
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:770
+#: lib/typster_web/live/editor_live/index.ex:787
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:598
-#: lib/typster_web/live/editor_live/index.ex:624
-#: lib/typster_web/live/editor_live/index.ex:913
+#: lib/typster_web/live/editor_live/index.ex:615
+#: lib/typster_web/live/editor_live/index.ex:641
+#: lib/typster_web/live/editor_live/index.ex:930
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr "Preview"
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:236
+#: lib/typster_web/live/shared_project_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:847
+#: lib/typster_web/live/editor_live/index.ex:864
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:845
+#: lib/typster_web/live/editor_live/index.ex:862
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:846
+#: lib/typster_web/live/editor_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -2037,9 +2037,9 @@ msgstr "Appended when you press Enter"
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:563
-#: lib/typster_web/live/editor_live/index.ex:609
-#: lib/typster_web/live/editor_live/index.ex:769
+#: lib/typster_web/live/editor_live/index.ex:580
+#: lib/typster_web/live/editor_live/index.ex:626
+#: lib/typster_web/live/editor_live/index.ex:786
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
@@ -2049,12 +2049,12 @@ msgstr "A file with that path already exists — pick another name."
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:705
+#: lib/typster_web/live/editor_live/index.ex:722
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:678
+#: lib/typster_web/live/editor_live/index.ex:695
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
@@ -2119,7 +2119,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:863
+#: lib/typster_web/live/editor_live/index.ex:880
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2145,12 +2145,12 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:914
+#: lib/typster_web/live/editor_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1389
+#: lib/typster_web/live/editor_live/index.ex:1406
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1391
+#: lib/typster_web/live/editor_live/index.ex:1408
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] "%{count} warning"
 msgstr[1] "%{count} warnings"
 
-#: lib/typster_web/live/editor_live/index.ex:1395
+#: lib/typster_web/live/editor_live/index.ex:1412
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2222,12 +2222,12 @@ msgstr "Off"
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:968
+#: lib/typster_web/live/editor_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:955
+#: lib/typster_web/live/editor_live/index.ex:972
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
@@ -2262,7 +2262,7 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:1040
+#: lib/typster_web/live/editor_live/index.ex:1057
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
@@ -2398,12 +2398,12 @@ msgstr "Last successful compile"
 msgid "share.export.meta"
 msgstr "Includes embedded fonts. Re-export to refresh."
 
-#: lib/typster_web/live/editor_live/index.ex:397
+#: lib/typster_web/live/editor_live/index.ex:414
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Could not send that invite."
 
-#: lib/typster_web/live/editor_live/index.ex:394
+#: lib/typster_web/live/editor_live/index.ex:411
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Invited %{email}"
@@ -2458,7 +2458,7 @@ msgstr "Invite people"
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
 
-#: lib/typster_web/live/editor_live/index.ex:1156
+#: lib/typster_web/live/editor_live/index.ex:1173
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
@@ -2538,17 +2538,17 @@ msgstr "Write — specific files"
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
 
-#: lib/typster_web/live/shared_project_live.ex:96
+#: lib/typster_web/live/shared_project_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr "Go to Typster"
@@ -2558,50 +2558,50 @@ msgstr "Go to Typster"
 msgid "share.public.invalid"
 msgstr "Invalid link"
 
-#: lib/typster_web/live/shared_project_live.ex:95
+#: lib/typster_web/live/shared_project_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr "The share link may have been rotated or revoked."
 
-#: lib/typster_web/live/shared_project_live.ex:94
+#: lib/typster_web/live/shared_project_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr "This link isn't valid"
 
-#: lib/typster_web/live/shared_project_live.ex:277
+#: lib/typster_web/live/shared_project_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1154
+#: lib/typster_web/live/editor_live/index.ex:1171
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
-#: lib/typster_web/live/editor_live/index.ex:1152
+#: lib/typster_web/live/editor_live/index.ex:1169
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
-#: lib/typster_web/live/editor_live/index.ex:1153
+#: lib/typster_web/live/editor_live/index.ex:1170
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Viewer"
 
-#: lib/typster_web/live/shared_project_live.ex:344
+#: lib/typster_web/live/shared_project_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/shared_project_live.ex:343
+#: lib/typster_web/live/shared_project_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Compiled output"
 
-#: lib/typster_web/live/shared_project_live.ex:345
+#: lib/typster_web/live/shared_project_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Read-only"
@@ -2651,7 +2651,7 @@ msgstr "People"
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1250
+#: lib/typster_web/live/editor_live/index.ex:1267
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
@@ -2691,7 +2691,7 @@ msgstr "You're in — welcome to the project."
 msgid "share.invite.invalid"
 msgstr "That invite link is invalid or has expired."
 
-#: lib/typster_web/live/shared_project_live.ex:243
+#: lib/typster_web/live/shared_project_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Powered by"
@@ -2752,7 +2752,7 @@ msgstr "Light"
 msgid "share.embed.width"
 msgstr "Width"
 
-#: lib/typster_web/live/editor_live/index.ex:1197
+#: lib/typster_web/live/editor_live/index.ex:1214
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// soon™ — still cooking 🍳  grab the iframe for now"
@@ -2772,32 +2772,32 @@ msgstr "Plot twist — this invite's addressed to a different email. Log in as t
 msgid "editor.share_owner_only"
 msgstr "Owner-only — sharing is their call."
 
-#: lib/typster_web/live/shared_project_live.ex:268
+#: lib/typster_web/live/shared_project_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr "Fork in Typster"
 
-#: lib/typster_web/live/shared_project_live.ex:259
+#: lib/typster_web/live/shared_project_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr "Make your own"
 
-#: lib/typster_web/live/shared_project_live.ex:159
+#: lib/typster_web/live/shared_project_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr "Sandbox"
 
-#: lib/typster_web/live/editor_live/index.ex:1081
+#: lib/typster_web/live/editor_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Link analytics"
 
-#: lib/typster_web/live/editor_live/index.ex:1083
+#: lib/typster_web/live/editor_live/index.ex:1100
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "this week"
 
-#: lib/typster_web/live/editor_live/index.ex:1082
+#: lib/typster_web/live/editor_live/index.ex:1099
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "opens"
@@ -2891,7 +2891,7 @@ msgstr "You must re-authenticate to access this page."
 msgid "auth.flash.welcome_back"
 msgstr "Welcome back!"
 
-#: lib/typster_web/live/editor_live/index.ex:788
+#: lib/typster_web/live/editor_live/index.ex:805
 #, elixir-autogen, elixir-format
 msgid "editor.starter.doc"
 msgstr ""
@@ -2926,64 +2926,69 @@ msgstr "Anyone can edit"
 msgid "share.adv.open_edit_sub"
 msgstr "Visitors with the link join as editors automatically. Big trust energy — enable with intent."
 
-#: lib/typster_web/live/shared_project_live.ex:361
+#: lib/typster_web/live/shared_project_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "share.join.copy_of"
 msgstr "%{name} (copy)"
 
-#: lib/typster_web/live/shared_project_live.ex:147
 #: lib/typster_web/live/shared_project_live.ex:151
+#: lib/typster_web/live/shared_project_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "share.join.edit"
 msgstr "Edit this project"
 
-#: lib/typster_web/live/shared_project_live.ex:127
-#: lib/typster_web/live/shared_project_live.ex:133
+#: lib/typster_web/live/shared_project_live.ex:131
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.join.fork"
 msgstr "Make a copy"
 
-#: lib/typster_web/live/shared_project_live.ex:186
+#: lib/typster_web/live/shared_project_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_cancel"
 msgstr "Cancel"
 
-#: lib/typster_web/live/shared_project_live.ex:189
+#: lib/typster_web/live/shared_project_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_confirm"
 msgstr "Copy it"
 
-#: lib/typster_web/live/shared_project_live.ex:315
+#: lib/typster_web/live/shared_project_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_failed"
 msgstr "Copying didn't go through. Try again in a moment."
 
-#: lib/typster_web/live/shared_project_live.ex:309
+#: lib/typster_web/live/shared_project_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_invalid_name"
 msgstr "That name won't fly — give your copy a proper one."
 
-#: lib/typster_web/live/shared_project_live.ex:181
+#: lib/typster_web/live/shared_project_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_name"
 msgstr "Name your copy"
 
-#: lib/typster_web/live/shared_project_live.ex:176
+#: lib/typster_web/live/shared_project_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_sub"
 msgstr "The whole project — files, assets, the lot — lands in your account as your own copy."
 
-#: lib/typster_web/live/shared_project_live.ex:175
+#: lib/typster_web/live/shared_project_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_title"
 msgstr "Copy this project"
 
-#: lib/typster_web/live/shared_project_live.ex:302
+#: lib/typster_web/live/shared_project_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "share.join.forked"
 msgstr "%{name} is yours now — happy typesetting."
 
-#: lib/typster_web/live/shared_project_live.ex:327
+#: lib/typster_web/live/shared_project_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "share.join.join_failed"
 msgstr "Couldn't add you to the project — the link's policy may have changed."
+
+#: lib/typster_web/live/editor_live/index.ex:26
+#, elixir-autogen, elixir-format
+msgid "editor.project_unavailable"
+msgstr "That project isn't here — or isn't yours to edit."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr "Log in"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:200
+#: lib/typster_web/live/editor_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Log out"
@@ -134,122 +134,122 @@ msgstr "After confirmation, password login can be enabled in settings."
 msgid "confirmation.welcome"
 msgstr "Welcome back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:416
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Assets"
 
-#: lib/typster_web/live/editor_live/index.html.heex:113
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:722
-#: lib/typster_web/live/editor_live/index.html.heex:723
+#: lib/typster_web/live/editor_live/index.html.heex:727
+#: lib/typster_web/live/editor_live/index.html.heex:728
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Download"
 
-#: lib/typster_web/live/editor_live/index.html.heex:223
-#: lib/typster_web/live/editor_live/index.html.heex:296
+#: lib/typster_web/live/editor_live/index.html.heex:228
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.ex:713
+#: lib/typster_web/live/editor_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Asset upload failed."
 
-#: lib/typster_web/live/editor_live/index.ex:710
+#: lib/typster_web/live/editor_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Asset is in."
 
-#: lib/typster_web/live/editor_live/index.ex:414
+#: lib/typster_web/live/editor_live/index.ex:419
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Binary assets cannot be opened in the editor."
 
-#: lib/typster_web/live/editor_live/index.ex:744
+#: lib/typster_web/live/editor_live/index.ex:747
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "File could not be created."
 
-#: lib/typster_web/live/editor_live/index.ex:571
-#: lib/typster_web/live/editor_live/index.ex:595
-#: lib/typster_web/live/editor_live/index.ex:887
+#: lib/typster_web/live/editor_live/index.ex:577
+#: lib/typster_web/live/editor_live/index.ex:601
+#: lib/typster_web/live/editor_live/index.ex:894
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
 
-#: lib/typster_web/live/editor_live/index.html.heex:246
+#: lib/typster_web/live/editor_live/index.html.heex:251
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
+#: lib/typster_web/live/editor_live/index.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "No file selected"
 
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "No files yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:738
-#: lib/typster_web/live/shared_project_live.ex:149
+#: lib/typster_web/live/editor_live/index.html.heex:743
+#: lib/typster_web/live/shared_project_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:821
+#: lib/typster_web/live/editor_live/index.ex:828
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:819
+#: lib/typster_web/live/editor_live/index.ex:826
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:820
+#: lib/typster_web/live/editor_live/index.ex:827
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
 
-#: lib/typster_web/live/editor_live/index.html.heex:416
-#: lib/typster_web/live/editor_live/index.html.heex:445
+#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Upload asset"
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Dark theme"
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:182
+#: lib/typster_web/live/editor_live/index.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Light theme"
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:188
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Use system theme"
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:142
+#: lib/typster_web/live/editor_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Toggle theme"
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr "My projects"
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Projects"
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Settings"
@@ -517,157 +517,157 @@ msgstr "Keep email and password tidy. Future You will appreciate it!"
 msgid "settings.title"
 msgstr "Account settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
-#: lib/typster_web/live/editor_live/index.html.heex:692
+#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:697
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Compiled"
 
-#: lib/typster_web/live/editor_live/index.html.heex:82
-#: lib/typster_web/live/editor_live/index.html.heex:688
+#: lib/typster_web/live/editor_live/index.html.heex:87
+#: lib/typster_web/live/editor_live/index.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Compiling…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:216
-#: lib/typster_web/live/editor_live/index.html.heex:217
+#: lib/typster_web/live/editor_live/index.html.heex:221
+#: lib/typster_web/live/editor_live/index.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Find in project…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
-#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Bold"
 
-#: lib/typster_web/live/editor_live/index.html.heex:565
-#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Heading"
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
-#: lib/typster_web/live/editor_live/index.html.heex:613
+#: lib/typster_web/live/editor_live/index.html.heex:617
+#: lib/typster_web/live/editor_live/index.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Image"
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
-#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Italic"
 
-#: lib/typster_web/live/editor_live/index.html.heex:593
-#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:574
-#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:579
+#: lib/typster_web/live/editor_live/index.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "List"
 
-#: lib/typster_web/live/editor_live/index.html.heex:584
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Math"
 
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:603
+#: lib/typster_web/live/editor_live/index.html.heex:607
+#: lib/typster_web/live/editor_live/index.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Outline"
 
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Headings show up here"
 
-#: lib/typster_web/live/editor_live/index.html.heex:924
-#: lib/typster_web/live/editor_live/index.html.heex:932
-#: lib/typster_web/live/editor_live/index.html.heex:941
+#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:937
+#: lib/typster_web/live/editor_live/index.html.heex:946
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Compile document"
 
-#: lib/typster_web/live/editor_live/index.html.heex:976
-#: lib/typster_web/live/editor_live/index.html.heex:984
-#: lib/typster_web/live/editor_live/index.html.heex:993
+#: lib/typster_web/live/editor_live/index.html.heex:1001
+#: lib/typster_web/live/editor_live/index.html.heex:1009
+#: lib/typster_web/live/editor_live/index.html.heex:1018
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Equation block"
 
-#: lib/typster_web/live/editor_live/index.html.heex:959
+#: lib/typster_web/live/editor_live/index.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:981
+#: lib/typster_web/live/editor_live/index.html.heex:1006
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Insert"
 
-#: lib/typster_web/live/editor_live/index.html.heex:916
+#: lib/typster_web/live/editor_live/index.html.heex:921
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Type a command or search…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:925
-#: lib/typster_web/live/editor_live/index.html.heex:949
-#: lib/typster_web/live/editor_live/index.html.heex:955
+#: lib/typster_web/live/editor_live/index.html.heex:930
+#: lib/typster_web/live/editor_live/index.html.heex:954
+#: lib/typster_web/live/editor_live/index.html.heex:960
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Settings"
 
-#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Suggested"
 
-#: lib/typster_web/live/editor_live/index.html.heex:977
-#: lib/typster_web/live/editor_live/index.html.heex:996
-#: lib/typster_web/live/editor_live/index.html.heex:1005
+#: lib/typster_web/live/editor_live/index.html.heex:1002
+#: lib/typster_web/live/editor_live/index.html.heex:1021
+#: lib/typster_web/live/editor_live/index.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Table"
 
-#: lib/typster_web/live/editor_live/index.html.heex:683
+#: lib/typster_web/live/editor_live/index.html.heex:688
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Build failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:714
+#: lib/typster_web/live/editor_live/index.html.heex:719
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Recompile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
-#: lib/typster_web/live/editor_live/index.html.heex:76
+#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.html.heex:697
+#: lib/typster_web/live/editor_live/index.html.heex:702
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Ready"
 
-#: lib/typster_web/live/editor_live/index.html.heex:706
+#: lib/typster_web/live/editor_live/index.html.heex:711
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Zoom in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:702
+#: lib/typster_web/live/editor_live/index.html.heex:707
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Zoom out"
@@ -827,38 +827,38 @@ msgstr "or with email"
 msgid "auth.oauth.soon"
 msgstr "Social login is coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "New file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:666
+#: lib/typster_web/live/editor_live/index.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Open template"
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Pick a file from the tree on the left, or start a fresh document."
 
-#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Templates are coming soon"
 
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "page"
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "A blank"
 
-#: lib/typster_web/live/editor_live/index.html.heex:622
-#: lib/typster_web/live/editor_live/index.html.heex:623
+#: lib/typster_web/live/editor_live/index.html.heex:627
+#: lib/typster_web/live/editor_live/index.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Find & replace"
@@ -1986,17 +1986,17 @@ msgstr "Technical reports"
 msgid "editor.view.flat"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Show full paths"
 
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Flat"
 
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Change file view"
@@ -2006,67 +2006,67 @@ msgstr "Change file view"
 msgid "editor.view.smart"
 msgstr "Smart"
 
-#: lib/typster_web/live/editor_live/index.html.heex:263
+#: lib/typster_web/live/editor_live/index.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Inline single-file folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:262
+#: lib/typster_web/live/editor_live/index.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Smart collapse"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Foldable folders"
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Appended when you press Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:341
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "filename"
 
-#: lib/typster_web/live/editor_live/index.ex:536
-#: lib/typster_web/live/editor_live/index.ex:582
-#: lib/typster_web/live/editor_live/index.ex:743
+#: lib/typster_web/live/editor_live/index.ex:542
+#: lib/typster_web/live/editor_live/index.ex:588
+#: lib/typster_web/live/editor_live/index.ex:746
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "A file with that path already exists — pick another name."
 
-#: lib/typster_web/live/editor_live/index.html.heex:57
+#: lib/typster_web/live/editor_live/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Open command palette"
 
-#: lib/typster_web/live/editor_live/index.ex:680
+#: lib/typster_web/live/editor_live/index.ex:682
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Asset deleted."
 
-#: lib/typster_web/live/editor_live/index.ex:649
+#: lib/typster_web/live/editor_live/index.ex:655
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "File deleted."
 
-#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Pinned"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:478
-#: lib/typster_web/live/editor_live/index.html.heex:479
+#: lib/typster_web/live/editor_live/index.html.heex:483
+#: lib/typster_web/live/editor_live/index.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Delete file"
@@ -2082,7 +2082,7 @@ msgid "editor.tree.pin"
 msgstr "Pin file"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Pinned"
@@ -2092,19 +2092,19 @@ msgstr "Pinned"
 msgid "editor.tree.unpin"
 msgstr "Unpin file"
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
 msgstr[0] "%{count} section"
 msgstr[1] "%{count} sections"
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "New folder"
 
-#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "folder name"
@@ -2114,130 +2114,130 @@ msgstr "folder name"
 msgid "editor.breadcrumb"
 msgstr "Breadcrumb"
 
-#: lib/typster_web/live/editor_live/index.html.heex:530
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:837
+#: lib/typster_web/live/editor_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
 
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Your templates"
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:482
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Remove this template?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:497
+#: lib/typster_web/live/editor_live/index.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Upload a file to reuse"
 
-#: lib/typster_web/live/editor_live/index.html.heex:467
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:472
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:888
+#: lib/typster_web/live/editor_live/index.ex:895
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1363
-#: lib/typster_web/live/editor_live/index.html.heex:681
-#: lib/typster_web/live/editor_live/index.html.heex:889
+#: lib/typster_web/live/editor_live/index.ex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1365
+#: lib/typster_web/live/editor_live/index.ex:1372
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%{count} warning"
+msgstr[1] "%{count} warnings"
 
-#: lib/typster_web/live/editor_live/index.ex:1369
+#: lib/typster_web/live/editor_live/index.ex:1376
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:795
+#: lib/typster_web/live/editor_live/index.html.heex:800
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Clear log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:801
+#: lib/typster_web/live/editor_live/index.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Close panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:777
+#: lib/typster_web/live/editor_live/index.html.heex:782
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "Jump to first"
 
-#: lib/typster_web/live/editor_live/index.html.heex:752
-#: lib/typster_web/live/editor_live/index.html.heex:891
+#: lib/typster_web/live/editor_live/index.html.heex:757
+#: lib/typster_web/live/editor_live/index.html.heex:896
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Compile log"
 
-#: lib/typster_web/live/editor_live/index.html.heex:809
+#: lib/typster_web/live/editor_live/index.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "No compiles yet"
 
-#: lib/typster_web/live/editor_live/index.html.heex:822
+#: lib/typster_web/live/editor_live/index.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "No problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:761
+#: lib/typster_web/live/editor_live/index.html.heex:766
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Problems"
 
-#: lib/typster_web/live/editor_live/index.html.heex:882
+#: lib/typster_web/live/editor_live/index.html.heex:887
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Toggle compile panel"
 
-#: lib/typster_web/live/editor_live/index.html.heex:782
+#: lib/typster_web/live/editor_live/index.html.heex:787
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Off"
 
-#: lib/typster_web/live/editor_live/index.html.heex:780
+#: lib/typster_web/live/editor_live/index.html.heex:785
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:942
+#: lib/typster_web/live/editor_live/index.ex:949
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:929
+#: lib/typster_web/live/editor_live/index.ex:936
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
 
-#: lib/typster_web/live/editor_live/index.html.heex:163
+#: lib/typster_web/live/editor_live/index.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr "Account"
 
-#: lib/typster_web/live/editor_live/index.html.heex:179
+#: lib/typster_web/live/editor_live/index.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr "Appearance"
@@ -2247,12 +2247,12 @@ msgstr "Appearance"
 msgid "editor.topbar.back"
 msgstr "Back"
 
-#: lib/typster_web/live/editor_live/index.html.heex:124
+#: lib/typster_web/live/editor_live/index.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr "Collaborators"
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr "Failed"
@@ -2262,17 +2262,17 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:1014
+#: lib/typster_web/live/editor_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
 
-#: lib/typster_web/live/editor_live/index.html.heex:152
+#: lib/typster_web/live/editor_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr "Language"
 
-#: lib/typster_web/live/editor_live/index.html.heex:60
+#: lib/typster_web/live/editor_live/index.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.omni_placeholder"
 msgstr "Search files, run commands, jump to…"
@@ -2282,268 +2282,268 @@ msgstr "Search files, run commands, jump to…"
 msgid "editor.topbar.switch_project"
 msgstr "Switch project"
 
-#: lib/typster_web/live/editor_live/index.html.heex:49
+#: lib/typster_web/live/editor_live/index.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.branch"
 msgstr "Branch"
 
-#: lib/typster_web/live/editor_live/index.html.heex:861
+#: lib/typster_web/live/editor_live/index.html.heex:866
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr "Compile times (last 12 runs)"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1033
+#: lib/typster_web/live/editor_live/index.html.heex:1058
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr "Close"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1156
-#: lib/typster_web/live/editor_live/index.html.heex:1453
+#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1478
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Copy"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1494
+#: lib/typster_web/live/editor_live/index.html.heex:1519
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Done"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Allow downloads"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Visitors can download the compiled PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1304
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Expires in 30 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1280
+#: lib/typster_web/live/editor_live/index.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Auto-revokes the link after the set period."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Password-protect"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1284
+#: lib/typster_web/live/editor_live/index.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Visitor must enter a passphrase before opening."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1274
+#: lib/typster_web/live/editor_live/index.html.heex:1299
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Require sign-in"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1275
+#: lib/typster_web/live/editor_live/index.html.heex:1300
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Visitors must sign in with a Typster account."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1336
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Components"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1350
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Visitor can edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "File tree"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1328
+#: lib/typster_web/live/editor_live/index.html.heex:1353
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Visitors can read & open your project on any plan. Upgrade to let them edit live in their browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1352
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Embed is free — interactive sandbox is Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1345
+#: lib/typster_web/live/editor_live/index.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Compiled preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1479
+#: lib/typster_web/live/editor_live/index.html.heex:1504
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Download PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1485
+#: lib/typster_web/live/editor_live/index.html.heex:1510
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Exports the document compiled in your browser."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1463
+#: lib/typster_web/live/editor_live/index.html.heex:1488
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Last successful compile"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1471
+#: lib/typster_web/live/editor_live/index.html.heex:1496
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Includes embedded fonts. Re-export to refresh."
 
-#: lib/typster_web/live/editor_live/index.ex:372
+#: lib/typster_web/live/editor_live/index.ex:376
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Could not send that invite."
 
-#: lib/typster_web/live/editor_live/index.ex:369
+#: lib/typster_web/live/editor_live/index.ex:373
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Invited %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1491
+#: lib/typster_web/live/editor_live/index.html.heex:1516
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "Learn about permissions →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1291
+#: lib/typster_web/live/editor_live/index.html.heex:1316
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Link activity"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1257
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Advanced"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1143
+#: lib/typster_web/live/editor_live/index.html.heex:1168
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr "Share link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1178
+#: lib/typster_web/live/editor_live/index.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr "Anyone with this link can…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1166
+#: lib/typster_web/live/editor_live/index.html.heex:1191
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr "Rotate key"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1185
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr "Rotating the key revokes the current link instantly."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.html.heex:1104
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr "Add by email…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1066
+#: lib/typster_web/live/editor_live/index.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr "Invite people"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1092
+#: lib/typster_web/live/editor_live/index.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1137
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1124
+#: lib/typster_web/live/editor_live/index.html.heex:1149
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr "Pending"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1131
+#: lib/typster_web/live/editor_live/index.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr "Remove"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1089
+#: lib/typster_web/live/editor_live/index.html.heex:1114
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr "Send invite"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1097
+#: lib/typster_web/live/editor_live/index.html.heex:1122
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr "People with access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1107
+#: lib/typster_web/live/editor_live/index.html.heex:1132
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr "you"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1249
+#: lib/typster_web/live/editor_live/index.html.heex:1274
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "careful"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1276
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Read + write everything and manage the link. Same as Owner."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1194
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr "Compiled output only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1195
+#: lib/typster_web/live/editor_live/index.html.heex:1220
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr "Hides the source. Shows the latest successful compile."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1193
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr "PDF only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1185
+#: lib/typster_web/live/editor_live/index.html.heex:1210
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr "Read"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1186
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr "See realtime source and the rendered preview. No editing."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1220
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Write — specific files"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1253
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
 
-#: lib/typster_web/live/editor_live/index.ex:1123
+#: lib/typster_web/live/editor_live/index.ex:1130
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1123
+#: lib/typster_web/live/editor_live/index.ex:1130
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2568,115 +2568,115 @@ msgstr "The share link may have been rotated or revoked."
 msgid "share.public.invalid_title"
 msgstr "This link isn't valid"
 
-#: lib/typster_web/live/shared_project_live.ex:171
+#: lib/typster_web/live/shared_project_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1128
-#: lib/typster_web/live/editor_live/index.html.heex:1085
+#: lib/typster_web/live/editor_live/index.ex:1135
+#: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
-#: lib/typster_web/live/editor_live/index.ex:1126
-#: lib/typster_web/live/editor_live/index.html.heex:1113
+#: lib/typster_web/live/editor_live/index.ex:1133
+#: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
-#: lib/typster_web/live/editor_live/index.ex:1127
-#: lib/typster_web/live/editor_live/index.html.heex:1086
+#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Viewer"
 
-#: lib/typster_web/live/shared_project_live.ex:193
+#: lib/typster_web/live/shared_project_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/shared_project_live.ex:192
+#: lib/typster_web/live/shared_project_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Compiled output"
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Read-only"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1306
+#: lib/typster_web/live/editor_live/index.html.heex:1331
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Link created"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1302
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Active editors now"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1298
+#: lib/typster_web/live/editor_live/index.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Opens last 7 days"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1025
+#: lib/typster_web/live/editor_live/index.html.heex:1050
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr "Invite collaborators, share a link, embed the project, or download the PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1046
+#: lib/typster_web/live/editor_live/index.html.heex:1071
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr "Embed"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1047
+#: lib/typster_web/live/editor_live/index.html.heex:1072
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr "Export PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1045
+#: lib/typster_web/live/editor_live/index.html.heex:1070
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr "Link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1044
+#: lib/typster_web/live/editor_live/index.html.heex:1069
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr "People"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1023
+#: lib/typster_web/live/editor_live/index.html.heex:1048
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1224
+#: lib/typster_web/live/editor_live/index.ex:1231
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Real-time opens, active editors, and locations — with Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1340
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "See who opens your link"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1270
+#: lib/typster_web/live/editor_live/index.html.heex:1295
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Unlock with Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Free links are read-only or fully editable. Upgrade to scope writes."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Per-file write access is Pro"
@@ -2691,68 +2691,68 @@ msgstr "You're in — welcome to the project."
 msgid "share.invite.invalid"
 msgstr "That invite link is invalid or has expired."
 
-#: lib/typster_web/live/shared_project_live.ex:156
+#: lib/typster_web/live/shared_project_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Powered by"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1369
+#: lib/typster_web/live/editor_live/index.html.heex:1394
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr "Always"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1396
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr "Hidden"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1395
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr "On edit"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1356
+#: lib/typster_web/live/editor_live/index.html.heex:1381
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr "Hide Typster footer"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1407
-#: lib/typster_web/live/editor_live/index.html.heex:1417
+#: lib/typster_web/live/editor_live/index.html.heex:1432
+#: lib/typster_web/live/editor_live/index.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr "Live preview"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1363
+#: lib/typster_web/live/editor_live/index.html.heex:1388
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr "Save CTA"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1377
+#: lib/typster_web/live/editor_live/index.html.heex:1402
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr "Theme"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1383
+#: lib/typster_web/live/editor_live/index.html.heex:1408
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr "Auto"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1385
+#: lib/typster_web/live/editor_live/index.html.heex:1410
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr "Dark"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1384
+#: lib/typster_web/live/editor_live/index.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr "Light"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1391
+#: lib/typster_web/live/editor_live/index.html.heex:1416
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr "Width"
 
-#: lib/typster_web/live/editor_live/index.ex:1171
+#: lib/typster_web/live/editor_live/index.ex:1178
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// soon™ — still cooking 🍳  grab the iframe for now"
@@ -2767,17 +2767,17 @@ msgstr "Shared"
 msgid "share.invite.wrong_account"
 msgstr "Plot twist — this invite's addressed to a different email. Log in as the invited account to claim it."
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "editor.share_owner_only"
 msgstr "Owner-only — sharing is their call."
 
-#: lib/typster_web/live/shared_project_live.ex:167
+#: lib/typster_web/live/shared_project_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr "Fork in Typster"
 
-#: lib/typster_web/live/shared_project_live.ex:163
+#: lib/typster_web/live/shared_project_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr "Make your own"
@@ -2787,17 +2787,17 @@ msgstr "Make your own"
 msgid "share.scope.sandbox"
 msgstr "Sandbox"
 
-#: lib/typster_web/live/editor_live/index.ex:1055
+#: lib/typster_web/live/editor_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Link analytics"
 
-#: lib/typster_web/live/editor_live/index.ex:1057
+#: lib/typster_web/live/editor_live/index.ex:1064
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "this week"
 
-#: lib/typster_web/live/editor_live/index.ex:1056
+#: lib/typster_web/live/editor_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "opens"
@@ -2839,3 +2839,54 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "error.not_found.title"
 msgstr "Undefined reference."
+
+#: lib/typster_web/live/editor_live/index.html.heex:983
+#, elixir-autogen, elixir-format
+msgid "editor.palette.headings"
+msgstr "Headings"
+
+#: lib/typster_web/controllers/user_session_controller.ex:8
+#, elixir-autogen, elixir-format
+msgid "auth.flash.confirmed"
+msgstr "User confirmed successfully."
+
+#: lib/typster_web/controllers/user_session_controller.ex:61
+#, elixir-autogen, elixir-format
+msgid "auth.flash.invalid_credentials"
+msgstr "Invalid email or password"
+
+#: lib/typster_web/controllers/user_session_controller.ex:27
+#, elixir-autogen, elixir-format
+msgid "auth.flash.link_invalid"
+msgstr "The link is invalid or it has expired."
+
+#: lib/typster_web/controllers/user_session_controller.ex:82
+#, elixir-autogen, elixir-format
+msgid "auth.flash.logged_out"
+msgstr "Logged out successfully."
+
+#: lib/typster_web/user_auth.ex:261
+#: lib/typster_web/user_auth.ex:310
+#, elixir-autogen, elixir-format
+msgid "auth.flash.login_required"
+msgstr "You must log in to access this page."
+
+#: lib/typster_web/controllers/user_session_controller.ex:45
+#, elixir-autogen, elixir-format
+msgid "auth.flash.magic_link_sent"
+msgstr "If your email is in our system, you will receive instructions for logging in shortly."
+
+#: lib/typster_web/controllers/user_session_controller.ex:77
+#, elixir-autogen, elixir-format
+msgid "auth.flash.password_updated"
+msgstr "Password updated successfully!"
+
+#: lib/typster_web/user_auth.ex:276
+#, elixir-autogen, elixir-format
+msgid "auth.flash.reauth_required"
+msgstr "You must re-authenticate to access this page."
+
+#: lib/typster_web/controllers/user_session_controller.ex:12
+#, elixir-autogen, elixir-format
+msgid "auth.flash.welcome_back"
+msgstr "Welcome back!"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -178,7 +178,7 @@ msgstr "File could not be created."
 
 #: lib/typster_web/live/editor_live/index.ex:577
 #: lib/typster_web/live/editor_live/index.ex:603
-#: lib/typster_web/live/editor_live/index.ex:909
+#: lib/typster_web/live/editor_live/index.ex:898
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Unsupported file format."
@@ -209,17 +209,17 @@ msgstr "Preview"
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
 
-#: lib/typster_web/live/editor_live/index.ex:843
+#: lib/typster_web/live/editor_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Error"
 
-#: lib/typster_web/live/editor_live/index.ex:841
+#: lib/typster_web/live/editor_live/index.ex:830
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Saved"
 
-#: lib/typster_web/live/editor_live/index.ex:842
+#: lib/typster_web/live/editor_live/index.ex:831
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Saving"
@@ -2119,7 +2119,7 @@ msgstr "Breadcrumb"
 msgid "editor.tab.close"
 msgstr "Close tab"
 
-#: lib/typster_web/live/editor_live/index.ex:859
+#: lib/typster_web/live/editor_live/index.ex:848
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Template saved."
@@ -2145,12 +2145,12 @@ msgstr "Upload a file to reuse"
 msgid "editor.tpl.use"
 msgstr "Start a file from this template"
 
-#: lib/typster_web/live/editor_live/index.ex:910
+#: lib/typster_web/live/editor_live/index.ex:899
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Added to the project."
 
-#: lib/typster_web/live/editor_live/index.ex:1385
+#: lib/typster_web/live/editor_live/index.ex:1374
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2159,14 +2159,14 @@ msgid_plural "%{count} errors"
 msgstr[0] "%{count} error"
 msgstr[1] "%{count} errors"
 
-#: lib/typster_web/live/editor_live/index.ex:1387
+#: lib/typster_web/live/editor_live/index.ex:1376
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
 msgstr[0] "%{count} warning"
 msgstr[1] "%{count} warnings"
 
-#: lib/typster_web/live/editor_live/index.ex:1391
+#: lib/typster_web/live/editor_live/index.ex:1380
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Compile failed"
@@ -2222,12 +2222,12 @@ msgstr "Off"
 msgid "editor.drawer.recompile"
 msgstr "Recompile after"
 
-#: lib/typster_web/live/editor_live/index.ex:964
+#: lib/typster_web/live/editor_live/index.ex:953
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "File moved."
 
-#: lib/typster_web/live/editor_live/index.ex:951
+#: lib/typster_web/live/editor_live/index.ex:940
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "A file with that name already lives there."
@@ -2262,7 +2262,7 @@ msgstr "Failed"
 msgid "editor.topbar.forward"
 msgstr "Forward"
 
-#: lib/typster_web/live/editor_live/index.ex:1036
+#: lib/typster_web/live/editor_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Guest"
@@ -2458,7 +2458,7 @@ msgstr "Invite people"
 msgid "share.people.invite_hint"
 msgstr "Invitees get an email with a link and can edit after signing in."
 
-#: lib/typster_web/live/editor_live/index.ex:1152
+#: lib/typster_web/live/editor_live/index.ex:1141
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Invitation sent"
@@ -2538,12 +2538,12 @@ msgstr "Write — specific files"
 msgid "share.perm.write_desc"
 msgstr "Pick exactly which files visitors can edit."
 
-#: lib/typster_web/live/editor_live/index.ex:1145
+#: lib/typster_web/live/editor_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1145
+#: lib/typster_web/live/editor_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2573,19 +2573,19 @@ msgstr "This link isn't valid"
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1150
+#: lib/typster_web/live/editor_live/index.ex:1139
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Editor"
 
-#: lib/typster_web/live/editor_live/index.ex:1148
+#: lib/typster_web/live/editor_live/index.ex:1137
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Owner"
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1138
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
@@ -2651,7 +2651,7 @@ msgstr "People"
 msgid "share.title"
 msgstr "Share"
 
-#: lib/typster_web/live/editor_live/index.ex:1246
+#: lib/typster_web/live/editor_live/index.ex:1235
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Upgrade"
@@ -2752,7 +2752,7 @@ msgstr "Light"
 msgid "share.embed.width"
 msgstr "Width"
 
-#: lib/typster_web/live/editor_live/index.ex:1193
+#: lib/typster_web/live/editor_live/index.ex:1182
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// soon™ — still cooking 🍳  grab the iframe for now"
@@ -2787,17 +2787,17 @@ msgstr "Make your own"
 msgid "share.scope.sandbox"
 msgstr "Sandbox"
 
-#: lib/typster_web/live/editor_live/index.ex:1077
+#: lib/typster_web/live/editor_live/index.ex:1066
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Link analytics"
 
-#: lib/typster_web/live/editor_live/index.ex:1079
+#: lib/typster_web/live/editor_live/index.ex:1068
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "this week"
 
-#: lib/typster_web/live/editor_live/index.ex:1078
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "opens"
@@ -2891,27 +2891,15 @@ msgstr "You must re-authenticate to access this page."
 msgid "auth.flash.welcome_back"
 msgstr "Welcome back!"
 
-#: lib/typster_web/live/editor_live/index.ex:783
+#: lib/typster_web/live/editor_live/index.ex:773
 #, elixir-autogen, elixir-format
-msgid "editor.starter.body"
-msgstr "Mix *bold*, _italic_, and `raw` text, or flex a little math: $E = m c^2$. Headings, lists, and figures all just work:"
-
-#: lib/typster_web/live/editor_live/index.ex:779
-#, elixir-autogen, elixir-format
-msgid "editor.starter.heading"
-msgstr "Introduction"
-
-#: lib/typster_web/live/editor_live/index.ex:781
-#, elixir-autogen, elixir-format
-msgid "editor.starter.intro"
-msgstr "Welcome to Typster. Your document compiles live — no `latexmk`, no waiting."
-
-#: lib/typster_web/live/editor_live/index.ex:785
-#, elixir-autogen, elixir-format
-msgid "editor.starter.point1"
-msgstr "Start typing here"
-
-#: lib/typster_web/live/editor_live/index.ex:786
-#, elixir-autogen, elixir-format
-msgid "editor.starter.point2"
-msgstr "Delete this once you have real thoughts"
+msgid "editor.starter.doc"
+msgstr ""
+"= Introduction\n"
+"\n"
+"Welcome to Typster. Your document compiles live — no `latexmk`, no waiting.\n"
+"\n"
+"Mix *bold*, _italic_, and `raw` text, or flex a little math: $E = m c^2$. Headings, lists, and figures all just work:\n"
+"\n"
+"- Start typing here\n"
+"- Delete this once you have real thoughts\n"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:738
+#: lib/typster_web/live/editor_live/index.ex:755
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:735
+#: lib/typster_web/live/editor_live/index.ex:752
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:440
+#: lib/typster_web/live/editor_live/index.ex:457
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:770
+#: lib/typster_web/live/editor_live/index.ex:787
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:598
-#: lib/typster_web/live/editor_live/index.ex:624
-#: lib/typster_web/live/editor_live/index.ex:913
+#: lib/typster_web/live/editor_live/index.ex:615
+#: lib/typster_web/live/editor_live/index.ex:641
+#: lib/typster_web/live/editor_live/index.ex:930
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr "Превью"
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:236
+#: lib/typster_web/live/shared_project_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:847
+#: lib/typster_web/live/editor_live/index.ex:864
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:845
+#: lib/typster_web/live/editor_live/index.ex:862
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:846
+#: lib/typster_web/live/editor_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -2043,9 +2043,9 @@ msgstr "Добавится по нажатию Enter"
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:563
-#: lib/typster_web/live/editor_live/index.ex:609
-#: lib/typster_web/live/editor_live/index.ex:769
+#: lib/typster_web/live/editor_live/index.ex:580
+#: lib/typster_web/live/editor_live/index.ex:626
+#: lib/typster_web/live/editor_live/index.ex:786
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,12 +2055,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:705
+#: lib/typster_web/live/editor_live/index.ex:722
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:678
+#: lib/typster_web/live/editor_live/index.ex:695
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2126,7 +2126,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:863
+#: lib/typster_web/live/editor_live/index.ex:880
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2152,12 +2152,12 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:914
+#: lib/typster_web/live/editor_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1389
+#: lib/typster_web/live/editor_live/index.ex:1406
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1391
+#: lib/typster_web/live/editor_live/index.ex:1408
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,7 +2175,7 @@ msgstr[0] "%{count} предупреждение"
 msgstr[1] "%{count} предупреждения"
 msgstr[2] "%{count} предупреждений"
 
-#: lib/typster_web/live/editor_live/index.ex:1395
+#: lib/typster_web/live/editor_live/index.ex:1412
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2231,12 +2231,12 @@ msgstr "Выкл"
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:968
+#: lib/typster_web/live/editor_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:955
+#: lib/typster_web/live/editor_live/index.ex:972
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
@@ -2271,7 +2271,7 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:1040
+#: lib/typster_web/live/editor_live/index.ex:1057
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
@@ -2407,12 +2407,12 @@ msgstr "Последний успешный результат"
 msgid "share.export.meta"
 msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
 
-#: lib/typster_web/live/editor_live/index.ex:397
+#: lib/typster_web/live/editor_live/index.ex:414
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Не удалось отправить приглашение."
 
-#: lib/typster_web/live/editor_live/index.ex:394
+#: lib/typster_web/live/editor_live/index.ex:411
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Приглашён %{email}"
@@ -2467,7 +2467,7 @@ msgstr "Пригласить людей"
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
 
-#: lib/typster_web/live/editor_live/index.ex:1156
+#: lib/typster_web/live/editor_live/index.ex:1173
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
@@ -2547,17 +2547,17 @@ msgstr "Запись — выбранные файлы"
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
 
-#: lib/typster_web/live/shared_project_live.ex:96
+#: lib/typster_web/live/shared_project_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr "На главную"
@@ -2567,50 +2567,50 @@ msgstr "На главную"
 msgid "share.public.invalid"
 msgstr "Недействительная ссылка"
 
-#: lib/typster_web/live/shared_project_live.ex:95
+#: lib/typster_web/live/shared_project_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr "Ссылку могли сменить или отозвать."
 
-#: lib/typster_web/live/shared_project_live.ex:94
+#: lib/typster_web/live/shared_project_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr "Ссылка недействительна"
 
-#: lib/typster_web/live/shared_project_live.ex:277
+#: lib/typster_web/live/shared_project_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1154
+#: lib/typster_web/live/editor_live/index.ex:1171
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
-#: lib/typster_web/live/editor_live/index.ex:1152
+#: lib/typster_web/live/editor_live/index.ex:1169
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
-#: lib/typster_web/live/editor_live/index.ex:1153
+#: lib/typster_web/live/editor_live/index.ex:1170
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Читатель"
 
-#: lib/typster_web/live/shared_project_live.ex:344
+#: lib/typster_web/live/shared_project_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/shared_project_live.ex:343
+#: lib/typster_web/live/shared_project_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/shared_project_live.ex:345
+#: lib/typster_web/live/shared_project_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Только чтение"
@@ -2660,7 +2660,7 @@ msgstr "Люди"
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1250
+#: lib/typster_web/live/editor_live/index.ex:1267
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
@@ -2700,7 +2700,7 @@ msgstr "Готово — добро пожаловать в проект."
 msgid "share.invite.invalid"
 msgstr "Эта ссылка-приглашение недействительна или истекла."
 
-#: lib/typster_web/live/shared_project_live.ex:243
+#: lib/typster_web/live/shared_project_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Работает на"
@@ -2761,7 +2761,7 @@ msgstr "Светлая"
 msgid "share.embed.width"
 msgstr "Ширина"
 
-#: lib/typster_web/live/editor_live/index.ex:1197
+#: lib/typster_web/live/editor_live/index.ex:1214
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// скоро™ — ещё готовим 🍳  пока бери iframe"
@@ -2781,32 +2781,32 @@ msgstr "Сюжетный поворот — приглашение оформл�
 msgid "editor.share_owner_only"
 msgstr "Только владелец — делиться решает он."
 
-#: lib/typster_web/live/shared_project_live.ex:268
+#: lib/typster_web/live/shared_project_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr "Форкнуть в Typster"
 
-#: lib/typster_web/live/shared_project_live.ex:259
+#: lib/typster_web/live/shared_project_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr "Сделать свой"
 
-#: lib/typster_web/live/shared_project_live.ex:159
+#: lib/typster_web/live/shared_project_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr "Песочница"
 
-#: lib/typster_web/live/editor_live/index.ex:1081
+#: lib/typster_web/live/editor_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Аналитика ссылки"
 
-#: lib/typster_web/live/editor_live/index.ex:1083
+#: lib/typster_web/live/editor_live/index.ex:1100
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "за неделю"
 
-#: lib/typster_web/live/editor_live/index.ex:1082
+#: lib/typster_web/live/editor_live/index.ex:1099
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "открытий"
@@ -2899,7 +2899,7 @@ msgstr "Для доступа к этой странице нужно войти
 msgid "auth.flash.welcome_back"
 msgstr "С возвращением!"
 
-#: lib/typster_web/live/editor_live/index.ex:788
+#: lib/typster_web/live/editor_live/index.ex:805
 #, elixir-autogen, elixir-format
 msgid "editor.starter.doc"
 msgstr ""
@@ -2934,64 +2934,69 @@ msgstr "Редактировать можно всем"
 msgid "share.adv.open_edit_sub"
 msgstr "Гости со ссылкой автоматически становятся редакторами. Максимум доверия — включайте осознанно."
 
-#: lib/typster_web/live/shared_project_live.ex:361
+#: lib/typster_web/live/shared_project_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "share.join.copy_of"
 msgstr "%{name} (копия)"
 
-#: lib/typster_web/live/shared_project_live.ex:147
 #: lib/typster_web/live/shared_project_live.ex:151
+#: lib/typster_web/live/shared_project_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "share.join.edit"
 msgstr "Редактировать проект"
 
-#: lib/typster_web/live/shared_project_live.ex:127
-#: lib/typster_web/live/shared_project_live.ex:133
+#: lib/typster_web/live/shared_project_live.ex:131
+#: lib/typster_web/live/shared_project_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "share.join.fork"
 msgstr "Сделать копию"
 
-#: lib/typster_web/live/shared_project_live.ex:186
+#: lib/typster_web/live/shared_project_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_cancel"
 msgstr "Отмена"
 
-#: lib/typster_web/live/shared_project_live.ex:189
+#: lib/typster_web/live/shared_project_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_confirm"
 msgstr "Копировать"
 
-#: lib/typster_web/live/shared_project_live.ex:315
+#: lib/typster_web/live/shared_project_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_failed"
 msgstr "Копирование не прошло. Попробуйте ещё раз через минуту."
 
-#: lib/typster_web/live/shared_project_live.ex:309
+#: lib/typster_web/live/shared_project_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_invalid_name"
 msgstr "Такое имя не пройдёт — дайте копии нормальное."
 
-#: lib/typster_web/live/shared_project_live.ex:181
+#: lib/typster_web/live/shared_project_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_name"
 msgstr "Назовите копию"
 
-#: lib/typster_web/live/shared_project_live.ex:176
+#: lib/typster_web/live/shared_project_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_sub"
 msgstr "Весь проект — файлы, ассеты, вообще всё — станет вашей личной копией."
 
-#: lib/typster_web/live/shared_project_live.ex:175
+#: lib/typster_web/live/shared_project_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_title"
 msgstr "Скопировать проект"
 
-#: lib/typster_web/live/shared_project_live.ex:302
+#: lib/typster_web/live/shared_project_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "share.join.forked"
 msgstr "«%{name}» теперь ваш — удачной вёрстки."
 
-#: lib/typster_web/live/shared_project_live.ex:327
+#: lib/typster_web/live/shared_project_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "share.join.join_failed"
 msgstr "Не получилось добавить вас в проект — возможно, владелец сменил настройки ссылки."
+
+#: lib/typster_web/live/editor_live/index.ex:26
+#, elixir-autogen, elixir-format
+msgid "editor.project_unavailable"
+msgstr "Такого проекта нет — или он не ваш, чтобы его редактировать."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -156,29 +156,29 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:717
+#: lib/typster_web/live/editor_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:714
+#: lib/typster_web/live/editor_live/index.ex:735
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:419
+#: lib/typster_web/live/editor_live/index.ex:440
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:749
+#: lib/typster_web/live/editor_live/index.ex:770
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:577
-#: lib/typster_web/live/editor_live/index.ex:603
-#: lib/typster_web/live/editor_live/index.ex:898
+#: lib/typster_web/live/editor_live/index.ex:598
+#: lib/typster_web/live/editor_live/index.ex:624
+#: lib/typster_web/live/editor_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -204,22 +204,22 @@ msgid "editor.preview"
 msgstr "Превью"
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:151
+#: lib/typster_web/live/shared_project_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:832
+#: lib/typster_web/live/editor_live/index.ex:847
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:830
+#: lib/typster_web/live/editor_live/index.ex:845
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:831
+#: lib/typster_web/live/editor_live/index.ex:846
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -2043,9 +2043,9 @@ msgstr "Добавится по нажатию Enter"
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:542
-#: lib/typster_web/live/editor_live/index.ex:588
-#: lib/typster_web/live/editor_live/index.ex:748
+#: lib/typster_web/live/editor_live/index.ex:563
+#: lib/typster_web/live/editor_live/index.ex:609
+#: lib/typster_web/live/editor_live/index.ex:769
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,12 +2055,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:684
+#: lib/typster_web/live/editor_live/index.ex:705
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:657
+#: lib/typster_web/live/editor_live/index.ex:678
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2126,7 +2126,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:848
+#: lib/typster_web/live/editor_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2152,12 +2152,12 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:899
+#: lib/typster_web/live/editor_live/index.ex:914
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1374
+#: lib/typster_web/live/editor_live/index.ex:1389
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1376
+#: lib/typster_web/live/editor_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,7 +2175,7 @@ msgstr[0] "%{count} предупреждение"
 msgstr[1] "%{count} предупреждения"
 msgstr[2] "%{count} предупреждений"
 
-#: lib/typster_web/live/editor_live/index.ex:1380
+#: lib/typster_web/live/editor_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2231,12 +2231,12 @@ msgstr "Выкл"
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:953
+#: lib/typster_web/live/editor_live/index.ex:968
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:940
+#: lib/typster_web/live/editor_live/index.ex:955
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
@@ -2271,7 +2271,7 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:1025
+#: lib/typster_web/live/editor_live/index.ex:1040
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
@@ -2307,12 +2307,12 @@ msgid "common.close"
 msgstr "Закрыть"
 
 #: lib/typster_web/live/editor_live/index.html.heex:1181
-#: lib/typster_web/live/editor_live/index.html.heex:1478
+#: lib/typster_web/live/editor_live/index.html.heex:1512
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Копировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1519
+#: lib/typster_web/live/editor_live/index.html.heex:1553
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Готово"
@@ -2327,102 +2327,102 @@ msgstr "Разрешить скачивание"
 msgid "share.adv.download_sub"
 msgstr "Посетители могут скачать готовый PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1304
+#: lib/typster_web/live/editor_live/index.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Истекает через 30 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1305
+#: lib/typster_web/live/editor_live/index.html.heex:1339
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Автоматически отзывает ссылку по сроку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1308
+#: lib/typster_web/live/editor_live/index.html.heex:1342
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Пароль"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1309
+#: lib/typster_web/live/editor_live/index.html.heex:1343
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Посетитель вводит пароль перед открытием."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1299
+#: lib/typster_web/live/editor_live/index.html.heex:1333
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Требовать вход"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1300
+#: lib/typster_web/live/editor_live/index.html.heex:1334
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Нужен вход в аккаунт Typster."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1361
+#: lib/typster_web/live/editor_live/index.html.heex:1395
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Компоненты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1375
+#: lib/typster_web/live/editor_live/index.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Гость может править"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1365
+#: lib/typster_web/live/editor_live/index.html.heex:1399
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "Дерево файлов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1353
+#: lib/typster_web/live/editor_live/index.html.heex:1387
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Гости могут читать и открывать проект на любом тарифе. Обновитесь до Pro, чтобы они правили прямо в браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1352
+#: lib/typster_web/live/editor_live/index.html.heex:1386
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Встраивание бесплатно — интерактивная песочница в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1404
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1504
+#: lib/typster_web/live/editor_live/index.html.heex:1538
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Скачать PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1510
+#: lib/typster_web/live/editor_live/index.html.heex:1544
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Экспортирует документ, собранный в вашем браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1488
+#: lib/typster_web/live/editor_live/index.html.heex:1522
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Последний успешный результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1496
+#: lib/typster_web/live/editor_live/index.html.heex:1530
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
 
-#: lib/typster_web/live/editor_live/index.ex:376
+#: lib/typster_web/live/editor_live/index.ex:397
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Не удалось отправить приглашение."
 
-#: lib/typster_web/live/editor_live/index.ex:373
+#: lib/typster_web/live/editor_live/index.ex:394
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Приглашён %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1516
+#: lib/typster_web/live/editor_live/index.html.heex:1550
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "О правах доступа →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1350
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Активность ссылки"
@@ -2467,7 +2467,7 @@ msgstr "Пригласить людей"
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
 
-#: lib/typster_web/live/editor_live/index.ex:1141
+#: lib/typster_web/live/editor_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
@@ -2547,17 +2547,17 @@ msgstr "Запись — выбранные файлы"
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
 
-#: lib/typster_web/live/shared_project_live.ex:80
+#: lib/typster_web/live/shared_project_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr "На главную"
@@ -2567,65 +2567,65 @@ msgstr "На главную"
 msgid "share.public.invalid"
 msgstr "Недействительная ссылка"
 
-#: lib/typster_web/live/shared_project_live.ex:79
+#: lib/typster_web/live/shared_project_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr "Ссылку могли сменить или отозвать."
 
-#: lib/typster_web/live/shared_project_live.ex:78
+#: lib/typster_web/live/shared_project_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr "Ссылка недействительна"
 
-#: lib/typster_web/live/shared_project_live.ex:173
+#: lib/typster_web/live/shared_project_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1139
+#: lib/typster_web/live/editor_live/index.ex:1154
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
-#: lib/typster_web/live/editor_live/index.ex:1137
+#: lib/typster_web/live/editor_live/index.ex:1152
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
-#: lib/typster_web/live/editor_live/index.ex:1138
+#: lib/typster_web/live/editor_live/index.ex:1153
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Читатель"
 
-#: lib/typster_web/live/shared_project_live.ex:195
+#: lib/typster_web/live/shared_project_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/shared_project_live.ex:196
+#: lib/typster_web/live/shared_project_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Только чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1331
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Ссылка создана"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Сейчас редактируют"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1323
+#: lib/typster_web/live/editor_live/index.html.heex:1357
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Открытий за 7 дней"
@@ -2660,22 +2660,22 @@ msgstr "Люди"
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1235
+#: lib/typster_web/live/editor_live/index.ex:1250
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1341
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Открытия, активные редакторы и геолокация — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "Кто открывает вашу ссылку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1295
+#: lib/typster_web/live/editor_live/index.html.heex:1329
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Открыть в Pro"
@@ -2700,68 +2700,68 @@ msgstr "Готово — добро пожаловать в проект."
 msgid "share.invite.invalid"
 msgstr "Эта ссылка-приглашение недействительна или истекла."
 
-#: lib/typster_web/live/shared_project_live.ex:158
+#: lib/typster_web/live/shared_project_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Работает на"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1394
+#: lib/typster_web/live/editor_live/index.html.heex:1428
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr "Всегда"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1396
+#: lib/typster_web/live/editor_live/index.html.heex:1430
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr "Скрыта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1395
+#: lib/typster_web/live/editor_live/index.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr "При правке"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1381
+#: lib/typster_web/live/editor_live/index.html.heex:1415
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr "Скрыть подпись Typster"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1432
-#: lib/typster_web/live/editor_live/index.html.heex:1442
+#: lib/typster_web/live/editor_live/index.html.heex:1466
+#: lib/typster_web/live/editor_live/index.html.heex:1476
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr "Живой предпросмотр"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1388
+#: lib/typster_web/live/editor_live/index.html.heex:1422
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr "Кнопка «Сохранить»"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1402
+#: lib/typster_web/live/editor_live/index.html.heex:1436
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr "Тема"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1408
+#: lib/typster_web/live/editor_live/index.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr "Авто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1410
+#: lib/typster_web/live/editor_live/index.html.heex:1444
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr "Тёмная"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1409
+#: lib/typster_web/live/editor_live/index.html.heex:1443
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr "Светлая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1416
+#: lib/typster_web/live/editor_live/index.html.heex:1450
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr "Ширина"
 
-#: lib/typster_web/live/editor_live/index.ex:1182
+#: lib/typster_web/live/editor_live/index.ex:1197
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// скоро™ — ещё готовим 🍳  пока бери iframe"
@@ -2781,32 +2781,32 @@ msgstr "Сюжетный поворот — приглашение оформл�
 msgid "editor.share_owner_only"
 msgstr "Только владелец — делиться решает он."
 
-#: lib/typster_web/live/shared_project_live.ex:169
+#: lib/typster_web/live/shared_project_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr "Форкнуть в Typster"
 
-#: lib/typster_web/live/shared_project_live.ex:165
+#: lib/typster_web/live/shared_project_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr "Сделать свой"
 
-#: lib/typster_web/live/shared_project_live.ex:107
+#: lib/typster_web/live/shared_project_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr "Песочница"
 
-#: lib/typster_web/live/editor_live/index.ex:1066
+#: lib/typster_web/live/editor_live/index.ex:1081
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Аналитика ссылки"
 
-#: lib/typster_web/live/editor_live/index.ex:1068
+#: lib/typster_web/live/editor_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "за неделю"
 
-#: lib/typster_web/live/editor_live/index.ex:1067
+#: lib/typster_web/live/editor_live/index.ex:1082
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "открытий"
@@ -2899,7 +2899,7 @@ msgstr "Для доступа к этой странице нужно войти
 msgid "auth.flash.welcome_back"
 msgstr "С возвращением!"
 
-#: lib/typster_web/live/editor_live/index.ex:773
+#: lib/typster_web/live/editor_live/index.ex:788
 #, elixir-autogen, elixir-format
 msgid "editor.starter.doc"
 msgstr ""
@@ -2911,3 +2911,87 @@ msgstr ""
 "\n"
 "- Печатай сюда\n"
 "- Удали, когда появятся настоящие мысли\n"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1299
+#, elixir-autogen, elixir-format
+msgid "share.adv.fork"
+msgstr "Копировать можно всем"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1300
+#, elixir-autogen, elixir-format
+msgid "share.adv.fork_sub"
+msgstr "У гостей появится кнопка «Сделать копию» — форк уедет к ним в аккаунт, ваш оригинал не тронут."
+
+#: lib/typster_web/live/editor_live/index.html.heex:1311
+#: lib/typster_web/live/editor_live/index.html.heex:1320
+#, elixir-autogen, elixir-format
+msgid "share.adv.open_edit"
+msgstr "Редактировать можно всем"
+
+#: lib/typster_web/live/editor_live/index.html.heex:1312
+#: lib/typster_web/live/editor_live/index.html.heex:1322
+#, elixir-autogen, elixir-format
+msgid "share.adv.open_edit_sub"
+msgstr "Гости со ссылкой автоматически становятся редакторами. Максимум доверия — включайте осознанно."
+
+#: lib/typster_web/live/shared_project_live.ex:361
+#, elixir-autogen, elixir-format
+msgid "share.join.copy_of"
+msgstr "%{name} (копия)"
+
+#: lib/typster_web/live/shared_project_live.ex:147
+#: lib/typster_web/live/shared_project_live.ex:151
+#, elixir-autogen, elixir-format
+msgid "share.join.edit"
+msgstr "Редактировать проект"
+
+#: lib/typster_web/live/shared_project_live.ex:127
+#: lib/typster_web/live/shared_project_live.ex:133
+#, elixir-autogen, elixir-format
+msgid "share.join.fork"
+msgstr "Сделать копию"
+
+#: lib/typster_web/live/shared_project_live.ex:186
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_cancel"
+msgstr "Отмена"
+
+#: lib/typster_web/live/shared_project_live.ex:189
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_confirm"
+msgstr "Копировать"
+
+#: lib/typster_web/live/shared_project_live.ex:315
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_failed"
+msgstr "Копирование не прошло. Попробуйте ещё раз через минуту."
+
+#: lib/typster_web/live/shared_project_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_invalid_name"
+msgstr "Такое имя не пройдёт — дайте копии нормальное."
+
+#: lib/typster_web/live/shared_project_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_name"
+msgstr "Назовите копию"
+
+#: lib/typster_web/live/shared_project_live.ex:176
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_sub"
+msgstr "Весь проект — файлы, ассеты, вообще всё — станет вашей личной копией."
+
+#: lib/typster_web/live/shared_project_live.ex:175
+#, elixir-autogen, elixir-format
+msgid "share.join.fork_title"
+msgstr "Скопировать проект"
+
+#: lib/typster_web/live/shared_project_live.ex:302
+#, elixir-autogen, elixir-format
+msgid "share.join.forked"
+msgstr "«%{name}» теперь ваш — удачной вёрстки."
+
+#: lib/typster_web/live/shared_project_live.ex:327
+#, elixir-autogen, elixir-format
+msgid "share.join.join_failed"
+msgstr "Не получилось добавить вас в проект — возможно, владелец сменил настройки ссылки."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr "Войти"
 
 #: lib/typster_web/components/layouts.ex:113
 #: lib/typster_web/components/layouts.ex:121
-#: lib/typster_web/live/editor_live/index.html.heex:200
+#: lib/typster_web/live/editor_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "auth.log_out"
 msgstr "Выйти"
@@ -134,122 +134,122 @@ msgstr "После подтверждения можно включить вхо
 msgid "confirmation.welcome"
 msgstr "С возвращением"
 
-#: lib/typster_web/live/editor_live/index.html.heex:411
+#: lib/typster_web/live/editor_live/index.html.heex:416
 #, elixir-autogen, elixir-format
 msgid "editor.assets"
 msgstr "Ассеты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:113
+#: lib/typster_web/live/editor_live/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "editor.compile"
 msgstr "Скомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:722
-#: lib/typster_web/live/editor_live/index.html.heex:723
+#: lib/typster_web/live/editor_live/index.html.heex:727
+#: lib/typster_web/live/editor_live/index.html.heex:728
 #, elixir-autogen, elixir-format
 msgid "editor.download"
 msgstr "Скачать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:223
-#: lib/typster_web/live/editor_live/index.html.heex:296
+#: lib/typster_web/live/editor_live/index.html.heex:228
+#: lib/typster_web/live/editor_live/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:713
+#: lib/typster_web/live/editor_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:710
+#: lib/typster_web/live/editor_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
 
-#: lib/typster_web/live/editor_live/index.ex:414
+#: lib/typster_web/live/editor_live/index.ex:419
 #, elixir-autogen, elixir-format
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:744
+#: lib/typster_web/live/editor_live/index.ex:747
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
-#: lib/typster_web/live/editor_live/index.ex:571
-#: lib/typster_web/live/editor_live/index.ex:595
-#: lib/typster_web/live/editor_live/index.ex:887
+#: lib/typster_web/live/editor_live/index.ex:577
+#: lib/typster_web/live/editor_live/index.ex:601
+#: lib/typster_web/live/editor_live/index.ex:894
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
 
-#: lib/typster_web/live/editor_live/index.html.heex:246
+#: lib/typster_web/live/editor_live/index.html.heex:251
 #, elixir-autogen
 msgid "editor.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:537
+#: lib/typster_web/live/editor_live/index.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "editor.no_file"
 msgstr "Файла нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:301
+#: lib/typster_web/live/editor_live/index.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "editor.no_files"
 msgstr "Файлов пока нет"
 
-#: lib/typster_web/live/editor_live/index.html.heex:675
+#: lib/typster_web/live/editor_live/index.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "editor.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:738
-#: lib/typster_web/live/shared_project_live.ex:149
+#: lib/typster_web/live/editor_live/index.html.heex:743
+#: lib/typster_web/live/shared_project_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:821
+#: lib/typster_web/live/editor_live/index.ex:828
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:819
+#: lib/typster_web/live/editor_live/index.ex:826
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:820
+#: lib/typster_web/live/editor_live/index.ex:827
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:416
-#: lib/typster_web/live/editor_live/index.html.heex:445
+#: lib/typster_web/live/editor_live/index.html.heex:421
+#: lib/typster_web/live/editor_live/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "editor.upload_asset"
 msgstr "Загрузить ассет"
 
 #: lib/typster_web/components/layouts.ex:241
-#: lib/typster_web/live/editor_live/index.html.heex:185
+#: lib/typster_web/live/editor_live/index.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "layout.theme.dark"
 msgstr "Темная тема"
 
 #: lib/typster_web/components/layouts.ex:233
-#: lib/typster_web/live/editor_live/index.html.heex:182
+#: lib/typster_web/live/editor_live/index.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "layout.theme.light"
 msgstr "Светлая тема"
 
 #: lib/typster_web/components/layouts.ex:225
-#: lib/typster_web/live/editor_live/index.html.heex:188
+#: lib/typster_web/live/editor_live/index.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "layout.theme.system"
 msgstr "Как в системе"
 
 #: lib/typster_web/components/layouts.ex:101
-#: lib/typster_web/live/editor_live/index.html.heex:142
+#: lib/typster_web/live/editor_live/index.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "layout.theme.toggle"
 msgstr "Переключить тему"
@@ -310,14 +310,14 @@ msgid "nav.my_projects"
 msgstr "Мои проекты"
 
 #: lib/typster_web/components/layouts.ex:169
-#: lib/typster_web/live/editor_live/index.html.heex:193
+#: lib/typster_web/live/editor_live/index.html.heex:198
 #: lib/typster_web/live/project_live/show.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "nav.projects"
 msgstr "Проекты"
 
 #: lib/typster_web/components/layouts.ex:171
-#: lib/typster_web/live/editor_live/index.html.heex:196
+#: lib/typster_web/live/editor_live/index.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "nav.settings"
 msgstr "Настройки"
@@ -519,157 +519,157 @@ msgstr "Держите email и пароль в порядке. Будущий �
 msgid "settings.title"
 msgstr "Настройки аккаунта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:103
-#: lib/typster_web/live/editor_live/index.html.heex:692
+#: lib/typster_web/live/editor_live/index.html.heex:108
+#: lib/typster_web/live/editor_live/index.html.heex:697
 #, elixir-autogen, elixir-format
 msgid "editor.compiled"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:82
-#: lib/typster_web/live/editor_live/index.html.heex:688
+#: lib/typster_web/live/editor_live/index.html.heex:87
+#: lib/typster_web/live/editor_live/index.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "editor.compiling"
 msgstr "Компиляция…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:216
-#: lib/typster_web/live/editor_live/index.html.heex:217
+#: lib/typster_web/live/editor_live/index.html.heex:221
+#: lib/typster_web/live/editor_live/index.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "editor.find_in_project"
 msgstr "Поиск в проекте…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:546
-#: lib/typster_web/live/editor_live/index.html.heex:547
+#: lib/typster_web/live/editor_live/index.html.heex:551
+#: lib/typster_web/live/editor_live/index.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "editor.format.bold"
 msgstr "Полужирный"
 
-#: lib/typster_web/live/editor_live/index.html.heex:565
-#: lib/typster_web/live/editor_live/index.html.heex:566
+#: lib/typster_web/live/editor_live/index.html.heex:570
+#: lib/typster_web/live/editor_live/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "editor.format.heading"
 msgstr "Заголовок"
 
-#: lib/typster_web/live/editor_live/index.html.heex:612
-#: lib/typster_web/live/editor_live/index.html.heex:613
+#: lib/typster_web/live/editor_live/index.html.heex:617
+#: lib/typster_web/live/editor_live/index.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "editor.format.image"
 msgstr "Изображение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:555
-#: lib/typster_web/live/editor_live/index.html.heex:556
+#: lib/typster_web/live/editor_live/index.html.heex:560
+#: lib/typster_web/live/editor_live/index.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "editor.format.italic"
 msgstr "Курсив"
 
-#: lib/typster_web/live/editor_live/index.html.heex:593
-#: lib/typster_web/live/editor_live/index.html.heex:594
+#: lib/typster_web/live/editor_live/index.html.heex:598
+#: lib/typster_web/live/editor_live/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "editor.format.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:574
-#: lib/typster_web/live/editor_live/index.html.heex:575
+#: lib/typster_web/live/editor_live/index.html.heex:579
+#: lib/typster_web/live/editor_live/index.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "editor.format.list"
 msgstr "Список"
 
-#: lib/typster_web/live/editor_live/index.html.heex:584
-#: lib/typster_web/live/editor_live/index.html.heex:585
+#: lib/typster_web/live/editor_live/index.html.heex:589
+#: lib/typster_web/live/editor_live/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "editor.format.math"
 msgstr "Формула"
 
-#: lib/typster_web/live/editor_live/index.html.heex:602
-#: lib/typster_web/live/editor_live/index.html.heex:603
+#: lib/typster_web/live/editor_live/index.html.heex:607
+#: lib/typster_web/live/editor_live/index.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "editor.format.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:388
+#: lib/typster_web/live/editor_live/index.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "editor.outline"
 msgstr "Структура"
 
-#: lib/typster_web/live/editor_live/index.html.heex:395
+#: lib/typster_web/live/editor_live/index.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "editor.outline_empty"
 msgstr "Здесь появятся заголовки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:924
-#: lib/typster_web/live/editor_live/index.html.heex:932
-#: lib/typster_web/live/editor_live/index.html.heex:941
+#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:937
+#: lib/typster_web/live/editor_live/index.html.heex:946
 #, elixir-autogen, elixir-format
 msgid "editor.palette.compile"
 msgstr "Скомпилировать документ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:976
-#: lib/typster_web/live/editor_live/index.html.heex:984
-#: lib/typster_web/live/editor_live/index.html.heex:993
+#: lib/typster_web/live/editor_live/index.html.heex:1001
+#: lib/typster_web/live/editor_live/index.html.heex:1009
+#: lib/typster_web/live/editor_live/index.html.heex:1018
 #, elixir-autogen, elixir-format
 msgid "editor.palette.equation"
 msgstr "Блок формулы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:959
+#: lib/typster_web/live/editor_live/index.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "editor.palette.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:981
+#: lib/typster_web/live/editor_live/index.html.heex:1006
 #, elixir-autogen, elixir-format
 msgid "editor.palette.insert"
 msgstr "Вставить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:916
+#: lib/typster_web/live/editor_live/index.html.heex:921
 #, elixir-autogen, elixir-format
 msgid "editor.palette.placeholder"
 msgstr "Введите команду или запрос…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:925
-#: lib/typster_web/live/editor_live/index.html.heex:949
-#: lib/typster_web/live/editor_live/index.html.heex:955
+#: lib/typster_web/live/editor_live/index.html.heex:930
+#: lib/typster_web/live/editor_live/index.html.heex:954
+#: lib/typster_web/live/editor_live/index.html.heex:960
 #, elixir-autogen, elixir-format
 msgid "editor.palette.settings"
 msgstr "Настройки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:929
+#: lib/typster_web/live/editor_live/index.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "editor.palette.suggested"
 msgstr "Рекомендуемые"
 
-#: lib/typster_web/live/editor_live/index.html.heex:977
-#: lib/typster_web/live/editor_live/index.html.heex:996
-#: lib/typster_web/live/editor_live/index.html.heex:1005
+#: lib/typster_web/live/editor_live/index.html.heex:1002
+#: lib/typster_web/live/editor_live/index.html.heex:1021
+#: lib/typster_web/live/editor_live/index.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "editor.palette.table"
 msgstr "Таблица"
 
-#: lib/typster_web/live/editor_live/index.html.heex:683
+#: lib/typster_web/live/editor_live/index.html.heex:688
 #, elixir-autogen, elixir-format
 msgid "editor.preview_failed"
 msgstr "Ошибка сборки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:714
+#: lib/typster_web/live/editor_live/index.html.heex:719
 #, elixir-autogen, elixir-format
 msgid "editor.refresh"
 msgstr "Перекомпилировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
-#: lib/typster_web/live/editor_live/index.html.heex:76
+#: lib/typster_web/live/editor_live/index.html.heex:79
+#: lib/typster_web/live/editor_live/index.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "editor.share"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.html.heex:697
+#: lib/typster_web/live/editor_live/index.html.heex:702
 #, elixir-autogen, elixir-format
 msgid "editor.status_ready"
 msgstr "Готов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:706
+#: lib/typster_web/live/editor_live/index.html.heex:711
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_in"
 msgstr "Увеличить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:702
+#: lib/typster_web/live/editor_live/index.html.heex:707
 #, elixir-autogen, elixir-format
 msgid "editor.zoom_out"
 msgstr "Уменьшить"
@@ -833,38 +833,38 @@ msgstr "или по почте"
 msgid "auth.oauth.soon"
 msgstr "Вход через соцсети скоро появится"
 
-#: lib/typster_web/live/editor_live/index.html.heex:658
+#: lib/typster_web/live/editor_live/index.html.heex:663
 #, elixir-autogen, elixir-format
 msgid "editor.empty.new_file"
 msgstr "Новый файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:666
+#: lib/typster_web/live/editor_live/index.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "editor.empty.open_template"
 msgstr "Открыть шаблон"
 
-#: lib/typster_web/live/editor_live/index.html.heex:655
+#: lib/typster_web/live/editor_live/index.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "editor.empty.sub"
 msgstr "Выберите файл в дереве слева или начните новый документ."
 
-#: lib/typster_web/live/editor_live/index.html.heex:664
+#: lib/typster_web/live/editor_live/index.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "editor.empty.template_soon"
 msgstr "Шаблоны скоро появятся"
 
-#: lib/typster_web/live/editor_live/index.html.heex:653
+#: lib/typster_web/live/editor_live/index.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_accent"
 msgstr "страница"
 
-#: lib/typster_web/live/editor_live/index.html.heex:652
+#: lib/typster_web/live/editor_live/index.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "editor.empty.title_lead"
 msgstr "Чистая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:622
-#: lib/typster_web/live/editor_live/index.html.heex:623
+#: lib/typster_web/live/editor_live/index.html.heex:627
+#: lib/typster_web/live/editor_live/index.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "editor.find"
 msgstr "Поиск и замена"
@@ -1992,17 +1992,17 @@ msgstr "Технические отчёты"
 msgid "editor.view.flat"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_desc"
 msgstr "Полные пути"
 
-#: lib/typster_web/live/editor_live/index.html.heex:264
+#: lib/typster_web/live/editor_live/index.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "editor.view.flat_label"
 msgstr "Плоско"
 
-#: lib/typster_web/live/editor_live/index.html.heex:229
+#: lib/typster_web/live/editor_live/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "editor.view.label"
 msgstr "Вид списка файлов"
@@ -2012,67 +2012,67 @@ msgstr "Вид списка файлов"
 msgid "editor.view.smart"
 msgstr "Свёрнуто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:263
+#: lib/typster_web/live/editor_live/index.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_desc"
 msgstr "Папки с одним файлом — в строку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:262
+#: lib/typster_web/live/editor_live/index.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "editor.view.smart_label"
 msgstr "Умное сворачивание"
 
 #: lib/typster_web/file_tree.ex:13
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree"
 msgstr "Дерево"
 
-#: lib/typster_web/live/editor_live/index.html.heex:261
+#: lib/typster_web/live/editor_live/index.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "editor.view.tree_desc"
 msgstr "Сворачиваемые папки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:354
+#: lib/typster_web/live/editor_live/index.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.append_hint"
 msgstr "Добавится по нажатию Enter"
 
-#: lib/typster_web/live/editor_live/index.html.heex:341
+#: lib/typster_web/live/editor_live/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "editor.newfile.placeholder"
 msgstr "имя файла"
 
-#: lib/typster_web/live/editor_live/index.ex:536
-#: lib/typster_web/live/editor_live/index.ex:582
-#: lib/typster_web/live/editor_live/index.ex:743
+#: lib/typster_web/live/editor_live/index.ex:542
+#: lib/typster_web/live/editor_live/index.ex:588
+#: lib/typster_web/live/editor_live/index.ex:746
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
 
-#: lib/typster_web/live/editor_live/index.html.heex:57
+#: lib/typster_web/live/editor_live/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:680
+#: lib/typster_web/live/editor_live/index.ex:682
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:649
+#: lib/typster_web/live/editor_live/index.ex:655
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:287
+#: lib/typster_web/live/editor_live/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "editor.pinned"
 msgstr "Закреплённые"
 
 #: lib/typster_web/file_tree.ex:224
-#: lib/typster_web/live/editor_live/index.html.heex:478
-#: lib/typster_web/live/editor_live/index.html.heex:479
+#: lib/typster_web/live/editor_live/index.html.heex:483
+#: lib/typster_web/live/editor_live/index.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "editor.tree.delete"
 msgstr "Удалить файл"
@@ -2088,7 +2088,7 @@ msgid "editor.tree.pin"
 msgstr "Закрепить файл"
 
 #: lib/typster_web/file_tree.ex:194
-#: lib/typster_web/live/editor_live/index.html.heex:517
+#: lib/typster_web/live/editor_live/index.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "editor.tree.pinned"
 msgstr "Закреплён"
@@ -2098,7 +2098,7 @@ msgstr "Закреплён"
 msgid "editor.tree.unpin"
 msgstr "Открепить файл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:390
+#: lib/typster_web/live/editor_live/index.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "%{count} section"
 msgid_plural "%{count} sections"
@@ -2106,12 +2106,12 @@ msgstr[0] "%{count} раздел"
 msgstr[1] "%{count} раздела"
 msgstr[2] "%{count} разделов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:238
+#: lib/typster_web/live/editor_live/index.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "editor.new_folder"
 msgstr "Новая папка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:340
+#: lib/typster_web/live/editor_live/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "editor.newfolder.placeholder"
 msgstr "имя папки"
@@ -2121,45 +2121,45 @@ msgstr "имя папки"
 msgid "editor.breadcrumb"
 msgstr "Хлебные крошки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:530
+#: lib/typster_web/live/editor_live/index.html.heex:535
 #, elixir-autogen, elixir-format
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:837
+#: lib/typster_web/live/editor_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
 
-#: lib/typster_web/live/editor_live/index.html.heex:451
+#: lib/typster_web/live/editor_live/index.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "editor.templates"
 msgstr "Ваши шаблоны"
 
-#: lib/typster_web/live/editor_live/index.html.heex:477
+#: lib/typster_web/live/editor_live/index.html.heex:482
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.delete_confirm"
 msgstr "Удалить этот шаблон?"
 
-#: lib/typster_web/live/editor_live/index.html.heex:497
+#: lib/typster_web/live/editor_live/index.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.upload"
 msgstr "Загрузите файл для повторного использования"
 
-#: lib/typster_web/live/editor_live/index.html.heex:467
-#: lib/typster_web/live/editor_live/index.html.heex:468
+#: lib/typster_web/live/editor_live/index.html.heex:472
+#: lib/typster_web/live/editor_live/index.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:888
+#: lib/typster_web/live/editor_live/index.ex:895
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1363
-#: lib/typster_web/live/editor_live/index.html.heex:681
-#: lib/typster_web/live/editor_live/index.html.heex:889
+#: lib/typster_web/live/editor_live/index.ex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:686
+#: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
 msgid "%{count} error"
 msgid_plural "%{count} errors"
@@ -2167,86 +2167,86 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1365
+#: lib/typster_web/live/editor_live/index.ex:1372
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%{count} предупреждение"
+msgstr[1] "%{count} предупреждения"
+msgstr[2] "%{count} предупреждений"
 
-#: lib/typster_web/live/editor_live/index.ex:1369
+#: lib/typster_web/live/editor_live/index.ex:1376
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:795
+#: lib/typster_web/live/editor_live/index.html.heex:800
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.clear"
 msgstr "Очистить лог"
 
-#: lib/typster_web/live/editor_live/index.html.heex:801
+#: lib/typster_web/live/editor_live/index.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.close"
 msgstr "Закрыть панель"
 
-#: lib/typster_web/live/editor_live/index.html.heex:777
+#: lib/typster_web/live/editor_live/index.html.heex:782
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.jump_first"
 msgstr "К первой"
 
-#: lib/typster_web/live/editor_live/index.html.heex:752
-#: lib/typster_web/live/editor_live/index.html.heex:891
+#: lib/typster_web/live/editor_live/index.html.heex:757
+#: lib/typster_web/live/editor_live/index.html.heex:896
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log"
 msgstr "Лог компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:809
+#: lib/typster_web/live/editor_live/index.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.log_empty"
 msgstr "Пока нет компиляций"
 
-#: lib/typster_web/live/editor_live/index.html.heex:822
+#: lib/typster_web/live/editor_live/index.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.no_problems"
 msgstr "Нет проблем"
 
-#: lib/typster_web/live/editor_live/index.html.heex:761
+#: lib/typster_web/live/editor_live/index.html.heex:766
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.problems"
 msgstr "Проблемы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:882
+#: lib/typster_web/live/editor_live/index.html.heex:887
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.toggle"
 msgstr "Показать панель компиляции"
 
-#: lib/typster_web/live/editor_live/index.html.heex:782
+#: lib/typster_web/live/editor_live/index.html.heex:787
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.delay_off"
 msgstr "Выкл"
 
-#: lib/typster_web/live/editor_live/index.html.heex:780
+#: lib/typster_web/live/editor_live/index.html.heex:785
 #, elixir-autogen, elixir-format
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:942
+#: lib/typster_web/live/editor_live/index.ex:949
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:929
+#: lib/typster_web/live/editor_live/index.ex:936
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
 
-#: lib/typster_web/live/editor_live/index.html.heex:163
+#: lib/typster_web/live/editor_live/index.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.account"
 msgstr "Аккаунт"
 
-#: lib/typster_web/live/editor_live/index.html.heex:179
+#: lib/typster_web/live/editor_live/index.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.appearance"
 msgstr "Оформление"
@@ -2256,12 +2256,12 @@ msgstr "Оформление"
 msgid "editor.topbar.back"
 msgstr "Назад"
 
-#: lib/typster_web/live/editor_live/index.html.heex:124
+#: lib/typster_web/live/editor_live/index.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.collaborators"
 msgstr "Соавторы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:91
+#: lib/typster_web/live/editor_live/index.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.failed"
 msgstr "Ошибка"
@@ -2271,17 +2271,17 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:1014
+#: lib/typster_web/live/editor_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
 
-#: lib/typster_web/live/editor_live/index.html.heex:152
+#: lib/typster_web/live/editor_live/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.language"
 msgstr "Язык"
 
-#: lib/typster_web/live/editor_live/index.html.heex:60
+#: lib/typster_web/live/editor_live/index.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.omni_placeholder"
 msgstr "Поиск файлов, команды, переходы…"
@@ -2291,268 +2291,268 @@ msgstr "Поиск файлов, команды, переходы…"
 msgid "editor.topbar.switch_project"
 msgstr "Сменить проект"
 
-#: lib/typster_web/live/editor_live/index.html.heex:49
+#: lib/typster_web/live/editor_live/index.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.branch"
 msgstr "Ветка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:861
+#: lib/typster_web/live/editor_live/index.html.heex:866
 #, elixir-autogen, elixir-format
 msgid "editor.status.compile_times"
 msgstr "Время компиляции (последние 12)"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1033
+#: lib/typster_web/live/editor_live/index.html.heex:1058
 #, elixir-autogen, elixir-format
 msgid "common.close"
 msgstr "Закрыть"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1156
-#: lib/typster_web/live/editor_live/index.html.heex:1453
+#: lib/typster_web/live/editor_live/index.html.heex:1181
+#: lib/typster_web/live/editor_live/index.html.heex:1478
 #, elixir-autogen, elixir-format
 msgid "common.copy"
 msgstr "Копировать"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1494
+#: lib/typster_web/live/editor_live/index.html.heex:1519
 #, elixir-autogen, elixir-format
 msgid "common.done"
 msgstr "Готово"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1263
+#: lib/typster_web/live/editor_live/index.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "share.adv.download"
 msgstr "Разрешить скачивание"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1264
+#: lib/typster_web/live/editor_live/index.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "share.adv.download_sub"
 msgstr "Посетители могут скачать готовый PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1279
+#: lib/typster_web/live/editor_live/index.html.heex:1304
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires"
 msgstr "Истекает через 30 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1280
+#: lib/typster_web/live/editor_live/index.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "share.adv.expires_sub"
 msgstr "Автоматически отзывает ссылку по сроку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1283
+#: lib/typster_web/live/editor_live/index.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "share.adv.password"
 msgstr "Пароль"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1284
+#: lib/typster_web/live/editor_live/index.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "share.adv.password_sub"
 msgstr "Посетитель вводит пароль перед открытием."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1274
+#: lib/typster_web/live/editor_live/index.html.heex:1299
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin"
 msgstr "Требовать вход"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1275
+#: lib/typster_web/live/editor_live/index.html.heex:1300
 #, elixir-autogen, elixir-format
 msgid "share.adv.signin_sub"
 msgstr "Нужен вход в аккаунт Typster."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1336
+#: lib/typster_web/live/editor_live/index.html.heex:1361
 #, elixir-autogen, elixir-format
 msgid "share.embed.components"
 msgstr "Компоненты"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1350
+#: lib/typster_web/live/editor_live/index.html.heex:1375
 #, elixir-autogen, elixir-format
 msgid "share.embed.editable"
 msgstr "Гость может править"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1340
+#: lib/typster_web/live/editor_live/index.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "share.embed.file_tree"
 msgstr "Дерево файлов"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1328
+#: lib/typster_web/live/editor_live/index.html.heex:1353
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_desc"
 msgstr "Гости могут читать и открывать проект на любом тарифе. Обновитесь до Pro, чтобы они правили прямо в браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1327
+#: lib/typster_web/live/editor_live/index.html.heex:1352
 #, elixir-autogen, elixir-format
 msgid "share.embed.free_title"
 msgstr "Встраивание бесплатно — интерактивная песочница в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1345
+#: lib/typster_web/live/editor_live/index.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "share.embed.preview"
 msgstr "Превью"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1479
+#: lib/typster_web/live/editor_live/index.html.heex:1504
 #, elixir-autogen, elixir-format
 msgid "share.export.download"
 msgstr "Скачать PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1485
+#: lib/typster_web/live/editor_live/index.html.heex:1510
 #, elixir-autogen, elixir-format
 msgid "share.export.hint"
 msgstr "Экспортирует документ, собранный в вашем браузере."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1463
+#: lib/typster_web/live/editor_live/index.html.heex:1488
 #, elixir-autogen, elixir-format
 msgid "share.export.label"
 msgstr "Последний успешный результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1471
+#: lib/typster_web/live/editor_live/index.html.heex:1496
 #, elixir-autogen, elixir-format
 msgid "share.export.meta"
 msgstr "Со встроенными шрифтами. Переэкспортируйте для обновления."
 
-#: lib/typster_web/live/editor_live/index.ex:372
+#: lib/typster_web/live/editor_live/index.ex:376
 #, elixir-autogen, elixir-format
 msgid "share.flash.invite_failed"
 msgstr "Не удалось отправить приглашение."
 
-#: lib/typster_web/live/editor_live/index.ex:369
+#: lib/typster_web/live/editor_live/index.ex:373
 #, elixir-autogen, elixir-format
 msgid "share.flash.invited"
 msgstr "Приглашён %{email}"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1491
+#: lib/typster_web/live/editor_live/index.html.heex:1516
 #, elixir-autogen, elixir-format
 msgid "share.learn"
 msgstr "О правах доступа →"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1291
+#: lib/typster_web/live/editor_live/index.html.heex:1316
 #, elixir-autogen, elixir-format
 msgid "share.link.activity"
 msgstr "Активность ссылки"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1257
+#: lib/typster_web/live/editor_live/index.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "share.link.advanced"
 msgstr "Дополнительно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1143
+#: lib/typster_web/live/editor_live/index.html.heex:1168
 #, elixir-autogen, elixir-format
 msgid "share.link.label"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1178
+#: lib/typster_web/live/editor_live/index.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "share.link.perm_label"
 msgstr "Любой по ссылке может…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1166
+#: lib/typster_web/live/editor_live/index.html.heex:1191
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate"
 msgstr "Сменить ключ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1160
+#: lib/typster_web/live/editor_live/index.html.heex:1185
 #, elixir-autogen, elixir-format
 msgid "share.link.rotate_hint"
 msgstr "Смена ключа мгновенно отзывает текущую ссылку."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1079
+#: lib/typster_web/live/editor_live/index.html.heex:1104
 #, elixir-autogen, elixir-format
 msgid "share.people.add_placeholder"
 msgstr "Добавить по email…"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1066
+#: lib/typster_web/live/editor_live/index.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "share.people.invite"
 msgstr "Пригласить людей"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1092
+#: lib/typster_web/live/editor_live/index.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1137
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1124
+#: lib/typster_web/live/editor_live/index.html.heex:1149
 #, elixir-autogen, elixir-format
 msgid "share.people.pending"
 msgstr "Ожидает"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1131
+#: lib/typster_web/live/editor_live/index.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "share.people.remove"
 msgstr "Удалить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1089
+#: lib/typster_web/live/editor_live/index.html.heex:1114
 #, elixir-autogen, elixir-format
 msgid "share.people.send"
 msgstr "Отправить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1097
+#: lib/typster_web/live/editor_live/index.html.heex:1122
 #, elixir-autogen, elixir-format
 msgid "share.people.with_access"
 msgstr "Есть доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1107
+#: lib/typster_web/live/editor_live/index.html.heex:1132
 #, elixir-autogen, elixir-format
 msgid "share.people.you"
 msgstr "вы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1249
+#: lib/typster_web/live/editor_live/index.html.heex:1274
 #, elixir-autogen, elixir-format
 msgid "share.perm.careful"
 msgstr "осторожно"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1250
+#: lib/typster_web/live/editor_live/index.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "share.perm.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1251
+#: lib/typster_web/live/editor_live/index.html.heex:1276
 #, elixir-autogen, elixir-format
 msgid "share.perm.full_desc"
 msgstr "Чтение и запись всего, управление ссылкой. Как у владельца."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1194
+#: lib/typster_web/live/editor_live/index.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "share.perm.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1195
+#: lib/typster_web/live/editor_live/index.html.heex:1220
 #, elixir-autogen, elixir-format
 msgid "share.perm.output_desc"
 msgstr "Скрывает исходник. Показывает последний успешный результат."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1193
+#: lib/typster_web/live/editor_live/index.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "share.perm.pdf_only"
 msgstr "только PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1185
+#: lib/typster_web/live/editor_live/index.html.heex:1210
 #, elixir-autogen, elixir-format
 msgid "share.perm.read"
 msgstr "Чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1186
+#: lib/typster_web/live/editor_live/index.html.heex:1211
 #, elixir-autogen, elixir-format
 msgid "share.perm.read_desc"
 msgstr "Видит исходник и превью в реальном времени. Без правок."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1220
+#: lib/typster_web/live/editor_live/index.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "share.perm.write"
 msgstr "Запись — выбранные файлы"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1228
+#: lib/typster_web/live/editor_live/index.html.heex:1253
 #, elixir-autogen, elixir-format
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
 
-#: lib/typster_web/live/editor_live/index.ex:1123
+#: lib/typster_web/live/editor_live/index.ex:1130
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1123
+#: lib/typster_web/live/editor_live/index.ex:1130
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2577,115 +2577,115 @@ msgstr "Ссылку могли сменить или отозвать."
 msgid "share.public.invalid_title"
 msgstr "Ссылка недействительна"
 
-#: lib/typster_web/live/shared_project_live.ex:171
+#: lib/typster_web/live/shared_project_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1128
-#: lib/typster_web/live/editor_live/index.html.heex:1085
+#: lib/typster_web/live/editor_live/index.ex:1135
+#: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
-#: lib/typster_web/live/editor_live/index.ex:1126
-#: lib/typster_web/live/editor_live/index.html.heex:1113
+#: lib/typster_web/live/editor_live/index.ex:1133
+#: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
-#: lib/typster_web/live/editor_live/index.ex:1127
-#: lib/typster_web/live/editor_live/index.html.heex:1086
+#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
 msgstr "Читатель"
 
-#: lib/typster_web/live/shared_project_live.ex:193
+#: lib/typster_web/live/shared_project_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/shared_project_live.ex:192
+#: lib/typster_web/live/shared_project_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Только чтение"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1306
+#: lib/typster_web/live/editor_live/index.html.heex:1331
 #, elixir-autogen, elixir-format
 msgid "share.stats.created"
 msgstr "Ссылка создана"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1302
+#: lib/typster_web/live/editor_live/index.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "share.stats.editors"
 msgstr "Сейчас редактируют"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1298
+#: lib/typster_web/live/editor_live/index.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "share.stats.opens"
 msgstr "Открытий за 7 дней"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1025
+#: lib/typster_web/live/editor_live/index.html.heex:1050
 #, elixir-autogen, elixir-format
 msgid "share.subtitle"
 msgstr "Пригласите соавторов, поделитесь ссылкой, встройте проект или скачайте PDF."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1046
+#: lib/typster_web/live/editor_live/index.html.heex:1071
 #, elixir-autogen, elixir-format
 msgid "share.tab.embed"
 msgstr "Встроить"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1047
+#: lib/typster_web/live/editor_live/index.html.heex:1072
 #, elixir-autogen, elixir-format
 msgid "share.tab.export"
 msgstr "Экспорт PDF"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1045
+#: lib/typster_web/live/editor_live/index.html.heex:1070
 #, elixir-autogen, elixir-format
 msgid "share.tab.link"
 msgstr "Ссылка"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1044
+#: lib/typster_web/live/editor_live/index.html.heex:1069
 #, elixir-autogen, elixir-format
 msgid "share.tab.people"
 msgstr "Люди"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1023
+#: lib/typster_web/live/editor_live/index.html.heex:1048
 #, elixir-autogen, elixir-format
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1224
+#: lib/typster_web/live/editor_live/index.ex:1231
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1316
+#: lib/typster_web/live/editor_live/index.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_desc"
 msgstr "Открытия, активные редакторы и геолокация — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1315
+#: lib/typster_web/live/editor_live/index.html.heex:1340
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.stats_title"
 msgstr "Кто открывает вашу ссылку"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1270
+#: lib/typster_web/live/editor_live/index.html.heex:1295
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.unlock"
 msgstr "Открыть в Pro"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1238
+#: lib/typster_web/live/editor_live/index.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_desc"
 msgstr "Бесплатные ссылки — только чтение или полный доступ. Точечная запись — в Pro."
 
-#: lib/typster_web/live/editor_live/index.html.heex:1237
+#: lib/typster_web/live/editor_live/index.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.write_title"
 msgstr "Пофайловая запись — в Pro"
@@ -2700,68 +2700,68 @@ msgstr "Готово — добро пожаловать в проект."
 msgid "share.invite.invalid"
 msgstr "Эта ссылка-приглашение недействительна или истекла."
 
-#: lib/typster_web/live/shared_project_live.ex:156
+#: lib/typster_web/live/shared_project_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Работает на"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1369
+#: lib/typster_web/live/editor_live/index.html.heex:1394
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_always"
 msgstr "Всегда"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1371
+#: lib/typster_web/live/editor_live/index.html.heex:1396
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_hidden"
 msgstr "Скрыта"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1370
+#: lib/typster_web/live/editor_live/index.html.heex:1395
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_onedit"
 msgstr "При правке"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1356
+#: lib/typster_web/live/editor_live/index.html.heex:1381
 #, elixir-autogen, elixir-format
 msgid "share.embed.hide_footer"
 msgstr "Скрыть подпись Typster"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1407
-#: lib/typster_web/live/editor_live/index.html.heex:1417
+#: lib/typster_web/live/editor_live/index.html.heex:1432
+#: lib/typster_web/live/editor_live/index.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "share.embed.live_preview"
 msgstr "Живой предпросмотр"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1363
+#: lib/typster_web/live/editor_live/index.html.heex:1388
 #, elixir-autogen, elixir-format
 msgid "share.embed.save_cta"
 msgstr "Кнопка «Сохранить»"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1377
+#: lib/typster_web/live/editor_live/index.html.heex:1402
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme"
 msgstr "Тема"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1383
+#: lib/typster_web/live/editor_live/index.html.heex:1408
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_auto"
 msgstr "Авто"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1385
+#: lib/typster_web/live/editor_live/index.html.heex:1410
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_dark"
 msgstr "Тёмная"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1384
+#: lib/typster_web/live/editor_live/index.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "share.embed.theme_light"
 msgstr "Светлая"
 
-#: lib/typster_web/live/editor_live/index.html.heex:1391
+#: lib/typster_web/live/editor_live/index.html.heex:1416
 #, elixir-autogen, elixir-format
 msgid "share.embed.width"
 msgstr "Ширина"
 
-#: lib/typster_web/live/editor_live/index.ex:1171
+#: lib/typster_web/live/editor_live/index.ex:1178
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// скоро™ — ещё готовим 🍳  пока бери iframe"
@@ -2776,17 +2776,17 @@ msgstr "Общий"
 msgid "share.invite.wrong_account"
 msgstr "Сюжетный поворот — приглашение оформлено на другой адрес. Войдите под приглашённым аккаунтом, чтобы забрать проект."
 
-#: lib/typster_web/live/editor_live/index.html.heex:74
+#: lib/typster_web/live/editor_live/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "editor.share_owner_only"
 msgstr "Только владелец — делиться решает он."
 
-#: lib/typster_web/live/shared_project_live.ex:167
+#: lib/typster_web/live/shared_project_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr "Форкнуть в Typster"
 
-#: lib/typster_web/live/shared_project_live.ex:163
+#: lib/typster_web/live/shared_project_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr "Сделать свой"
@@ -2796,17 +2796,17 @@ msgstr "Сделать свой"
 msgid "share.scope.sandbox"
 msgstr "Песочница"
 
-#: lib/typster_web/live/editor_live/index.ex:1055
+#: lib/typster_web/live/editor_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Аналитика ссылки"
 
-#: lib/typster_web/live/editor_live/index.ex:1057
+#: lib/typster_web/live/editor_live/index.ex:1064
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "за неделю"
 
-#: lib/typster_web/live/editor_live/index.ex:1056
+#: lib/typster_web/live/editor_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "открытий"
@@ -2847,3 +2847,54 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "error.not_found.title"
 msgstr "Висячая ссылка."
+
+#: lib/typster_web/live/editor_live/index.html.heex:983
+#, elixir-autogen, elixir-format
+msgid "editor.palette.headings"
+msgstr "Заголовки"
+
+#: lib/typster_web/controllers/user_session_controller.ex:8
+#, elixir-autogen, elixir-format
+msgid "auth.flash.confirmed"
+msgstr "Аккаунт подтверждён."
+
+#: lib/typster_web/controllers/user_session_controller.ex:61
+#, elixir-autogen, elixir-format
+msgid "auth.flash.invalid_credentials"
+msgstr "Неверный email или пароль"
+
+#: lib/typster_web/controllers/user_session_controller.ex:27
+#, elixir-autogen, elixir-format
+msgid "auth.flash.link_invalid"
+msgstr "Ссылка недействительна или устарела."
+
+#: lib/typster_web/controllers/user_session_controller.ex:82
+#, elixir-autogen, elixir-format
+msgid "auth.flash.logged_out"
+msgstr "Вы вышли из аккаунта."
+
+#: lib/typster_web/user_auth.ex:261
+#: lib/typster_web/user_auth.ex:310
+#, elixir-autogen, elixir-format
+msgid "auth.flash.login_required"
+msgstr "Чтобы открыть эту страницу, войдите в аккаунт."
+
+#: lib/typster_web/controllers/user_session_controller.ex:45
+#, elixir-autogen, elixir-format
+msgid "auth.flash.magic_link_sent"
+msgstr "Если этот адрес есть у нас в системе, письмо со ссылкой для входа уже летит к вам."
+
+#: lib/typster_web/controllers/user_session_controller.ex:77
+#, elixir-autogen, elixir-format
+msgid "auth.flash.password_updated"
+msgstr "Пароль обновлён!"
+
+#: lib/typster_web/user_auth.ex:276
+#, elixir-autogen, elixir-format
+msgid "auth.flash.reauth_required"
+msgstr "Для доступа к этой странице нужно войти заново."
+
+#: lib/typster_web/controllers/user_session_controller.ex:12
+#, elixir-autogen, elixir-format
+msgid "auth.flash.welcome_back"
+msgstr "С возвращением!"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -156,12 +156,12 @@ msgstr "Скачать"
 msgid "editor.files"
 msgstr "Файлы"
 
-#: lib/typster_web/live/editor_live/index.ex:715
+#: lib/typster_web/live/editor_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_upload_failed"
 msgstr "Ассет не загрузился."
 
-#: lib/typster_web/live/editor_live/index.ex:712
+#: lib/typster_web/live/editor_live/index.ex:714
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_uploaded"
 msgstr "Ассет на месте."
@@ -171,14 +171,14 @@ msgstr "Ассет на месте."
 msgid "editor.flash.binary_asset"
 msgstr "Бинарные ассеты нельзя открыть в редакторе."
 
-#: lib/typster_web/live/editor_live/index.ex:747
+#: lib/typster_web/live/editor_live/index.ex:749
 #, elixir-autogen, elixir-format
 msgid "editor.flash.create_failed"
 msgstr "Файл не удалось создать."
 
 #: lib/typster_web/live/editor_live/index.ex:577
-#: lib/typster_web/live/editor_live/index.ex:601
-#: lib/typster_web/live/editor_live/index.ex:894
+#: lib/typster_web/live/editor_live/index.ex:603
+#: lib/typster_web/live/editor_live/index.ex:909
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -209,17 +209,17 @@ msgstr "Превью"
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:828
+#: lib/typster_web/live/editor_live/index.ex:843
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:826
+#: lib/typster_web/live/editor_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:827
+#: lib/typster_web/live/editor_live/index.ex:842
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -2045,7 +2045,7 @@ msgstr "имя файла"
 
 #: lib/typster_web/live/editor_live/index.ex:542
 #: lib/typster_web/live/editor_live/index.ex:588
-#: lib/typster_web/live/editor_live/index.ex:746
+#: lib/typster_web/live/editor_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_exists"
 msgstr "Файл с таким путём уже существует — выбери другое имя."
@@ -2055,12 +2055,12 @@ msgstr "Файл с таким путём уже существует — выб
 msgid "editor.command_open"
 msgstr "Открыть палитру команд"
 
-#: lib/typster_web/live/editor_live/index.ex:682
+#: lib/typster_web/live/editor_live/index.ex:684
 #, elixir-autogen, elixir-format
 msgid "editor.flash.asset_deleted"
 msgstr "Ассет удалён."
 
-#: lib/typster_web/live/editor_live/index.ex:655
+#: lib/typster_web/live/editor_live/index.ex:657
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_deleted"
 msgstr "Файл удалён."
@@ -2126,7 +2126,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:844
+#: lib/typster_web/live/editor_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2152,12 +2152,12 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:895
+#: lib/typster_web/live/editor_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1370
+#: lib/typster_web/live/editor_live/index.ex:1385
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1372
+#: lib/typster_web/live/editor_live/index.ex:1387
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,7 +2175,7 @@ msgstr[0] "%{count} предупреждение"
 msgstr[1] "%{count} предупреждения"
 msgstr[2] "%{count} предупреждений"
 
-#: lib/typster_web/live/editor_live/index.ex:1376
+#: lib/typster_web/live/editor_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2231,12 +2231,12 @@ msgstr "Выкл"
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:949
+#: lib/typster_web/live/editor_live/index.ex:964
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:936
+#: lib/typster_web/live/editor_live/index.ex:951
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
@@ -2271,7 +2271,7 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:1021
+#: lib/typster_web/live/editor_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
@@ -2467,7 +2467,7 @@ msgstr "Пригласить людей"
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
 
-#: lib/typster_web/live/editor_live/index.ex:1137
+#: lib/typster_web/live/editor_live/index.ex:1152
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
@@ -2547,12 +2547,12 @@ msgstr "Запись — выбранные файлы"
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1130
+#: lib/typster_web/live/editor_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2582,19 +2582,19 @@ msgstr "Ссылка недействительна"
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1135
+#: lib/typster_web/live/editor_live/index.ex:1150
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
-#: lib/typster_web/live/editor_live/index.ex:1133
+#: lib/typster_web/live/editor_live/index.ex:1148
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
-#: lib/typster_web/live/editor_live/index.ex:1134
+#: lib/typster_web/live/editor_live/index.ex:1149
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
@@ -2660,7 +2660,7 @@ msgstr "Люди"
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1231
+#: lib/typster_web/live/editor_live/index.ex:1246
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
@@ -2761,7 +2761,7 @@ msgstr "Светлая"
 msgid "share.embed.width"
 msgstr "Ширина"
 
-#: lib/typster_web/live/editor_live/index.ex:1178
+#: lib/typster_web/live/editor_live/index.ex:1193
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// скоро™ — ещё готовим 🍳  пока бери iframe"
@@ -2796,17 +2796,17 @@ msgstr "Сделать свой"
 msgid "share.scope.sandbox"
 msgstr "Песочница"
 
-#: lib/typster_web/live/editor_live/index.ex:1062
+#: lib/typster_web/live/editor_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Аналитика ссылки"
 
-#: lib/typster_web/live/editor_live/index.ex:1064
+#: lib/typster_web/live/editor_live/index.ex:1079
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "за неделю"
 
-#: lib/typster_web/live/editor_live/index.ex:1063
+#: lib/typster_web/live/editor_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "открытий"
@@ -2898,3 +2898,28 @@ msgstr "Для доступа к этой странице нужно войти
 #, elixir-autogen, elixir-format
 msgid "auth.flash.welcome_back"
 msgstr "С возвращением!"
+
+#: lib/typster_web/live/editor_live/index.ex:783
+#, elixir-autogen, elixir-format
+msgid "editor.starter.body"
+msgstr "Сочетай *жирный*, _курсив_ и `моноширинный` текст или закинь немного математики: $E = m c^2$. Заголовки, списки и фигуры просто работают:"
+
+#: lib/typster_web/live/editor_live/index.ex:779
+#, elixir-autogen, elixir-format
+msgid "editor.starter.heading"
+msgstr "Введение"
+
+#: lib/typster_web/live/editor_live/index.ex:781
+#, elixir-autogen, elixir-format
+msgid "editor.starter.intro"
+msgstr "Добро пожаловать в Typster. Документ компилируется вживую — без `latexmk` и без ожидания."
+
+#: lib/typster_web/live/editor_live/index.ex:785
+#, elixir-autogen, elixir-format
+msgid "editor.starter.point1"
+msgstr "Печатай сюда"
+
+#: lib/typster_web/live/editor_live/index.ex:786
+#, elixir-autogen, elixir-format
+msgid "editor.starter.point2"
+msgstr "Удали, когда появятся настоящие мысли"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -178,7 +178,7 @@ msgstr "Файл не удалось создать."
 
 #: lib/typster_web/live/editor_live/index.ex:577
 #: lib/typster_web/live/editor_live/index.ex:603
-#: lib/typster_web/live/editor_live/index.ex:909
+#: lib/typster_web/live/editor_live/index.ex:898
 #, elixir-autogen, elixir-format
 msgid "editor.flash.unsupported_file"
 msgstr "Неподдерживаемый формат файла."
@@ -209,17 +209,17 @@ msgstr "Превью"
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
 
-#: lib/typster_web/live/editor_live/index.ex:843
+#: lib/typster_web/live/editor_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "editor.status.error"
 msgstr "Ошибка"
 
-#: lib/typster_web/live/editor_live/index.ex:841
+#: lib/typster_web/live/editor_live/index.ex:830
 #, elixir-autogen, elixir-format
 msgid "editor.status.saved"
 msgstr "Сохранено"
 
-#: lib/typster_web/live/editor_live/index.ex:842
+#: lib/typster_web/live/editor_live/index.ex:831
 #, elixir-autogen, elixir-format
 msgid "editor.status.saving"
 msgstr "Сохраняем"
@@ -2126,7 +2126,7 @@ msgstr "Хлебные крошки"
 msgid "editor.tab.close"
 msgstr "Закрыть вкладку"
 
-#: lib/typster_web/live/editor_live/index.ex:859
+#: lib/typster_web/live/editor_live/index.ex:848
 #, elixir-autogen, elixir-format
 msgid "editor.flash.template_saved"
 msgstr "Шаблон сохранён."
@@ -2152,12 +2152,12 @@ msgstr "Загрузите файл для повторного использо
 msgid "editor.tpl.use"
 msgstr "Создать файл из этого шаблона"
 
-#: lib/typster_web/live/editor_live/index.ex:910
+#: lib/typster_web/live/editor_live/index.ex:899
 #, elixir-autogen, elixir-format
 msgid "editor.flash.dropped_added"
 msgstr "Добавлено в проект."
 
-#: lib/typster_web/live/editor_live/index.ex:1385
+#: lib/typster_web/live/editor_live/index.ex:1374
 #: lib/typster_web/live/editor_live/index.html.heex:686
 #: lib/typster_web/live/editor_live/index.html.heex:894
 #, elixir-autogen, elixir-format
@@ -2167,7 +2167,7 @@ msgstr[0] "%{count} ошибка"
 msgstr[1] "%{count} ошибки"
 msgstr[2] "%{count} ошибок"
 
-#: lib/typster_web/live/editor_live/index.ex:1387
+#: lib/typster_web/live/editor_live/index.ex:1376
 #, elixir-autogen, elixir-format
 msgid "%{count} warning"
 msgid_plural "%{count} warnings"
@@ -2175,7 +2175,7 @@ msgstr[0] "%{count} предупреждение"
 msgstr[1] "%{count} предупреждения"
 msgstr[2] "%{count} предупреждений"
 
-#: lib/typster_web/live/editor_live/index.ex:1391
+#: lib/typster_web/live/editor_live/index.ex:1380
 #, elixir-autogen, elixir-format
 msgid "editor.compile_failed"
 msgstr "Ошибка компиляции"
@@ -2231,12 +2231,12 @@ msgstr "Выкл"
 msgid "editor.drawer.recompile"
 msgstr "Перекомпиляция через"
 
-#: lib/typster_web/live/editor_live/index.ex:964
+#: lib/typster_web/live/editor_live/index.ex:953
 #, elixir-autogen, elixir-format
 msgid "editor.flash.file_moved"
 msgstr "Файл перемещён."
 
-#: lib/typster_web/live/editor_live/index.ex:951
+#: lib/typster_web/live/editor_live/index.ex:940
 #, elixir-autogen, elixir-format
 msgid "editor.flash.move_conflict"
 msgstr "Там уже лежит файл с таким именем."
@@ -2271,7 +2271,7 @@ msgstr "Ошибка"
 msgid "editor.topbar.forward"
 msgstr "Вперёд"
 
-#: lib/typster_web/live/editor_live/index.ex:1036
+#: lib/typster_web/live/editor_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "editor.topbar.guest"
 msgstr "Гость"
@@ -2467,7 +2467,7 @@ msgstr "Пригласить людей"
 msgid "share.people.invite_hint"
 msgstr "Приглашённые получат письмо со ссылкой и смогут редактировать после входа."
 
-#: lib/typster_web/live/editor_live/index.ex:1152
+#: lib/typster_web/live/editor_live/index.ex:1141
 #, elixir-autogen, elixir-format
 msgid "share.people.invite_sent"
 msgstr "Приглашение отправлено"
@@ -2547,12 +2547,12 @@ msgstr "Запись — выбранные файлы"
 msgid "share.perm.write_desc"
 msgstr "Выберите, какие файлы можно редактировать."
 
-#: lib/typster_web/live/editor_live/index.ex:1145
+#: lib/typster_web/live/editor_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "share.plan.free"
 msgstr "Free"
 
-#: lib/typster_web/live/editor_live/index.ex:1145
+#: lib/typster_web/live/editor_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "share.plan.pro"
 msgstr "Pro"
@@ -2582,19 +2582,19 @@ msgstr "Ссылка недействительна"
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
 
-#: lib/typster_web/live/editor_live/index.ex:1150
+#: lib/typster_web/live/editor_live/index.ex:1139
 #: lib/typster_web/live/editor_live/index.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "share.role.editor"
 msgstr "Редактор"
 
-#: lib/typster_web/live/editor_live/index.ex:1148
+#: lib/typster_web/live/editor_live/index.ex:1137
 #: lib/typster_web/live/editor_live/index.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "share.role.owner"
 msgstr "Владелец"
 
-#: lib/typster_web/live/editor_live/index.ex:1149
+#: lib/typster_web/live/editor_live/index.ex:1138
 #: lib/typster_web/live/editor_live/index.html.heex:1111
 #, elixir-autogen, elixir-format
 msgid "share.role.viewer"
@@ -2660,7 +2660,7 @@ msgstr "Люди"
 msgid "share.title"
 msgstr "Поделиться"
 
-#: lib/typster_web/live/editor_live/index.ex:1246
+#: lib/typster_web/live/editor_live/index.ex:1235
 #, elixir-autogen, elixir-format
 msgid "share.upgrade.cta"
 msgstr "Перейти на Pro"
@@ -2761,7 +2761,7 @@ msgstr "Светлая"
 msgid "share.embed.width"
 msgstr "Ширина"
 
-#: lib/typster_web/live/editor_live/index.ex:1193
+#: lib/typster_web/live/editor_live/index.ex:1182
 #, elixir-autogen, elixir-format
 msgid "share.embed.coming_soon"
 msgstr "// скоро™ — ещё готовим 🍳  пока бери iframe"
@@ -2796,17 +2796,17 @@ msgstr "Сделать свой"
 msgid "share.scope.sandbox"
 msgstr "Песочница"
 
-#: lib/typster_web/live/editor_live/index.ex:1077
+#: lib/typster_web/live/editor_live/index.ex:1066
 #, elixir-autogen, elixir-format
 msgid "share.analytics.label"
 msgstr "Аналитика ссылки"
 
-#: lib/typster_web/live/editor_live/index.ex:1079
+#: lib/typster_web/live/editor_live/index.ex:1068
 #, elixir-autogen, elixir-format
 msgid "share.analytics.last_7d"
 msgstr "за неделю"
 
-#: lib/typster_web/live/editor_live/index.ex:1078
+#: lib/typster_web/live/editor_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "share.analytics.total"
 msgstr "открытий"
@@ -2899,27 +2899,15 @@ msgstr "Для доступа к этой странице нужно войти
 msgid "auth.flash.welcome_back"
 msgstr "С возвращением!"
 
-#: lib/typster_web/live/editor_live/index.ex:783
+#: lib/typster_web/live/editor_live/index.ex:773
 #, elixir-autogen, elixir-format
-msgid "editor.starter.body"
-msgstr "Сочетай *жирный*, _курсив_ и `моноширинный` текст или закинь немного математики: $E = m c^2$. Заголовки, списки и фигуры просто работают:"
-
-#: lib/typster_web/live/editor_live/index.ex:779
-#, elixir-autogen, elixir-format
-msgid "editor.starter.heading"
-msgstr "Введение"
-
-#: lib/typster_web/live/editor_live/index.ex:781
-#, elixir-autogen, elixir-format
-msgid "editor.starter.intro"
-msgstr "Добро пожаловать в Typster. Документ компилируется вживую — без `latexmk` и без ожидания."
-
-#: lib/typster_web/live/editor_live/index.ex:785
-#, elixir-autogen, elixir-format
-msgid "editor.starter.point1"
-msgstr "Печатай сюда"
-
-#: lib/typster_web/live/editor_live/index.ex:786
-#, elixir-autogen, elixir-format
-msgid "editor.starter.point2"
-msgstr "Удали, когда появятся настоящие мысли"
+msgid "editor.starter.doc"
+msgstr ""
+"= Введение\n"
+"\n"
+"Добро пожаловать в Typster. Документ компилируется вживую — без `latexmk` и без ожидания.\n"
+"\n"
+"Сочетай *жирный*, _курсив_ и `моноширинный` текст или закинь немного математики: $E = m c^2$. Заголовки, списки и фигуры просто работают:\n"
+"\n"
+"- Печатай сюда\n"
+"- Удали, когда появятся настоящие мысли\n"

--- a/priv/repo/migrations/20260706000000_add_join_policies_to_share_links.exs
+++ b/priv/repo/migrations/20260706000000_add_join_policies_to_share_links.exs
@@ -1,0 +1,12 @@
+defmodule Typster.Repo.Migrations.AddJoinPoliciesToShareLinks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:share_links) do
+      # Both default to false: visitors can neither copy the project nor join
+      # as collaborators until the owner explicitly opts in per link.
+      add :allow_fork, :boolean, default: false, null: false
+      add :open_edit, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/typster/analytics_test.exs
+++ b/test/typster/analytics_test.exs
@@ -1,0 +1,32 @@
+defmodule Typster.AnalyticsTest do
+  use Typster.DataCase, async: false
+
+  alias Typster.Analytics
+
+  defmodule ExplodingImpl do
+    def record(_repo, _token, _opts), do: raise(RuntimeError, "table missing")
+    def summary(_repo, _token), do: raise(RuntimeError, "table missing")
+  end
+
+  # A failing analytics impl (e.g. a Pro build whose pro_share_opens migration
+  # hasn't run) must degrade gracefully — a public embed/share open must never
+  # 500 because of a stats INSERT, and the owner's Share modal must still open.
+  describe "best-effort dispatch" do
+    setup do
+      Application.put_env(:typster, :analytics_impl, ExplodingImpl)
+      on_exit(fn -> Application.delete_env(:typster, :analytics_impl) end)
+      :ok
+    end
+
+    test "record/2 swallows impl crashes" do
+      assert Analytics.record("some-token") == :error
+    end
+
+    test "summary/1 degrades to zeros when the impl crashes" do
+      assert %{total: 0, last_7d: 0, last_at: nil, daily: daily} =
+               Analytics.summary("some-token")
+
+      assert Enum.all?(daily, &(&1 == 0))
+    end
+  end
+end

--- a/test/typster/files_test.exs
+++ b/test/typster/files_test.exs
@@ -134,6 +134,89 @@ defmodule Typster.FilesTest do
     end
   end
 
+  describe "create_file/3 path validation" do
+    setup do
+      user = Typster.AccountsFixtures.user_fixture()
+      %{scope: Typster.Accounts.Scope.for_user(user), project: project_fixture(user)}
+    end
+
+    test "rejects traversal, absolute, backslash, and empty-segment paths", %{
+      scope: scope,
+      project: project
+    } do
+      bad_paths = [
+        "../evil.typ",
+        "a/../b.typ",
+        "./x.typ",
+        "/etc/x.typ",
+        "a\\b.typ",
+        "a//b.typ",
+        "a/ /b.typ"
+      ]
+
+      for bad <- bad_paths do
+        assert {:error, changeset} = Files.create_file(scope, project.id, %{path: bad})
+        assert %{path: [_ | _]} = errors_on(changeset)
+      end
+    end
+
+    test "accepts normal nested relative paths", %{scope: scope, project: project} do
+      assert {:ok, _} = Files.create_file(scope, project.id, %{path: "chapters/01-intro.typ"})
+      assert {:ok, _} = Files.create_file(scope, project.id, %{path: "refs.bib"})
+    end
+
+    test "update_file/3 enforces the same path rules", %{scope: scope, project: project} do
+      {:ok, file} = Files.create_file(scope, project.id, %{path: "ok.typ"})
+      assert {:error, changeset} = Files.update_file(scope, file, %{path: "../../etc/evil.typ"})
+      assert %{path: [_ | _]} = errors_on(changeset)
+    end
+  end
+
+  describe "create_file/3 parent scoping" do
+    setup do
+      user = Typster.AccountsFixtures.user_fixture()
+      %{scope: Typster.Accounts.Scope.for_user(user), project: project_fixture(user)}
+    end
+
+    test "accepts a parent from the same project", %{scope: scope, project: project} do
+      {:ok, parent} = Files.create_file(scope, project.id, %{path: "sections/intro.typ"})
+
+      assert {:ok, _} =
+               Files.create_file(scope, project.id, %{
+                 path: "sections/body.typ",
+                 parent_id: parent.id
+               })
+    end
+
+    test "rejects a parent from another project (cross-project linking)", %{
+      scope: scope,
+      project: project
+    } do
+      other = project_fixture(scope)
+      {:ok, foreign_parent} = Files.create_file(scope, other.id, %{path: "main.typ"})
+
+      assert {:error, changeset} =
+               Files.create_file(scope, project.id, %{path: "x.typ", parent_id: foreign_parent.id})
+
+      assert %{parent_id: ["does not belong to this project"]} = errors_on(changeset)
+    end
+
+    test "rejects a parent owned by a different user (cross-tenant linking)", %{
+      scope: scope,
+      project: project
+    } do
+      other_user = Typster.AccountsFixtures.user_fixture()
+      other_scope = Typster.Accounts.Scope.for_user(other_user)
+      other_project = project_fixture(other_user)
+      {:ok, foreign} = Files.create_file(other_scope, other_project.id, %{path: "main.typ"})
+
+      assert {:error, changeset} =
+               Files.create_file(scope, project.id, %{path: "x.typ", parent_id: foreign.id})
+
+      assert %{parent_id: ["does not belong to this project"]} = errors_on(changeset)
+    end
+  end
+
   describe "set_pinned/3" do
     setup do
       user = Typster.AccountsFixtures.user_fixture()

--- a/test/typster/projects_fork_test.exs
+++ b/test/typster/projects_fork_test.exs
@@ -1,0 +1,61 @@
+defmodule Typster.ProjectsForkTest do
+  use Typster.DataCase, async: true
+
+  import Typster.AccountsFixtures, only: [user_scope_fixture: 0]
+  import Typster.ProjectsFixtures
+
+  alias Typster.Files
+  alias Typster.Projects
+
+  setup do
+    owner = user_scope_fixture()
+    project = project_fixture(owner)
+    %{owner: owner, project: project}
+  end
+
+  describe "fork_project/3" do
+    test "deep-copies files and re-links the hierarchy to the new owner", %{
+      owner: owner,
+      project: project
+    } do
+      dir = file_fixture(project, owner, %{path: "chapters", content: nil})
+
+      child =
+        file_fixture(project, owner, %{
+          path: "chapters/one.typ",
+          content: "= One",
+          parent_id: dir.id
+        })
+
+      visitor = user_scope_fixture()
+      assert {:ok, fork} = Projects.fork_project(visitor, project, %{name: "My copy"})
+
+      assert fork.user_id == visitor.user.id
+      assert fork.name == "My copy"
+
+      copies = Files.get_file_tree(visitor, fork.id)
+      assert length(copies) == 2
+
+      dir_copy = Enum.find(copies, &(&1.path == "chapters"))
+      child_copy = Enum.find(copies, &(&1.path == "chapters/one.typ"))
+
+      # Fresh rows with the hierarchy remapped to the copied ids.
+      assert dir_copy.id != dir.id
+      assert child_copy.id != child.id
+      assert child_copy.parent_id == dir_copy.id
+      assert child_copy.content == "= One"
+
+      # The source project is untouched and still the original owner's.
+      originals = Files.get_file_tree(owner, project.id)
+      assert Enum.map(originals, & &1.id) |> Enum.sort() == Enum.sort([dir.id, child.id])
+    end
+
+    test "an invalid name rolls the whole fork back", %{owner: owner, project: project} do
+      file_fixture(project, owner, %{path: "main.typ", content: "= Hi"})
+      visitor = user_scope_fixture()
+
+      assert {:error, %Ecto.Changeset{}} = Projects.fork_project(visitor, project, %{name: ""})
+      assert Projects.list_projects(visitor) == []
+    end
+  end
+end

--- a/test/typster/sharing_join_test.exs
+++ b/test/typster/sharing_join_test.exs
@@ -1,0 +1,116 @@
+defmodule Typster.SharingJoinTest do
+  # async: false — these tests inject the :collaboration_impl override, which
+  # is global application env (same trade-off as Typster.FeaturesTest).
+  use Typster.DataCase, async: false
+
+  import Typster.AccountsFixtures, only: [user_scope_fixture: 0, user_fixture: 1]
+  import Typster.ProjectsFixtures
+
+  alias Typster.Accounts.Scope
+  alias Typster.Sharing
+  alias Typster.Sharing.Collaborator
+
+  # Stand-in for the private Typster.Pro.Collaboration: grants whenever the
+  # link's open_edit flag is on, ignoring the owner's plan.
+  defmodule OpenDoor do
+    def open_edit?(_owner, %{open_edit: open_edit}), do: open_edit
+  end
+
+  setup do
+    on_exit(fn -> Application.delete_env(:typster, :collaboration_impl) end)
+
+    owner = user_scope_fixture()
+    project = project_fixture(owner)
+    file_fixture(project, owner, %{path: "main.typ", content: "= Hi"})
+    link = Sharing.get_or_create_link(owner, project.id)
+
+    %{owner: owner, project: project, link: link}
+  end
+
+  describe "fork_via_link/3" do
+    test "clones the project for a stranger when allow_fork is on", %{
+      owner: owner,
+      project: project,
+      link: link
+    } do
+      {:ok, link} = Sharing.update_link(owner, link, %{allow_fork: true})
+      visitor = user_scope_fixture()
+
+      assert {:ok, fork} = Sharing.fork_via_link(visitor, link.token, %{name: "Mine now"})
+      assert fork.user_id == visitor.user.id
+      assert fork.id != project.id
+    end
+
+    test "refuses while allow_fork is off (the default)", %{link: link} do
+      visitor = user_scope_fixture()
+      assert {:error, :forbidden} = Sharing.fork_via_link(visitor, link.token, %{name: "Nope"})
+    end
+
+    test "unknown tokens and anonymous visitors get :not_found", %{link: link} do
+      visitor = user_scope_fixture()
+      assert {:error, :not_found} = Sharing.fork_via_link(visitor, "xxxx-xxxx-xxxx", %{name: "?"})
+      assert {:error, :not_found} = Sharing.fork_via_link(%Scope{user: nil}, link.token, %{})
+    end
+  end
+
+  describe "join_via_link/2" do
+    test "joins a stranger as an accepted editor and is idempotent", %{
+      owner: owner,
+      link: link
+    } do
+      {:ok, link} = Sharing.update_link(owner, link, %{open_edit: true})
+      Application.put_env(:typster, :collaboration_impl, OpenDoor)
+      visitor = user_scope_fixture()
+
+      assert {:ok, %Collaborator{} = collab} = Sharing.join_via_link(visitor, link.token)
+      assert collab.status == :accepted
+      assert collab.role == :editor
+      assert collab.user_id == visitor.user.id
+
+      assert {:ok, %Collaborator{id: same_id}} = Sharing.join_via_link(visitor, link.token)
+      assert same_id == collab.id
+    end
+
+    test "accepts a prior email invite in place, keeping its role", %{
+      owner: owner,
+      project: project,
+      link: link
+    } do
+      {:ok, link} = Sharing.update_link(owner, link, %{open_edit: true})
+      Application.put_env(:typster, :collaboration_impl, OpenDoor)
+
+      email = "invitee#{System.unique_integer([:positive])}@example.com"
+      {:ok, invite} = Sharing.invite_collaborator(owner, project.id, email, :viewer)
+      visitor = Scope.for_user(user_fixture(%{email: email}))
+
+      assert {:ok, %Collaborator{} = collab} = Sharing.join_via_link(visitor, link.token)
+      assert collab.id == invite.id
+      assert collab.status == :accepted
+      assert collab.role == :viewer
+      assert collab.user_id == visitor.user.id
+    end
+
+    test "the owner short-circuits without a collaborator row", %{owner: owner, link: link} do
+      {:ok, link} = Sharing.update_link(owner, link, %{open_edit: true})
+      Application.put_env(:typster, :collaboration_impl, OpenDoor)
+
+      assert {:ok, :owner} = Sharing.join_via_link(owner, link.token)
+      assert Sharing.list_collaborators(owner, link.project_id) == []
+    end
+
+    test "refuses while open_edit is off, even with a permissive impl", %{link: link} do
+      Application.put_env(:typster, :collaboration_impl, OpenDoor)
+      visitor = user_scope_fixture()
+
+      assert {:error, :forbidden} = Sharing.join_via_link(visitor, link.token)
+    end
+
+    test "the community fallback denies even with open_edit on", %{owner: owner, link: link} do
+      {:ok, link} = Sharing.update_link(owner, link, %{open_edit: true})
+      Application.put_env(:typster, :collaboration_impl, Typster.Sharing.Collaboration.Free)
+      visitor = user_scope_fixture()
+
+      assert {:error, :forbidden} = Sharing.join_via_link(visitor, link.token)
+    end
+  end
+end

--- a/test/typster_web/live/editor_live_test.exs
+++ b/test/typster_web/live/editor_live_test.exs
@@ -16,6 +16,17 @@ defmodule TypsterWeb.EditorLiveTest do
     view
   end
 
+  test "a stranger's project URL redirects to /projects instead of a 500", %{conn: conn} do
+    stranger_project = project_fixture(Typster.AccountsFixtures.user_fixture())
+
+    # Same response for "no access" and "doesn't exist" — no existence leak.
+    assert {:error, {:live_redirect, %{to: "/projects"}}} =
+             live(conn, ~p"/projects/#{stranger_project.id}/edit")
+
+    assert {:error, {:live_redirect, %{to: "/projects"}}} =
+             live(conn, ~p"/projects/#{Ecto.UUID.generate()}/edit")
+  end
+
   test "the new-file button reveals an inline draft row", %{conn: conn, project: project} do
     view = open_editor(conn, project)
 

--- a/test/typster_web/live/shared_project_live_test.exs
+++ b/test/typster_web/live/shared_project_live_test.exs
@@ -34,8 +34,10 @@ defmodule TypsterWeb.SharedProjectLiveTest do
       # Top bar shows the project name and the read-only pill.
       assert has_element?(view, ".embed-bar .slug", project.name)
       assert has_element?(view, ".ro-pill")
-      # Open-in-Typster CTA in the footer.
+      # Open-in-Typster CTA in the footer. On the top-level /p page it
+      # navigates in place (no target).
       assert has_element?(view, ".embed-foot__cta")
+      refute has_element?(view, ~s|.embed-foot__cta[target="_blank"]|)
     end
   end
 
@@ -73,6 +75,12 @@ defmodule TypsterWeb.SharedProjectLiveTest do
 
       assert has_element?(view, ".share-public--embed")
       assert has_element?(view, ".embed-comp")
+
+      # The CTA must escape the host iframe: new top-level window on our site.
+      assert has_element?(
+               view,
+               ~s|a.embed-foot__cta[target="_blank"][rel="noopener"][href="/projects/#{link.project_id}/edit"]|
+             )
     end
   end
 
@@ -88,6 +96,53 @@ defmodule TypsterWeb.SharedProjectLiveTest do
       # If the catch-all clause were missing, the pushes above would have
       # crashed the LiveView and this assertion would fail.
       assert has_element?(view, ".embed-comp")
+    end
+  end
+
+  describe "fork via /p" do
+    test "a signed-in visitor copies the project into their account", %{
+      conn: conn,
+      scope: scope,
+      link: link
+    } do
+      {:ok, link} = Sharing.update_link(scope, link, %{allow_fork: true})
+      visitor = Typster.AccountsFixtures.user_fixture()
+      conn = log_in_user(conn, visitor)
+
+      {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: link.token]}")
+
+      assert has_element?(view, "#shared-fork-open")
+      view |> element("#shared-fork-open") |> render_click()
+
+      view
+      |> form("#shared-fork-form", fork: %{name: "Fork of the century"})
+      |> render_submit()
+
+      {path, _flash} = assert_redirect(view)
+      assert path =~ ~r"^/projects/[0-9a-f-]+/edit$"
+    end
+
+    test "anonymous visitors are pointed at log-in instead", %{
+      conn: conn,
+      scope: scope,
+      link: link
+    } do
+      {:ok, link} = Sharing.update_link(scope, link, %{allow_fork: true})
+
+      {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: link.token]}")
+
+      assert has_element?(view, "#shared-fork-login")
+      refute has_element?(view, "#shared-fork-open")
+    end
+
+    test "no copy affordance while allow_fork is off (the default)", %{
+      conn: conn,
+      link: link
+    } do
+      {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: link.token]}")
+
+      refute has_element?(view, "#shared-fork-open")
+      refute has_element?(view, "#shared-fork-login")
     end
   end
 end


### PR DESCRIPTION
Closes #125.

## What

Review of the v3.1 design handoff against the implementation + a live exercise of every API endpoint surfaced five gaps; all fixed here.

### API hardening (reproduced live, then fixed)
- **Path validation** — the file changeset now rejects traversal segments (`..`/`.`), absolute paths, backslashes, and empty segments. Previously `POST /api/projects/:id/files` stored `../../etc/evil.typ` verbatim (201).
- **Parent scoping** — `parent_id` must belong to the same project; previously a file could be linked to a parent in another project or another tenant's file.
- 8 new ExUnit tests cover both (incl. the cross-tenant case).

### Design parity (chat 5 + quick-switcher spec)
- **Symbol breadcrumb** — the top bar crumb now ends with the nearest heading above the cursor (`chapters / ch1.typ › Background`), updated client-side on every cursor move, hidden when above the first heading. Verified live in the editor.
- **⌘K palette headings** — the palette gains a Headings group (numbered, jumps via the existing `goto` command). Verified live: groups now Suggested / Files / Headings / Insert.

### i18n
- All ~9 hardcoded auth flashes (`UserSessionController`, `UserAuth`: login, logout, magic link, auth-redirect) wrapped in gettext; EN msgstr kept verbatim to the previous strings so existing assertions hold, RU filled in house voice.
- Filled the `%{count} warning(s)` plural (was the only empty entry in both catalogs; RU with all 3 plural forms).
- New `editor.palette.headings` key (en/ru), fuzzy-match artifacts cleaned.

## Verification
`mix precommit` green: **279 tests, 0 failures** · assets build clean · breadcrumb + palette verified in a live editor session · API re-exercise: traversal and cross-project parent now 422.