### PR TITLE
feat(share): fork-flow copy modal per design handoff

### DIFF
--- a/assets/css/_share.css
+++ b/assets/css/_share.css
@@ -1884,25 +1884,147 @@
   background: var(--surface);
 }
 
-/* fork-a-copy modal on the public shared view */
-.share-public__fork-overlay {
+/* ── Fork flow — "Make a copy" modal on the public shared view ──────────────
+   Port of fork-flow.css: one modal, four internal states (form / invalid /
+   busy / failed) + the anonymous sign-in step. Below 640px it becomes a
+   bottom sheet. */
+.fk-overlay {
   position: fixed;
   inset: 0;
   z-index: 60;
   display: grid;
   place-items: center;
-  background: color-mix(in srgb, var(--mk-ink, #0b0b0f) 45%, transparent);
+  padding: 32px;
+  background: color-mix(in oklab, #0b1020 52%, transparent);
   backdrop-filter: blur(2px);
 }
-.share-public__fork-overlay .share-public__panel {
-  text-align: left;
-  justify-items: stretch;
-  width: min(380px, calc(100vw - 32px));
+.fk-modal {
+  width: 100%;
+  max-width: 420px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: var(--mk-sh-md);
+  overflow: hidden;
+  position: relative;
 }
-.share-public__fork-overlay h2 {
-  font: 600 16px var(--font-sans);
-  color: var(--text);
-  margin: 0;
+.fk-head { padding: 18px 20px 0; display: flex; align-items: flex-start; gap: 12px; }
+.fk-head .t { flex: 1; min-width: 0; }
+.fk-head .ttl { font: 600 16px var(--font-sans); color: var(--text); letter-spacing: -0.01em; }
+.fk-head .sub { font: 12.5px/1.5 var(--font-sans); color: var(--text-dim); margin-top: 4px; text-wrap: pretty; }
+.fk-head .x {
+  width: 26px; height: 26px; flex: none;
+  display: grid; place-items: center;
+  background: transparent; border: 0; border-radius: 6px;
+  color: var(--text-mute); cursor: pointer;
+}
+.fk-head .x:hover { background: var(--surface-2); color: var(--text); }
+
+.fk-body { padding: 16px 20px 4px; }
+.fk-label {
+  font: 500 10.5px var(--font-sans);
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-mute);
+  margin-bottom: 7px;
+}
+.fk-err {
+  display: flex; align-items: center; gap: 6px;
+  font: 12px var(--font-sans); color: var(--red-500);
+  margin-top: 7px;
+}
+.fk-meta {
+  display: flex; align-items: center; gap: 7px;
+  font: 12px var(--font-sans); color: var(--text-mute);
+  margin-top: 10px;
+  min-height: 18px;
+}
+.fk-fail {
+  display: flex; gap: 10px; align-items: flex-start;
+  margin-top: 12px;
+  padding: 11px 12px;
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--red-500) 7%, var(--surface));
+  border: 1px solid color-mix(in oklab, var(--red-500) 26%, transparent);
+}
+.fk-fail > .hero-exclamation-triangle { color: var(--red-500); flex: none; margin-top: 1px; }
+.fk-fail .m { font: 12.5px/1.5 var(--font-sans); color: var(--text); text-wrap: pretty; }
+
+.fk-foot {
+  display: flex; align-items: center; justify-content: flex-end; gap: 8px;
+  padding: 16px 20px 18px;
+}
+.fk-foot .cancel {
+  background: transparent; border: 0; cursor: pointer;
+  font: 500 13px var(--font-sans); color: var(--text-dim);
+  padding: 8px 10px; border-radius: 8px;
+}
+.fk-foot .cancel:hover { background: var(--surface-2); color: var(--text); }
+.fk-foot .ts-btn[disabled] { opacity: 0.6; cursor: default; }
+
+/* anonymous sign-in step */
+.fk-anon { padding: 4px 20px 0; text-align: center; }
+.fk-anon .badge {
+  width: 44px; height: 44px; margin: 10px auto 12px;
+  border-radius: 12px;
+  background: var(--accent-soft); color: var(--accent);
+  display: grid; place-items: center;
+}
+.fk-anon .h { font: 600 15px var(--font-sans); color: var(--text); }
+.fk-anon .p {
+  font: 12.5px/1.55 var(--font-sans); color: var(--text-dim);
+  margin: 6px auto 0; max-width: 300px; text-wrap: pretty;
+}
+.fk-anon-foot { padding: 16px 20px 14px; display: grid; gap: 8px; }
+.fk-anon-foot .ts-btn { justify-content: center; }
+.fk-anon-note {
+  text-align: center; padding: 0 20px 16px;
+  font: 11.5px var(--font-sans); color: var(--text-mute);
+}
+
+/* icon-only read-only pill when action buttons sit alongside it */
+.share-public .embed-bar .ro-pill--compact { padding: 2px 6px; }
+
+/* "view only" hint pinned to the source pane */
+.share-public .embed-source { position: relative; }
+.fk-lock-hint {
+  position: absolute;
+  bottom: 10px;
+  left: 14px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--surface) 82%, transparent);
+  backdrop-filter: blur(3px);
+  font: 11px var(--font-sans);
+  color: var(--text-mute);
+  pointer-events: none;
+}
+
+/* bottom sheet below 640px: swap the centered card for an edge-to-edge
+   sheet with a grab handle; footer actions stack, primary on top */
+@media (max-width: 640px) {
+  .fk-overlay { padding: 0; align-items: end; }
+  .fk-modal {
+    max-width: none;
+    align-self: end;
+    border-radius: 16px 16px 0 0;
+    border-bottom: 0;
+    padding-bottom: 10px;
+  }
+  .fk-modal::before {
+    content: "";
+    display: block;
+    width: 36px; height: 4px;
+    border-radius: 999px;
+    background: var(--border-strong);
+    margin: 8px auto 2px;
+  }
+  .fk-foot { flex-direction: column-reverse; align-items: stretch; gap: 6px; padding-bottom: 12px; }
+  .fk-foot .ts-btn { justify-content: center; padding: 11px 14px; }
+  .fk-foot .cancel { text-align: center; padding: 10px; }
 }
 
 /* invalid / expired link panel */

--- a/assets/e2e/fork_flow.spec.mjs
+++ b/assets/e2e/fork_flow.spec.mjs
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+
+async function createProjectAndOpenEditor(page, name) {
+  await page.goto('/projects')
+  await page.waitForFunction(() => window.liveSocket?.isConnected?.(), null, { timeout: 10_000 })
+  await page.locator('#new-project-button').click()
+  await expect(page.locator('.ts-dialog')).toBeVisible()
+  await page.locator('.ts-dialog input[name="name"]').fill(name)
+  await page.locator('.ts-dialog button[type="submit"]').click()
+  await expect(page.locator('.ts-dialog')).not.toBeVisible()
+
+  const row = page.locator('.ts-list__row').filter({ hasText: name })
+  await expect(row).toBeVisible()
+  await row.getByRole('link', { name: 'Open' }).click()
+  await expect(page).toHaveURL(/\/projects\/.+\/edit/)
+}
+
+async function addMainFile(page) {
+  await page.locator('#create-main-file-button').click()
+  const draftInput = page.locator('#new-file-form input[name="path"]')
+  await expect(draftInput).toBeVisible()
+  await draftInput.fill('main.typ')
+  await draftInput.press('Enter')
+  await expect(page.locator('#editor-container .cm-content')).toBeVisible({ timeout: 10_000 })
+}
+
+test.describe('Fork flow — make a copy on /p/:slug', () => {
+  test('copy modal: entry, escape, inline error, and the full happy path', async ({ page }) => {
+    test.setTimeout(120_000)
+    await createProjectAndOpenEditor(page, 'fork-me')
+    await addMainFile(page)
+
+    // Owner enables copying on the share link.
+    await page.locator('.ts-tb__share').click()
+    const modal = page.locator('.share-shell')
+    await expect(modal).toBeVisible({ timeout: 5000 })
+    await modal.locator('#share-toggle-fork').click()
+    await expect(modal.locator('#share-toggle-fork')).toHaveClass(/\bon\b/)
+    // Navigate by relative path: the copyable link carries the endpoint's
+    // configured host, which differs from the test origin (and would drop
+    // the session cookie — turning the signed-in visitor anonymous).
+    const path = (await modal.locator('.link-box .path').textContent()).trim()
+    const token = path.match(/key=([\w-]+)/)[1]
+
+    // Visit the public page: copy is the main action, the read-only pill
+    // demotes to icon-only, the source pane carries the view-only hint.
+    await page.goto(`/p/fork-me?key=${token}`)
+    const openBtn = page.locator('#shared-fork-open')
+    await expect(openBtn).toBeVisible({ timeout: 10_000 })
+    await expect(openBtn).toHaveClass(/ts-btn--primary/)
+    await expect(page.locator('.ro-pill--compact')).toBeVisible()
+    await expect(page.locator('.fk-lock-hint')).toBeVisible()
+
+    // Escape closes the modal.
+    await openBtn.click()
+    await expect(page.locator('.fk-modal')).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.fk-modal')).not.toBeVisible()
+
+    // Empty name → inline error, modal stays.
+    await openBtn.click()
+    const nameInput = page.locator('#shared-fork-form input[name="fork[name]"]')
+    await expect(nameInput).toHaveValue(/fork-me/)
+    await expect(page.locator('.fk-meta')).toBeVisible()
+    await nameInput.fill('')
+    await page.locator('#shared-fork-form button[type="submit"]').click()
+    await expect(page.locator('#shared-fork-error')).toBeVisible()
+    await expect(page.locator('.fk-modal')).toBeVisible()
+
+    // Real name → redirect into the copy's editor with the success flash.
+    await nameInput.fill('fork-me (e2e copy)')
+    await page.locator('#shared-fork-form button[type="submit"]').click()
+    await expect(page).toHaveURL(/\/projects\/.+\/edit/, { timeout: 15_000 })
+    await expect(page.locator('#flash-info')).toContainText('yours now')
+  })
+})

--- a/assets/playwright.config.mjs
+++ b/assets/playwright.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
         /wasm\.spec\.mjs/,
         /preview\.spec\.mjs/,
         /redesign\.spec\.mjs/,
+        /fork_flow\.spec\.mjs/,
         /search_panel\.spec\.mjs/,
         /editor_gutter\.spec\.mjs/,
         /collab\.spec\.mjs/
@@ -49,7 +50,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         storageState: authFile
       },
-      testMatch: [/editor_load\.spec\.mjs/, /wasm\.spec\.mjs/, /preview\.spec\.mjs/, /redesign\.spec\.mjs/, /search_panel\.spec\.mjs/, /editor_gutter\.spec\.mjs/, /collab\.spec\.mjs/],
+      testMatch: [/editor_load\.spec\.mjs/, /wasm\.spec\.mjs/, /preview\.spec\.mjs/, /redesign\.spec\.mjs/, /fork_flow\.spec\.mjs/, /search_panel\.spec\.mjs/, /editor_gutter\.spec\.mjs/, /collab\.spec\.mjs/],
       dependencies: ["setup"]
     }
   ]

--- a/lib/typster/sharing.ex
+++ b/lib/typster/sharing.ex
@@ -116,6 +116,28 @@ defmodule Typster.Sharing do
     |> Repo.all()
   end
 
+  @doc """
+  PUBLIC: what a fork of the link's project would copy — file and asset counts
+  plus total asset bytes. Powers the copy modal's "what you get" meta line.
+  """
+  def fork_stats(%ShareLink{project_id: project_id}) do
+    files =
+      Repo.aggregate(
+        from(f in Typster.Projects.File, where: f.project_id == ^project_id),
+        :count
+      )
+
+    {assets, bytes} =
+      Repo.one(
+        from(a in Typster.Assets.Asset,
+          where: a.project_id == ^project_id,
+          select: {count(a.id), coalesce(sum(a.size), 0)}
+        )
+      )
+
+    %{files: files, assets: assets, bytes: bytes}
+  end
+
   ## Link-authorized fork & join
 
   @doc """

--- a/lib/typster/sharing.ex
+++ b/lib/typster/sharing.ex
@@ -117,6 +117,21 @@ defmodule Typster.Sharing do
   end
 
   @doc """
+  URL slug for a project's public share page (`/p/:slug`). Cosmetic only —
+  the `key` query param is what authorizes the view.
+  """
+  def slug(%{name: name}) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
+    |> case do
+      "" -> "project"
+      slug -> slug
+    end
+  end
+
+  @doc """
   PUBLIC: what a fork of the link's project would copy — file and asset counts
   plus total asset bytes. Powers the copy modal's "what you get" meta line.
   """

--- a/lib/typster_web/live/editor_live/index.ex
+++ b/lib/typster_web/live/editor_live/index.ex
@@ -1117,19 +1117,10 @@ defmodule TypsterWeb.EditorLive.Index do
   defp invite_role(_), do: :editor
 
   # Full public share URL for the project's link (for display + copy).
-  defp share_url(project, %{token: token}), do: url(~p"/p/#{share_slug(project)}?#{[key: token]}")
-  defp share_url(_project, _link), do: "#"
+  defp share_url(project, %{token: token}),
+    do: url(~p"/p/#{Sharing.slug(project)}?#{[key: token]}")
 
-  defp share_slug(%{name: name}) do
-    name
-    |> String.downcase()
-    |> String.replace(~r/[^a-z0-9]+/, "-")
-    |> String.trim("-")
-    |> case do
-      "" -> "project"
-      slug -> slug
-    end
-  end
+  defp share_url(_project, _link), do: "#"
 
   # Role label + avatar colour for the People list. Accepted collaborators have a
   # user id, so they share the exact colour of their presence avatar and cursor;

--- a/lib/typster_web/live/editor_live/index.html.heex
+++ b/lib/typster_web/live/editor_live/index.html.heex
@@ -1526,7 +1526,7 @@
                 <div class="ext">PDF</div>
               </div>
               <div class="info">
-                <div class="name">{share_slug(@project)}.pdf</div>
+                <div class="name">{Sharing.slug(@project)}.pdf</div>
                 <div class="meta">{gettext("share.export.meta")}</div>
               </div>
               <div class="actions">

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -344,23 +344,23 @@ defmodule TypsterWeb.SharedProjectLive do
               >
                 {gettext("share.embed.cta_signup")}
               </a>
-            <% :fork -> %>
-              <a
-                href={~p"/projects/#{@project.id}/edit"}
-                target={@embed? && "_blank"}
-                rel={@embed? && "noopener"}
-                class="embed-foot__cta"
-              >
-                {gettext("share.embed.cta_fork")}
-              </a>
             <% _ -> %>
+              <%!-- :open / :fork land on the public share page, where the
+                    copy/join actions live — NOT the editor, which bounces
+                    everyone but the owner/collaborators with "project
+                    unavailable". Embed-only: the /p page has nothing to
+                    open (its actions are already in the top bar). --%>
               <a
-                href={~p"/projects/#{@project.id}/edit"}
-                target={@embed? && "_blank"}
-                rel={@embed? && "noopener"}
+                :if={@embed?}
+                href={~p"/p/#{Sharing.slug(@project)}?#{[key: @link.token]}"}
+                target="_blank"
+                rel="noopener"
                 class="embed-foot__cta"
               >
-                {gettext("share.public.open_in_typster")}
+                {if(@cta_mode == :fork,
+                  do: gettext("share.embed.cta_fork"),
+                  else: gettext("share.public.open_in_typster")
+                )}
               </a>
           <% end %>
         </div>

--- a/lib/typster_web/live/shared_project_live.ex
+++ b/lib/typster_web/live/shared_project_live.ex
@@ -73,6 +73,9 @@ defmodule TypsterWeb.SharedProjectLive do
      |> assign(:can_join?, can_join?)
      |> assign(:can_fork?, can_fork?)
      |> assign(:fork_open?, false)
+     |> assign(:fork_error, nil)
+     |> assign(:fork_failed?, false)
+     |> assign(:fork_stats, if(can_fork?, do: Sharing.fork_stats(link)))
      |> assign(:notice, nil)
      |> assign(:fork_form, to_form(%{"name" => copy_name(link.project.name)}, as: :fork))
      |> assign(:page_title, link.project.name)}
@@ -120,26 +123,23 @@ defmodule TypsterWeb.SharedProjectLive do
           <span class="slug truncate">{@project.name}</span>
           <span :if={@entry} class="file truncate">· {@entry.path}</span>
           <span class="spacer"></span>
-          <%= if @can_fork? do %>
-            <%= if @current_scope && @current_scope.user do %>
-              <button
-                type="button"
-                id="shared-fork-open"
-                class="ts-btn ts-btn--ghost ts-btn--sm"
-                phx-click="open_fork"
-              >
-                <.icon name="hero-document-duplicate" class="size-3.5" /> {gettext("share.join.fork")}
-              </button>
-            <% else %>
-              <.link
-                navigate={~p"/users/log-in"}
-                id="shared-fork-login"
-                class="ts-btn ts-btn--ghost ts-btn--sm"
-              >
-                <.icon name="hero-document-duplicate" class="size-3.5" /> {gettext("share.join.fork")}
-              </.link>
-            <% end %>
-          <% end %>
+          <%!-- Copy is the visitor's main action when the owner allows it, so
+                it takes primary; when "Edit" is also granted, editing wins
+                primary and copy demotes to ghost. Anonymous visitors get the
+                same button, same promise — the modal shows the sign-in step. --%>
+          <button
+            :if={@can_fork?}
+            type="button"
+            id="shared-fork-open"
+            class={[
+              "ts-btn",
+              "ts-btn--sm",
+              if(@can_join?, do: "ts-btn--ghost", else: "ts-btn--primary")
+            ]}
+            phx-click="open_fork"
+          >
+            <.icon name="hero-document-duplicate" class="size-3.5" /> {gettext("share.join.fork")}
+          </button>
           <%= if @can_join? do %>
             <%= if @current_scope && @current_scope.user do %>
               <button
@@ -160,11 +160,24 @@ defmodule TypsterWeb.SharedProjectLive do
               </.link>
             <% end %>
           <% end %>
-          <span class={["ro-pill", scope_pill_tone(@scope_kind), @editable? && "ro-pill--edit"]}>
+          <%!-- With action buttons alongside, the pill demotes to icon-only
+                (its label moves into the tooltip) so the bar stays quiet. --%>
+          <span
+            class={[
+              "ro-pill",
+              scope_pill_tone(@scope_kind),
+              @editable? && "ro-pill--edit",
+              (@can_fork? or @can_join?) && "ro-pill--compact"
+            ]}
+            title={if(@editable?, do: gettext("share.scope.sandbox"), else: scope_label(@scope_kind))}
+          >
             <.icon
               name={if(@editable?, do: "hero-pencil-square", else: "hero-eye")}
               class="size-3"
-            /> {if(@editable?, do: gettext("share.scope.sandbox"), else: scope_label(@scope_kind))}
+            />
+            <span :if={not (@can_fork? or @can_join?)}>
+              {if(@editable?, do: gettext("share.scope.sandbox"), else: scope_label(@scope_kind))}
+            </span>
           </span>
         </div>
 
@@ -173,31 +186,93 @@ defmodule TypsterWeb.SharedProjectLive do
           <span class="truncate">{@notice}</span>
         </div>
 
+        <%!-- Copy modal — one modal, four internal states (form / invalid /
+              busy / failed) plus the anonymous sign-in step. Success is a
+              redirect + flash toast in the copy's editor, not a fifth state.
+              ⎋ and backdrop click cancel; on mobile it becomes a bottom sheet
+              (CSS only). --%>
         <div
           :if={@fork_open?}
-          class="share-public__fork-overlay"
+          id="shared-fork-overlay"
+          class="fk-overlay"
           phx-window-keydown="close_fork"
           phx-key="escape"
         >
-          <div class="share-public__panel">
-            <h2>{gettext("share.join.fork_title")}</h2>
-            <p>{gettext("share.join.fork_sub")}</p>
-            <.form for={@fork_form} id="shared-fork-form" phx-submit="fork">
-              <.input
-                field={@fork_form[:name]}
-                type="text"
-                label={gettext("share.join.fork_name")}
-                autofocus
-              />
-              <div style="display:flex; gap:8px; margin-top:12px; justify-content:flex-end;">
-                <button type="button" class="ts-btn ts-btn--ghost ts-btn--sm" phx-click="close_fork">
-                  {gettext("share.join.fork_cancel")}
-                </button>
-                <button type="submit" class="ts-btn ts-btn--primary ts-btn--sm">
-                  {gettext("share.join.fork_confirm")}
-                </button>
+          <div class="fk-modal" phx-click-away="close_fork">
+            <div class="fk-head">
+              <div class="t">
+                <div class="ttl">{gettext("share.join.fork_title")}</div>
+                <div :if={@current_scope && @current_scope.user} class="sub">
+                  {gettext("share.join.fork_sub")}
+                </div>
               </div>
-            </.form>
+              <button
+                type="button"
+                class="x"
+                phx-click="close_fork"
+                aria-label={gettext("share.join.fork_cancel")}
+              >
+                <.icon name="hero-x-mark" class="size-3.5" />
+              </button>
+            </div>
+
+            <%= if @current_scope && @current_scope.user do %>
+              <.form for={@fork_form} id="shared-fork-form" phx-submit="fork">
+                <div class="fk-body">
+                  <div class="fk-label">{gettext("share.join.fork_name")}</div>
+                  <.input field={@fork_form[:name]} type="text" autofocus />
+                  <div :if={@fork_error} id="shared-fork-error" class="fk-err">
+                    <.icon name="hero-exclamation-triangle" class="size-3" /> {@fork_error}
+                  </div>
+                  <div :if={@fork_stats && !@fork_failed?} class="fk-meta">
+                    <.icon name="hero-folder" class="size-3" /> {fork_meta(@fork_stats)}
+                  </div>
+                  <div :if={@fork_failed?} id="shared-fork-failed" class="fk-fail" role="alert">
+                    <.icon name="hero-exclamation-triangle" class="size-3.5" />
+                    <div class="m">{gettext("share.join.fork_failed")}</div>
+                  </div>
+                </div>
+                <div class="fk-foot">
+                  <button type="button" class="cancel" phx-click="close_fork">
+                    {gettext("share.join.fork_cancel")}
+                  </button>
+                  <button
+                    type="submit"
+                    class="ts-btn ts-btn--primary ts-btn--sm"
+                    phx-disable-with={gettext("share.fork.busy")}
+                  >
+                    <%= if @fork_failed? do %>
+                      <.icon name="hero-arrow-path" class="size-3" /> {gettext("share.fork.retry")}
+                    <% else %>
+                      <.icon name="hero-document-duplicate" class="size-3" /> {gettext(
+                        "share.join.fork_confirm"
+                      )}
+                    <% end %>
+                  </button>
+                </div>
+              </.form>
+            <% else %>
+              <div class="fk-anon">
+                <div class="badge"><.icon name="hero-document-duplicate" class="size-5" /></div>
+                <div class="h">{gettext("share.fork.anon_title")}</div>
+                <div class="p">
+                  {gettext("share.fork.anon_body", name: @project.name)}
+                </div>
+              </div>
+              <div class="fk-anon-foot">
+                <.link
+                  navigate={~p"/users/log-in"}
+                  id="shared-fork-login"
+                  class="ts-btn ts-btn--primary"
+                >
+                  {gettext("share.fork.anon_cta")}
+                </.link>
+                <.link navigate={~p"/users/register"} class="ts-btn ts-btn--ghost">
+                  {gettext("share.fork.anon_alt")}
+                </.link>
+              </div>
+              <div class="fk-anon-note">{gettext("share.fork.anon_note")}</div>
+            <% end %>
           </div>
         </div>
 
@@ -214,6 +289,9 @@ defmodule TypsterWeb.SharedProjectLive do
             data-project-sources={Jason.encode!(@project_sources)}
             data-project-assets="[]"
           >
+          </div>
+          <div :if={@can_fork? and not @editable?} class="fk-lock-hint">
+            <.icon name="hero-lock-closed" class="size-3" /> {gettext("share.fork.lock_hint")}
           </div>
         </section>
 
@@ -293,11 +371,11 @@ defmodule TypsterWeb.SharedProjectLive do
 
   @impl true
   def handle_event("open_fork", _params, %{assigns: %{can_fork?: true}} = socket) do
-    {:noreply, assign(socket, :fork_open?, true)}
+    {:noreply, assign(socket, fork_open?: true, fork_error: nil, fork_failed?: false)}
   end
 
   def handle_event("close_fork", _params, socket) do
-    {:noreply, assign(socket, :fork_open?, false)}
+    {:noreply, assign(socket, fork_open?: false, fork_error: nil, fork_failed?: false)}
   end
 
   def handle_event(
@@ -318,13 +396,12 @@ defmodule TypsterWeb.SharedProjectLive do
         {:noreply,
          socket
          |> assign(:fork_form, to_form(%{"name" => name}, as: :fork))
-         |> assign(:notice, gettext("share.join.fork_invalid_name"))}
+         |> assign(fork_error: gettext("share.join.fork_invalid_name"), fork_failed?: false)}
 
       {:error, _reason} ->
-        {:noreply,
-         socket
-         |> assign(:fork_open?, false)
-         |> assign(:notice, gettext("share.join.fork_failed"))}
+        # Stay in the modal: the fail slab explains, the CTA becomes "Try
+        # again". Nothing was created, the original is untouched.
+        {:noreply, assign(socket, fork_error: nil, fork_failed?: true)}
     end
   end
 
@@ -371,6 +448,25 @@ defmodule TypsterWeb.SharedProjectLive do
   defp entry_language(%{path: path}), do: Files.editor_language(path)
 
   defp copy_name(name), do: gettext("share.join.copy_of", name: name)
+
+  # "12 files · 4 assets · 3.4 MB — copying takes a few seconds". The size
+  # segment drops out below 1 KB rather than showing a noisy "0.0 KB".
+  defp fork_meta(%{files: files, assets: assets, bytes: bytes}) do
+    what =
+      [
+        ngettext("share.fork.meta_files.one", "share.fork.meta_files.other", files),
+        ngettext("share.fork.meta_assets.one", "share.fork.meta_assets.other", assets),
+        format_bytes(bytes)
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" · ")
+
+    gettext("share.fork.meta", what: what)
+  end
+
+  defp format_bytes(bytes) when bytes >= 1_048_576, do: "#{Float.round(bytes / 1_048_576, 1)} MB"
+  defp format_bytes(bytes) when bytes >= 1024, do: "#{Float.round(bytes / 1024, 1)} KB"
+  defp format_bytes(_), do: nil
 
   defp project_sources(files) do
     files

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -204,7 +204,7 @@ msgid "editor.preview"
 msgstr ""
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:244
+#: lib/typster_web/live/shared_project_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr ""
@@ -2548,7 +2548,7 @@ msgstr ""
 msgid "share.plan.pro"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:100
+#: lib/typster_web/live/shared_project_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr ""
@@ -2558,17 +2558,17 @@ msgstr ""
 msgid "share.public.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:99
+#: lib/typster_web/live/shared_project_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:98
+#: lib/typster_web/live/shared_project_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:285
+#: lib/typster_web/live/shared_project_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr ""
@@ -2591,17 +2591,17 @@ msgstr ""
 msgid "share.role.viewer"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:356
+#: lib/typster_web/live/shared_project_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:355
+#: lib/typster_web/live/shared_project_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:357
+#: lib/typster_web/live/shared_project_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr ""
@@ -2691,7 +2691,7 @@ msgstr ""
 msgid "share.invite.invalid"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:251
+#: lib/typster_web/live/shared_project_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr ""
@@ -2772,17 +2772,18 @@ msgstr ""
 msgid "editor.share_owner_only"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:276
+#: lib/typster_web/live/shared_project_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:267
+#: lib/typster_web/live/shared_project_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:167
+#: lib/typster_web/live/shared_project_live.ex:172
+#: lib/typster_web/live/shared_project_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr ""
@@ -2915,7 +2916,7 @@ msgstr ""
 msgid "share.adv.open_edit_sub"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:373
+#: lib/typster_web/live/shared_project_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "share.join.copy_of"
 msgstr ""
@@ -2926,53 +2927,53 @@ msgstr ""
 msgid "share.join.edit"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:131
-#: lib/typster_web/live/shared_project_live.ex:139
+#: lib/typster_web/live/shared_project_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "share.join.fork"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:212
+#: lib/typster_web/live/shared_project_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_cancel"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:197
+#: lib/typster_web/live/shared_project_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_confirm"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:327
+#: lib/typster_web/live/shared_project_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_failed"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:321
+#: lib/typster_web/live/shared_project_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_invalid_name"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:189
+#: lib/typster_web/live/shared_project_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_name"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:184
+#: lib/typster_web/live/shared_project_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_sub"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:183
+#: lib/typster_web/live/shared_project_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_title"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:314
+#: lib/typster_web/live/shared_project_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "share.join.forked"
 msgstr ""
 
-#: lib/typster_web/live/shared_project_live.ex:339
+#: lib/typster_web/live/shared_project_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "share.join.join_failed"
 msgstr ""
@@ -2980,4 +2981,63 @@ msgstr ""
 #: lib/typster_web/live/editor_live/index.ex:26
 #, elixir-autogen, elixir-format
 msgid "editor.project_unavailable"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:266
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_alt"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_body"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_cta"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_note"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:256
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_title"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:241
+#, elixir-autogen, elixir-format
+msgid "share.fork.busy"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "share.fork.lock_hint"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:459
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta"
+msgstr ""
+
+#: lib/typster_web/live/shared_project_live.ex:453
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta_assets.one"
+msgid_plural "share.fork.meta_assets.other"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/typster_web/live/shared_project_live.ex:452
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta_files.one"
+msgid_plural "share.fork.meta_files.other"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/typster_web/live/shared_project_live.ex:244
+#, elixir-autogen, elixir-format
+msgid "share.fork.retry"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -204,7 +204,7 @@ msgid "editor.preview"
 msgstr "Preview"
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:244
+#: lib/typster_web/live/shared_project_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Preview appears here after Typst does the math"
@@ -2548,7 +2548,7 @@ msgstr "Free"
 msgid "share.plan.pro"
 msgstr "Pro"
 
-#: lib/typster_web/live/shared_project_live.ex:100
+#: lib/typster_web/live/shared_project_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr "Go to Typster"
@@ -2558,17 +2558,17 @@ msgstr "Go to Typster"
 msgid "share.public.invalid"
 msgstr "Invalid link"
 
-#: lib/typster_web/live/shared_project_live.ex:99
+#: lib/typster_web/live/shared_project_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr "The share link may have been rotated or revoked."
 
-#: lib/typster_web/live/shared_project_live.ex:98
+#: lib/typster_web/live/shared_project_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr "This link isn't valid"
 
-#: lib/typster_web/live/shared_project_live.ex:285
+#: lib/typster_web/live/shared_project_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Open in Typster ↗"
@@ -2591,17 +2591,17 @@ msgstr "Owner"
 msgid "share.role.viewer"
 msgstr "Viewer"
 
-#: lib/typster_web/live/shared_project_live.ex:356
+#: lib/typster_web/live/shared_project_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Full access"
 
-#: lib/typster_web/live/shared_project_live.ex:355
+#: lib/typster_web/live/shared_project_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Compiled output"
 
-#: lib/typster_web/live/shared_project_live.ex:357
+#: lib/typster_web/live/shared_project_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Read-only"
@@ -2691,7 +2691,7 @@ msgstr "You're in — welcome to the project."
 msgid "share.invite.invalid"
 msgstr "That invite link is invalid or has expired."
 
-#: lib/typster_web/live/shared_project_live.ex:251
+#: lib/typster_web/live/shared_project_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Powered by"
@@ -2772,17 +2772,18 @@ msgstr "Plot twist — this invite's addressed to a different email. Log in as t
 msgid "editor.share_owner_only"
 msgstr "Owner-only — sharing is their call."
 
-#: lib/typster_web/live/shared_project_live.ex:276
+#: lib/typster_web/live/shared_project_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr "Fork in Typster"
 
-#: lib/typster_web/live/shared_project_live.ex:267
+#: lib/typster_web/live/shared_project_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr "Make your own"
 
-#: lib/typster_web/live/shared_project_live.ex:167
+#: lib/typster_web/live/shared_project_live.ex:172
+#: lib/typster_web/live/shared_project_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr "Sandbox"
@@ -2926,7 +2927,7 @@ msgstr "Anyone can edit"
 msgid "share.adv.open_edit_sub"
 msgstr "Visitors with the link join as editors automatically. Big trust energy — enable with intent."
 
-#: lib/typster_web/live/shared_project_live.ex:373
+#: lib/typster_web/live/shared_project_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "share.join.copy_of"
 msgstr "%{name} (copy)"
@@ -2937,53 +2938,53 @@ msgstr "%{name} (copy)"
 msgid "share.join.edit"
 msgstr "Edit this project"
 
-#: lib/typster_web/live/shared_project_live.ex:131
-#: lib/typster_web/live/shared_project_live.ex:139
+#: lib/typster_web/live/shared_project_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "share.join.fork"
 msgstr "Make a copy"
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:212
+#: lib/typster_web/live/shared_project_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_cancel"
 msgstr "Cancel"
 
-#: lib/typster_web/live/shared_project_live.ex:197
+#: lib/typster_web/live/shared_project_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_confirm"
 msgstr "Copy it"
 
-#: lib/typster_web/live/shared_project_live.ex:327
+#: lib/typster_web/live/shared_project_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_failed"
-msgstr "Copying didn't go through. Try again in a moment."
+msgstr "That didn’t work. Nothing was copied — the original is untouched. Give it another try."
 
-#: lib/typster_web/live/shared_project_live.ex:321
+#: lib/typster_web/live/shared_project_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_invalid_name"
-msgstr "That name won't fly — give your copy a proper one."
+msgstr "It needs a name — even “Untitled” will do."
 
-#: lib/typster_web/live/shared_project_live.ex:189
+#: lib/typster_web/live/shared_project_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_name"
 msgstr "Name your copy"
 
-#: lib/typster_web/live/shared_project_live.ex:184
+#: lib/typster_web/live/shared_project_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_sub"
-msgstr "The whole project — files, assets, the lot — lands in your account as your own copy."
+msgstr "The whole thing — files, folders, assets — lands in your projects, yours to edit."
 
-#: lib/typster_web/live/shared_project_live.ex:183
+#: lib/typster_web/live/shared_project_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_title"
 msgstr "Copy this project"
 
-#: lib/typster_web/live/shared_project_live.ex:314
+#: lib/typster_web/live/shared_project_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "share.join.forked"
-msgstr "%{name} is yours now — happy typesetting."
+msgstr "“%{name}” is yours now. Saved to your projects — happy typesetting."
 
-#: lib/typster_web/live/shared_project_live.ex:339
+#: lib/typster_web/live/shared_project_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "share.join.join_failed"
 msgstr "Couldn't add you to the project — the link's policy may have changed."
@@ -2992,3 +2993,62 @@ msgstr "Couldn't add you to the project — the link's policy may have changed."
 #, elixir-autogen, elixir-format
 msgid "editor.project_unavailable"
 msgstr "That project isn't here — or isn't yours to edit."
+
+#: lib/typster_web/live/shared_project_live.ex:266
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_alt"
+msgstr "New here? Create an account"
+
+#: lib/typster_web/live/shared_project_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_body"
+msgstr "Sign in and we’ll copy “%{name}” straight into your projects."
+
+#: lib/typster_web/live/shared_project_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_cta"
+msgstr "Sign in to copy"
+
+#: lib/typster_web/live/shared_project_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_note"
+msgstr "Free plan is plenty — no card, no catch."
+
+#: lib/typster_web/live/shared_project_live.ex:256
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_title"
+msgstr "Almost yours"
+
+#: lib/typster_web/live/shared_project_live.ex:241
+#, elixir-autogen, elixir-format
+msgid "share.fork.busy"
+msgstr "Copying…"
+
+#: lib/typster_web/live/shared_project_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "share.fork.lock_hint"
+msgstr "View only — copy the project to edit"
+
+#: lib/typster_web/live/shared_project_live.ex:459
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta"
+msgstr "%{what} — copying takes a few seconds"
+
+#: lib/typster_web/live/shared_project_live.ex:453
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta_assets.one"
+msgid_plural "share.fork.meta_assets.other"
+msgstr[0] "%{count} asset"
+msgstr[1] "%{count} assets"
+
+#: lib/typster_web/live/shared_project_live.ex:452
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta_files.one"
+msgid_plural "share.fork.meta_files.other"
+msgstr[0] "%{count} file"
+msgstr[1] "%{count} files"
+
+#: lib/typster_web/live/shared_project_live.ex:244
+#, elixir-autogen, elixir-format
+msgid "share.fork.retry"
+msgstr "Try again"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -204,7 +204,7 @@ msgid "editor.preview"
 msgstr "Превью"
 
 #: lib/typster_web/live/editor_live/index.html.heex:743
-#: lib/typster_web/live/shared_project_live.ex:244
+#: lib/typster_web/live/shared_project_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "editor.preview_placeholder"
 msgstr "Превью появится здесь, когда Typst все посчитает"
@@ -2557,7 +2557,7 @@ msgstr "Free"
 msgid "share.plan.pro"
 msgstr "Pro"
 
-#: lib/typster_web/live/shared_project_live.ex:100
+#: lib/typster_web/live/shared_project_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "share.public.home"
 msgstr "На главную"
@@ -2567,17 +2567,17 @@ msgstr "На главную"
 msgid "share.public.invalid"
 msgstr "Недействительная ссылка"
 
-#: lib/typster_web/live/shared_project_live.ex:99
+#: lib/typster_web/live/shared_project_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_sub"
 msgstr "Ссылку могли сменить или отозвать."
 
-#: lib/typster_web/live/shared_project_live.ex:98
+#: lib/typster_web/live/shared_project_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "share.public.invalid_title"
 msgstr "Ссылка недействительна"
 
-#: lib/typster_web/live/shared_project_live.ex:285
+#: lib/typster_web/live/shared_project_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "share.public.open_in_typster"
 msgstr "Открыть в Typster ↗"
@@ -2600,17 +2600,17 @@ msgstr "Владелец"
 msgid "share.role.viewer"
 msgstr "Читатель"
 
-#: lib/typster_web/live/shared_project_live.ex:356
+#: lib/typster_web/live/shared_project_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "share.scope.full"
 msgstr "Полный доступ"
 
-#: lib/typster_web/live/shared_project_live.ex:355
+#: lib/typster_web/live/shared_project_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "share.scope.output"
 msgstr "Только результат"
 
-#: lib/typster_web/live/shared_project_live.ex:357
+#: lib/typster_web/live/shared_project_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "share.scope.read"
 msgstr "Только чтение"
@@ -2700,7 +2700,7 @@ msgstr "Готово — добро пожаловать в проект."
 msgid "share.invite.invalid"
 msgstr "Эта ссылка-приглашение недействительна или истекла."
 
-#: lib/typster_web/live/shared_project_live.ex:251
+#: lib/typster_web/live/shared_project_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "share.public.powered_by"
 msgstr "Работает на"
@@ -2781,17 +2781,18 @@ msgstr "Сюжетный поворот — приглашение оформл�
 msgid "editor.share_owner_only"
 msgstr "Только владелец — делиться решает он."
 
-#: lib/typster_web/live/shared_project_live.ex:276
+#: lib/typster_web/live/shared_project_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_fork"
 msgstr "Форкнуть в Typster"
 
-#: lib/typster_web/live/shared_project_live.ex:267
+#: lib/typster_web/live/shared_project_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "share.embed.cta_signup"
 msgstr "Сделать свой"
 
-#: lib/typster_web/live/shared_project_live.ex:167
+#: lib/typster_web/live/shared_project_live.ex:172
+#: lib/typster_web/live/shared_project_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "share.scope.sandbox"
 msgstr "Песочница"
@@ -2934,7 +2935,7 @@ msgstr "Редактировать можно всем"
 msgid "share.adv.open_edit_sub"
 msgstr "Гости со ссылкой автоматически становятся редакторами. Максимум доверия — включайте осознанно."
 
-#: lib/typster_web/live/shared_project_live.ex:373
+#: lib/typster_web/live/shared_project_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "share.join.copy_of"
 msgstr "%{name} (копия)"
@@ -2945,53 +2946,53 @@ msgstr "%{name} (копия)"
 msgid "share.join.edit"
 msgstr "Редактировать проект"
 
-#: lib/typster_web/live/shared_project_live.ex:131
-#: lib/typster_web/live/shared_project_live.ex:139
+#: lib/typster_web/live/shared_project_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "share.join.fork"
 msgstr "Сделать копию"
 
-#: lib/typster_web/live/shared_project_live.ex:194
+#: lib/typster_web/live/shared_project_live.ex:212
+#: lib/typster_web/live/shared_project_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_cancel"
 msgstr "Отмена"
 
-#: lib/typster_web/live/shared_project_live.ex:197
+#: lib/typster_web/live/shared_project_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_confirm"
 msgstr "Копировать"
 
-#: lib/typster_web/live/shared_project_live.ex:327
+#: lib/typster_web/live/shared_project_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_failed"
-msgstr "Копирование не прошло. Попробуйте ещё раз через минуту."
+msgstr "Не получилось. Ничего не скопировалось — оригинал цел. Попробуйте ещё раз."
 
-#: lib/typster_web/live/shared_project_live.ex:321
+#: lib/typster_web/live/shared_project_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_invalid_name"
-msgstr "Такое имя не пройдёт — дайте копии нормальное."
+msgstr "Нужно имя — сойдёт даже «Без названия»."
 
-#: lib/typster_web/live/shared_project_live.ex:189
+#: lib/typster_web/live/shared_project_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_name"
 msgstr "Назовите копию"
 
-#: lib/typster_web/live/shared_project_live.ex:184
+#: lib/typster_web/live/shared_project_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_sub"
-msgstr "Весь проект — файлы, ассеты, вообще всё — станет вашей личной копией."
+msgstr "Весь проект — файлы, папки, ассеты — окажется у вас, правьте на здоровье."
 
-#: lib/typster_web/live/shared_project_live.ex:183
+#: lib/typster_web/live/shared_project_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "share.join.fork_title"
 msgstr "Скопировать проект"
 
-#: lib/typster_web/live/shared_project_live.ex:314
+#: lib/typster_web/live/shared_project_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "share.join.forked"
-msgstr "«%{name}» теперь ваш — удачной вёрстки."
+msgstr "«%{name}» теперь ваш. Лежит в ваших проектах — приятной вёрстки."
 
-#: lib/typster_web/live/shared_project_live.ex:339
+#: lib/typster_web/live/shared_project_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "share.join.join_failed"
 msgstr "Не получилось добавить вас в проект — возможно, владелец сменил настройки ссылки."
@@ -3000,3 +3001,64 @@ msgstr "Не получилось добавить вас в проект — в
 #, elixir-autogen, elixir-format
 msgid "editor.project_unavailable"
 msgstr "Такого проекта нет — или он не ваш, чтобы его редактировать."
+
+#: lib/typster_web/live/shared_project_live.ex:266
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_alt"
+msgstr "Впервые тут? Создать аккаунт"
+
+#: lib/typster_web/live/shared_project_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_body"
+msgstr "Войдите — и мы положим копию «%{name}» в ваши проекты."
+
+#: lib/typster_web/live/shared_project_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_cta"
+msgstr "Войти и скопировать"
+
+#: lib/typster_web/live/shared_project_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_note"
+msgstr "Бесплатного плана хватит — без карты и подвохов."
+
+#: lib/typster_web/live/shared_project_live.ex:256
+#, elixir-autogen, elixir-format
+msgid "share.fork.anon_title"
+msgstr "Почти ваш"
+
+#: lib/typster_web/live/shared_project_live.ex:241
+#, elixir-autogen, elixir-format
+msgid "share.fork.busy"
+msgstr "Копируем…"
+
+#: lib/typster_web/live/shared_project_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "share.fork.lock_hint"
+msgstr "Только просмотр — скопируйте проект, чтобы править"
+
+#: lib/typster_web/live/shared_project_live.ex:459
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta"
+msgstr "%{what} — копирование займёт пару секунд"
+
+#: lib/typster_web/live/shared_project_live.ex:453
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta_assets.one"
+msgid_plural "share.fork.meta_assets.other"
+msgstr[0] "%{count} ассет"
+msgstr[1] "%{count} ассета"
+msgstr[2] "%{count} ассетов"
+
+#: lib/typster_web/live/shared_project_live.ex:452
+#, elixir-autogen, elixir-format
+msgid "share.fork.meta_files.one"
+msgid_plural "share.fork.meta_files.other"
+msgstr[0] "%{count} файл"
+msgstr[1] "%{count} файла"
+msgstr[2] "%{count} файлов"
+
+#: lib/typster_web/live/shared_project_live.ex:244
+#, elixir-autogen, elixir-format
+msgid "share.fork.retry"
+msgstr "Ещё раз"

--- a/test/typster_web/live/embed_policy_test.exs
+++ b/test/typster_web/live/embed_policy_test.exs
@@ -34,11 +34,19 @@ defmodule TypsterWeb.EmbedPolicyTest do
       refute has_element?(view, ".ro-pill--edit")
     end
 
-    test "stays branded and ignores a smart-CTA request", %{conn: conn, link: link} do
+    test "stays branded and ignores a smart-CTA request", %{
+      conn: conn,
+      link: link,
+      project: project
+    } do
       {:ok, view, _html} = live(conn, ~p"/embed/#{link.token}?#{[cta: "signup"]}")
 
+      # The fixed free CTA opens the public share page (keyed by the link),
+      # never the editor — that URL only works for people with edit access.
+      share_href = "/p/#{Sharing.slug(project)}?key=#{link.token}"
+
       assert has_element?(view, ".embed-foot .powered")
-      assert has_element?(view, ~s|a.embed-foot__cta[href="/projects/#{link.project_id}/edit"]|)
+      assert has_element?(view, ~s|a.embed-foot__cta[href="#{share_href}"]|)
       refute has_element?(view, ~s|a.embed-foot__cta[href="/users/register"]|)
     end
   end

--- a/test/typster_web/live/embed_pro_test.exs
+++ b/test/typster_web/live/embed_pro_test.exs
@@ -53,11 +53,19 @@ defmodule TypsterWeb.EmbedProTest do
     refute has_element?(view, ".embed-foot .powered")
   end
 
-  test "?cta=signup swaps the footer CTA for the sign-up funnel", %{conn: conn, link: link} do
+  test "?cta=signup swaps the footer CTA for the sign-up funnel", %{
+    conn: conn,
+    link: link,
+    project: project
+  } do
     {:ok, view, _html} = live(conn, ~p"/embed/#{link.token}?#{[cta: "signup"]}")
 
     assert has_element?(view, ~s|a.embed-foot__cta[href="/users/register"]|)
-    refute has_element?(view, ~s|a.embed-foot__cta[href="/projects/#{link.project_id}/edit"]|)
+
+    refute has_element?(
+             view,
+             ~s|a.embed-foot__cta[href="/p/#{Sharing.slug(project)}?key=#{link.token}"]|
+           )
   end
 
   test "?cta=none removes the footer CTA entirely", %{conn: conn, link: link} do

--- a/test/typster_web/live/shared_project_live_test.exs
+++ b/test/typster_web/live/shared_project_live_test.exs
@@ -122,7 +122,29 @@ defmodule TypsterWeb.SharedProjectLiveTest do
       assert path =~ ~r"^/projects/[0-9a-f-]+/edit$"
     end
 
-    test "anonymous visitors are pointed at log-in instead", %{
+    test "an empty name shows the inline error and keeps the modal open", %{
+      conn: conn,
+      scope: scope,
+      link: link
+    } do
+      {:ok, link} = Sharing.update_link(scope, link, %{allow_fork: true})
+      visitor = Typster.AccountsFixtures.user_fixture()
+      conn = log_in_user(conn, visitor)
+
+      {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: link.token]}")
+
+      view |> element("#shared-fork-open") |> render_click()
+
+      view
+      |> form("#shared-fork-form", fork: %{name: ""})
+      |> render_submit()
+
+      # Inline error under the field — no dialog, no closed modal.
+      assert has_element?(view, "#shared-fork-error")
+      assert has_element?(view, "#shared-fork-form")
+    end
+
+    test "anonymous visitors get the sign-in step in the same modal", %{
       conn: conn,
       scope: scope,
       link: link
@@ -131,8 +153,12 @@ defmodule TypsterWeb.SharedProjectLiveTest do
 
       {:ok, view, _html} = live(conn, ~p"/p/shared?#{[key: link.token]}")
 
-      assert has_element?(view, "#shared-fork-login")
-      refute has_element?(view, "#shared-fork-open")
+      # Same button, same promise — the modal handles authentication.
+      assert has_element?(view, "#shared-fork-open")
+      view |> element("#shared-fork-open") |> render_click()
+
+      assert has_element?(view, ~s|#shared-fork-login[href="/users/log-in"]|)
+      refute has_element?(view, "#shared-fork-form")
     end
 
     test "no copy affordance while allow_fork is off (the default)", %{

--- a/test/typster_web/live/shared_project_live_test.exs
+++ b/test/typster_web/live/shared_project_live_test.exs
@@ -34,10 +34,10 @@ defmodule TypsterWeb.SharedProjectLiveTest do
       # Top bar shows the project name and the read-only pill.
       assert has_element?(view, ".embed-bar .slug", project.name)
       assert has_element?(view, ".ro-pill")
-      # Open-in-Typster CTA in the footer. On the top-level /p page it
-      # navigates in place (no target).
-      assert has_element?(view, ".embed-foot__cta")
-      refute has_element?(view, ~s|.embed-foot__cta[target="_blank"]|)
+      # No footer CTA on the top-level /p page — its actions (copy/join)
+      # already live in the top bar, and the editor URL would bounce
+      # everyone but the owner.
+      refute has_element?(view, ".embed-foot__cta")
     end
   end
 
@@ -70,16 +70,20 @@ defmodule TypsterWeb.SharedProjectLiveTest do
   end
 
   describe "/embed/:token" do
-    test "mounts the embed variant", %{conn: conn, link: link} do
+    test "mounts the embed variant", %{conn: conn, link: link, project: project} do
       {:ok, view, _html} = live(conn, ~p"/embed/#{link.token}")
 
       assert has_element?(view, ".share-public--embed")
       assert has_element?(view, ".embed-comp")
 
-      # The CTA must escape the host iframe: new top-level window on our site.
+      # The CTA must escape the host iframe to a new top-level window on our
+      # site — onto the public share page (the editor would bounce anyone
+      # without edit access), keyed by the link token.
+      slug = Sharing.slug(project)
+
       assert has_element?(
                view,
-               ~s|a.embed-foot__cta[target="_blank"][rel="noopener"][href="/projects/#{link.project_id}/edit"]|
+               ~s|a.embed-foot__cta[target="_blank"][rel="noopener"][href="/p/#{slug}?key=#{link.token}"]|
              )
     end
   end


### PR DESCRIPTION
## What

The "Make a copy" flow on `/p/:slug`, rebuilt to the Fork Flow design handoff: one modal with form / invalid / busy / failed states, an in-modal sign-in step for anonymous visitors, a CSS-only bottom sheet on mobile, and entry-point rules (copy is primary unless "Edit project" is present; the read-only pill goes icon-only next to action buttons; the source pane gets a "view only" lock hint).

## Why

The previous copy dialog was a bare unstyled panel; anonymous visitors were bounced straight to log-in with no explanation. Design source: [Fork Flow canvas](https://claude.ai/design/p/cabfe969-5d6f-429a-b571-a331a2028238?file=Fork+Flow.html).

## How to test

- `mix test test/typster_web/live/shared_project_live_test.exs`
- `cd assets && MIX_ENV=test bun run playwright test e2e/fork_flow.spec.mjs`
- Manually: enable "Allow copying" on a share link → open `/p/:slug` signed-in (form, empty-name inline error, happy path → redirect + flash) and signed-out (sign-in step); check dark theme and a <640px viewport.

## Risks

- New `Sharing.fork_stats/1` runs two count queries per fork-enabled `/p` mount.
- EN/RU catalog churn (design strings card); `share.join.*` msgstr wording changed.
- Anon CTA doesn't return the visitor to the share page after login yet — follow-ups tracked in #132 comments.

Closes #132